### PR TITLE
Fix: Add row and column selection capabilities for PCA analysis

### DIFF
--- a/cmd/complab-desktop/frontend/dist/index.html
+++ b/cmd/complab-desktop/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>temp</title>
-  <script type="module" crossorigin src="/assets/index-QyqBRQdx.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-BFm7fWx1.css">
+  <script type="module" crossorigin src="/assets/index-DEkRz8-p.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-8gJbzpiJ.css">
 </head>
 <body>
 <div id="root"></div>

--- a/cmd/complab-desktop/frontend/src/types/index.ts
+++ b/cmd/complab-desktop/frontend/src/types/index.ts
@@ -13,6 +13,8 @@ export interface PCARequest {
   standardScale: boolean;
   robustScale: boolean;
   method: string;
+  excludedRows?: number[];
+  excludedColumns?: number[];
 }
 
 export interface PCAResult {

--- a/cmd/complab-desktop/frontend/wailsjs/go/models.ts
+++ b/cmd/complab-desktop/frontend/wailsjs/go/models.ts
@@ -25,6 +25,8 @@ export namespace main {
 	    standardScale: boolean;
 	    robustScale: boolean;
 	    method: string;
+	    excludedRows?: number[];
+	    excludedColumns?: number[];
 	
 	    static createFrom(source: any = {}) {
 	        return new PCARequest(source);
@@ -40,6 +42,8 @@ export namespace main {
 	        this.standardScale = source["standardScale"];
 	        this.robustScale = source["robustScale"];
 	        this.method = source["method"];
+	        this.excludedRows = source["excludedRows"];
+	        this.excludedColumns = source["excludedColumns"];
 	    }
 	}
 	export class PCAResponse {

--- a/internal/utils/range_parser.go
+++ b/internal/utils/range_parser.go
@@ -1,0 +1,153 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ParseRanges parses a comma-separated string of indices and ranges into a slice of integers.
+// Examples:
+//   - "1,3,5" returns [1, 3, 5]
+//   - "1-3,5" returns [1, 2, 3, 5]
+//   - "1,3-5,7" returns [1, 3, 4, 5, 7]
+// Note: Input indices are 1-based (human-friendly), output indices are 0-based
+func ParseRanges(input string) ([]int, error) {
+	if input == "" {
+		return []int{}, nil
+	}
+
+	// Use a map to avoid duplicates
+	indexMap := make(map[int]bool)
+	
+	// Split by comma
+	parts := strings.Split(input, ",")
+	
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		
+		// Check if it's a range (contains hyphen)
+		if strings.Contains(part, "-") {
+			rangeParts := strings.Split(part, "-")
+			if len(rangeParts) != 2 {
+				return nil, fmt.Errorf("invalid range format: %s", part)
+			}
+			
+			start, err := strconv.Atoi(strings.TrimSpace(rangeParts[0]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid start index in range %s: %v", part, err)
+			}
+			
+			end, err := strconv.Atoi(strings.TrimSpace(rangeParts[1]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid end index in range %s: %v", part, err)
+			}
+			
+			if start < 1 || end < 1 {
+				return nil, fmt.Errorf("indices must be positive (1-based), got range %d-%d", start, end)
+			}
+			
+			if start > end {
+				return nil, fmt.Errorf("invalid range: start %d is greater than end %d", start, end)
+			}
+			
+			// Add all indices in the range (convert to 0-based)
+			for i := start; i <= end; i++ {
+				indexMap[i-1] = true
+			}
+		} else {
+			// Single index
+			index, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, fmt.Errorf("invalid index %s: %v", part, err)
+			}
+			
+			if index < 1 {
+				return nil, fmt.Errorf("indices must be positive (1-based), got %d", index)
+			}
+			
+			// Convert to 0-based
+			indexMap[index-1] = true
+		}
+	}
+	
+	// Convert map to sorted slice
+	result := make([]int, 0, len(indexMap))
+	for index := range indexMap {
+		result = append(result, index)
+	}
+	sort.Ints(result)
+	
+	return result, nil
+}
+
+// FilterMatrix removes specified rows and columns from a matrix
+func FilterMatrix(data [][]float64, excludedRows, excludedColumns []int) ([][]float64, error) {
+	if len(data) == 0 {
+		return data, nil
+	}
+	
+	// Create maps for O(1) lookup
+	excludeRowMap := make(map[int]bool)
+	for _, idx := range excludedRows {
+		if idx < 0 || idx >= len(data) {
+			return nil, fmt.Errorf("row index %d out of bounds (0-%d)", idx, len(data)-1)
+		}
+		excludeRowMap[idx] = true
+	}
+	
+	excludeColMap := make(map[int]bool)
+	numCols := len(data[0])
+	for _, idx := range excludedColumns {
+		if idx < 0 || idx >= numCols {
+			return nil, fmt.Errorf("column index %d out of bounds (0-%d)", idx, numCols-1)
+		}
+		excludeColMap[idx] = true
+	}
+	
+	// Build filtered matrix
+	var filtered [][]float64
+	for i, row := range data {
+		if excludeRowMap[i] {
+			continue
+		}
+		
+		var filteredRow []float64
+		for j, val := range row {
+			if !excludeColMap[j] {
+				filteredRow = append(filteredRow, val)
+			}
+		}
+		
+		if len(filteredRow) > 0 {
+			filtered = append(filtered, filteredRow)
+		}
+	}
+	
+	return filtered, nil
+}
+
+// FilterStringSlice removes elements at specified indices from a string slice
+func FilterStringSlice(items []string, excludedIndices []int) ([]string, error) {
+	// Create map for O(1) lookup
+	excludeMap := make(map[int]bool)
+	for _, idx := range excludedIndices {
+		if idx < 0 || idx >= len(items) {
+			return nil, fmt.Errorf("index %d out of bounds (0-%d)", idx, len(items)-1)
+		}
+		excludeMap[idx] = true
+	}
+	
+	var filtered []string
+	for i, item := range items {
+		if !excludeMap[i] {
+			filtered = append(filtered, item)
+		}
+	}
+	
+	return filtered, nil
+}

--- a/internal/utils/range_parser_test.go
+++ b/internal/utils/range_parser_test.go
@@ -1,0 +1,254 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseRanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []int
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			want:    []int{},
+			wantErr: false,
+		},
+		{
+			name:    "single index",
+			input:   "3",
+			want:    []int{2}, // 0-based
+			wantErr: false,
+		},
+		{
+			name:    "multiple indices",
+			input:   "1,3,5",
+			want:    []int{0, 2, 4}, // 0-based
+			wantErr: false,
+		},
+		{
+			name:    "simple range",
+			input:   "2-4",
+			want:    []int{1, 2, 3}, // 0-based
+			wantErr: false,
+		},
+		{
+			name:    "mixed indices and ranges",
+			input:   "1,3-5,7",
+			want:    []int{0, 2, 3, 4, 6}, // 0-based
+			wantErr: false,
+		},
+		{
+			name:    "with spaces",
+			input:   "1, 3 - 5 , 7",
+			want:    []int{0, 2, 3, 4, 6}, // 0-based
+			wantErr: false,
+		},
+		{
+			name:    "duplicates removed",
+			input:   "1,2,1,3,2-4",
+			want:    []int{0, 1, 2, 3}, // 0-based, sorted, unique
+			wantErr: false,
+		},
+		{
+			name:    "invalid index",
+			input:   "0",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "negative index",
+			input:   "-1",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid range format",
+			input:   "1-2-3",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "reversed range",
+			input:   "5-3",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric",
+			input:   "a,b,c",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRanges(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRanges() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseRanges() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterMatrix(t *testing.T) {
+	tests := []struct {
+		name            string
+		data            [][]float64
+		excludedRows    []int
+		excludedColumns []int
+		want            [][]float64
+		wantErr         bool
+	}{
+		{
+			name: "no exclusions",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			excludedRows:    []int{},
+			excludedColumns: []int{},
+			want: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exclude rows",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			excludedRows:    []int{0, 2},
+			excludedColumns: []int{},
+			want: [][]float64{
+				{4, 5, 6},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exclude columns",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			excludedRows:    []int{},
+			excludedColumns: []int{0, 2},
+			want: [][]float64{
+				{2},
+				{5},
+				{8},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exclude both",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			excludedRows:    []int{1},
+			excludedColumns: []int{1},
+			want: [][]float64{
+				{1, 3},
+				{7, 9},
+			},
+			wantErr: false,
+		},
+		{
+			name: "out of bounds row",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			excludedRows:    []int{3},
+			excludedColumns: []int{},
+			want:            nil,
+			wantErr:         true,
+		},
+		{
+			name: "out of bounds column",
+			data: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			excludedRows:    []int{},
+			excludedColumns: []int{3},
+			want:            nil,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterMatrix(tt.data, tt.excludedRows, tt.excludedColumns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FilterMatrix() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterMatrix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterStringSlice(t *testing.T) {
+	tests := []struct {
+		name            string
+		items           []string
+		excludedIndices []int
+		want            []string
+		wantErr         bool
+	}{
+		{
+			name:            "no exclusions",
+			items:           []string{"a", "b", "c"},
+			excludedIndices: []int{},
+			want:            []string{"a", "b", "c"},
+			wantErr:         false,
+		},
+		{
+			name:            "exclude some",
+			items:           []string{"a", "b", "c", "d"},
+			excludedIndices: []int{1, 3},
+			want:            []string{"a", "c"},
+			wantErr:         false,
+		},
+		{
+			name:            "out of bounds",
+			items:           []string{"a", "b", "c"},
+			excludedIndices: []int{3},
+			want:            nil,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterStringSlice(tt.items, tt.excludedIndices)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FilterStringSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterStringSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/types/pca.go
+++ b/pkg/types/pca.go
@@ -5,10 +5,12 @@ type Matrix [][]float64
 
 // PCAConfig holds configuration for PCA analysis
 type PCAConfig struct {
-	Components    int    `json:"components"`
-	MeanCenter    bool   `json:"mean_center"`
-	StandardScale bool   `json:"standard_scale"`
-	Method        string `json:"method"` // "svd" or "eigen"
+	Components      int    `json:"components"`
+	MeanCenter      bool   `json:"mean_center"`
+	StandardScale   bool   `json:"standard_scale"`
+	Method          string `json:"method"` // "svd" or "eigen"
+	ExcludedRows    []int  `json:"excluded_rows,omitempty"`    // 0-based indices of rows to exclude
+	ExcludedColumns []int  `json:"excluded_columns,omitempty"` // 0-based indices of columns to exclude
 }
 
 // PCAResult contains the results of PCA analysis


### PR DESCRIPTION
## Summary
Implements row and column selection features for PCA analysis in both CLI and GUI interfaces, allowing users to exclude specific data points from the analysis.

Closes #17

## Changes Made

### CLI Enhancements
- Added `--exclude-rows` and `--exclude-cols` flags to the analyze command
- Implemented range parsing to support formats like "1,3-5,7"
- Data filtering occurs before PCA computation

### GUI Enhancements
- Updated DataTable component with checkbox selection for rows and columns
- All rows and columns are selected by default
- Selection state is managed and converted to exclusion lists for the backend
- Visual feedback shows selected row/column counts

### Core Updates
- Extended `PCAConfig` struct with `ExcludedRows` and `ExcludedColumns` fields
- Created utility functions for parsing ranges and filtering matrices
- Added comprehensive unit tests for all new functionality

## Testing
- ✅ Unit tests for range parsing and matrix filtering
- ✅ CLI tested with various exclusion patterns
- ✅ GUI tested with row/column selection
- ✅ All existing tests pass

## Example Usage

### CLI
```bash
# Exclude rows 1, 5-10 and columns 3, 4
complab-cli analyze --exclude-rows 1,5-10 --exclude-cols 3,4 data/iris_data.csv
```

### GUI
- Load a CSV file
- Use checkboxes in the data table to select/deselect rows and columns
- Only selected data is used for PCA analysis

🤖 Generated with [Claude Code](https://claude.ai/code)