### PR TITLE
Fix: Move Scores Matrix below visualization plots in desktop UI

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -261,16 +261,6 @@ function App() {
                         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg border border-gray-200 dark:border-gray-700">
                             <h2 className="text-xl font-semibold mb-4">PCA Results</h2>
                             
-                            {/* Scores Matrix */}
-                            <div className="mb-6">
-                                <DataTable
-                                    headers={pcaResponse.result.component_labels || []}
-                                    rowNames={fileData?.rowNames || []}
-                                    data={pcaResponse.result.scores}
-                                    title="Scores Matrix"
-                                />
-                            </div>
-                            
                             {/* Explained Variance */}
                             <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
                                 <h3 className="text-lg font-semibold mb-2">Explained Variance</h3>
@@ -415,6 +405,16 @@ function App() {
                                         </div>
                                     )}
                                 </div>
+                            </div>
+                            
+                            {/* Scores Matrix */}
+                            <div className="mt-6">
+                                <DataTable
+                                    headers={pcaResponse.result.component_labels || []}
+                                    rowNames={fileData?.rowNames || []}
+                                    data={pcaResponse.result.scores}
+                                    title="Scores Matrix"
+                                />
                             </div>
                             
                         </div>


### PR DESCRIPTION
## Summary
Reorders the PCA results display to show the Scores Matrix below the visualization plots, improving the visual flow and user experience by prioritizing visual insights over raw numerical data.

## Changes
- Moved the Scores Matrix div block from before the Explained Variance section to after the visualizations
- Changed margin class from `mb-6` to `mt-6` to maintain proper spacing
- No functional changes - purely a UI layout reorganization

## Testing
- [x] Code compiles without errors
- [x] All Go tests pass (`go test ./...`)
- [x] Frontend builds successfully (`npm run build`)
- [ ] Manual testing in GUI (requires Wails environment)

## Visual Impact
**Before:** Scores Matrix → Explained Variance → Visualizations
**After:** Explained Variance → Visualizations → Scores Matrix

This arrangement prioritizes the visual insights (plots) which are typically what users want to see first, with the detailed numerical data (Scores Matrix) available below for those who need it.

Closes #28