### PR TITLE
feat: replace text header with GoPCA logo image

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import { ParseCSV, RunPCA } from "../wailsjs/go/main/App";
 import { DataTable } from './components/DataTable';
 import { FileData, PCARequest, PCAResponse } from './types';
+import logo from './assets/images/GoPCA-logo-1024.png';
 
 function App() {
     const [fileData, setFileData] = useState<FileData | null>(null);
@@ -92,7 +93,7 @@ function App() {
     return (
         <div className="flex flex-col h-screen bg-gray-900 text-white">
             <header className="bg-gray-800 p-4 shadow-lg">
-                <h1 className="text-2xl font-bold text-center">GoPCA Desktop</h1>
+                <img src={logo} alt="GoPCA - Principal Component Analysis Tool" className="h-12 mx-auto" />
             </header>
             
             <main className="flex-1 overflow-auto p-6">


### PR DESCRIPTION
## Summary
This PR replaces the text-based "GoPCA Desktop" heading with the GoPCA logo image for enhanced visual branding.

## Changes
- Added import for the GoPCA logo image (1024px version)
- Replaced the `<h1>` text element with an `<img>` element
- Styled the logo with Tailwind classes for proper sizing and centering
- Added descriptive alt text for accessibility

## Visual Result
The header now displays the red GoPCA logo with star and arrows design instead of plain text, creating a more professional and visually appealing interface.

## Testing
- ✅ Frontend builds successfully
- ✅ Logo image is properly included in the build
- ✅ Logo displays centered in the header with appropriate height

Closes #21