### PR TITLE
Fix: Reorder GUI layout for better UX flow

### DIFF
--- a/cmd/complab-desktop/frontend/dist/index.html
+++ b/cmd/complab-desktop/frontend/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>temp</title>
-  <script type="module" crossorigin src="/assets/index-IaT8QOgk.js"></script>
+  <script type="module" crossorigin src="/assets/index-QyqBRQdx.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BFm7fWx1.css">
 </head>
 <body>

--- a/cmd/complab-desktop/frontend/src/App.tsx
+++ b/cmd/complab-desktop/frontend/src/App.tsx
@@ -92,6 +92,19 @@ function App() {
                         </div>
                     </div>
                     
+                    {/* Data Display */}
+                    {fileData && (
+                        <div className="bg-gray-800 rounded-lg p-6 shadow-lg">
+                            <h2 className="text-xl font-semibold mb-4">Loaded Data</h2>
+                            <DataTable
+                                headers={fileData.headers}
+                                rowNames={fileData.rowNames}
+                                data={fileData.data}
+                                title="Input Data"
+                            />
+                        </div>
+                    )}
+                    
                     {/* Configuration Section */}
                     {fileData && (
                         <div className="bg-gray-800 rounded-lg p-6 shadow-lg">
@@ -167,19 +180,6 @@ function App() {
                     {error && (
                         <div className="bg-red-800 border border-red-600 rounded-lg p-4">
                             <p className="text-red-200">{error}</p>
-                        </div>
-                    )}
-                    
-                    {/* Data Display */}
-                    {fileData && (
-                        <div className="bg-gray-800 rounded-lg p-6 shadow-lg">
-                            <h2 className="text-xl font-semibold mb-4">Loaded Data</h2>
-                            <DataTable
-                                headers={fileData.headers}
-                                rowNames={fileData.rowNames}
-                                data={fileData.data}
-                                title="Input Data"
-                            />
                         </div>
                     )}
                     


### PR DESCRIPTION
## Summary
Reorders the GUI layout to show the loaded data grid immediately after file upload, before the PCA configuration section.

## Changes
- Moved "Loaded Data" section to appear between file upload and PCA configuration
- No logic changes, only component reordering in App.tsx

## Why
This provides better visual feedback that data was loaded successfully before asking users to configure analysis parameters. Users naturally want to see their data after loading it.

## Testing
- Built frontend successfully with `npm run build`
- Layout now shows sections in logical order:
  1. Step 1: Load Data
  2. Loaded Data (grid)
  3. Step 2: Configure PCA

Closes #15