### PR TITLE
feat: add Kernel PCA implementation

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -52,6 +52,11 @@ type PCARequest struct {
 	Method          string      `json:"method"`
 	ExcludedRows    []int       `json:"excludedRows,omitempty"`
 	ExcludedColumns []int       `json:"excludedColumns,omitempty"`
+	// Kernel PCA parameters
+	KernelType   string  `json:"kernelType,omitempty"`
+	KernelGamma  float64 `json:"kernelGamma,omitempty"`
+	KernelDegree int     `json:"kernelDegree,omitempty"`
+	KernelCoef0  float64 `json:"kernelCoef0,omitempty"`
 }
 
 // PCAResponse represents the PCA analysis results
@@ -213,8 +218,20 @@ func (a *App) RunPCA(request PCARequest) PCAResponse {
 		ExcludedColumns: request.ExcludedColumns,
 	}
 	
+	// Add kernel parameters if using kernel PCA
+	if strings.ToLower(request.Method) == "kernel" {
+		config.KernelType = request.KernelType
+		config.KernelGamma = request.KernelGamma
+		config.KernelDegree = request.KernelDegree
+		config.KernelCoef0 = request.KernelCoef0
+		
+		// Skip standard preprocessing for kernel PCA
+		config.MeanCenter = false
+		config.StandardScale = false
+	}
+	
 	// Perform PCA
-	engine := core.NewPCAEngine()
+	engine := core.NewPCAEngineForMethod(config.Method)
 	result, err := engine.Fit(dataToAnalyze, config)
 	if err != nil {
 		return PCAResponse{

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -28,7 +28,12 @@ function App() {
         meanCenter: true,
         standardScale: true,
         robustScale: false,
-        method: 'SVD'
+        method: 'SVD',
+        // Kernel PCA parameters
+        kernelType: 'rbf',
+        kernelGamma: 1.0,
+        kernelDegree: 3,
+        kernelCoef0: 0.0
     });
     
     const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -205,8 +210,9 @@ function App() {
                                         onChange={(e) => setConfig({...config, method: e.target.value})}
                                         className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                                     >
-                                        <option value="NIPALS">NIPALS</option>
                                         <option value="SVD">SVD</option>
+                                        <option value="NIPALS">NIPALS</option>
+                                        <option value="kernel">Kernel PCA</option>
                                     </select>
                                 </div>
                             </div>
@@ -239,6 +245,75 @@ function App() {
                                     Robust Scale
                                 </label>
                             </div>
+                            
+                            {/* Kernel PCA Options */}
+                            {config.method === 'kernel' && (
+                                <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-4">
+                                    <h4 className="font-medium text-sm">Kernel PCA Options</h4>
+                                    <div className="grid grid-cols-2 gap-4">
+                                        <div>
+                                            <label className="block text-sm font-medium mb-1">
+                                                Kernel Type
+                                            </label>
+                                            <select
+                                                value={config.kernelType}
+                                                onChange={(e) => setConfig({...config, kernelType: e.target.value})}
+                                                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
+                                            >
+                                                <option value="rbf">RBF (Gaussian)</option>
+                                                <option value="linear">Linear</option>
+                                                <option value="poly">Polynomial</option>
+                                            </select>
+                                        </div>
+                                        <div>
+                                            <label className="block text-sm font-medium mb-1">
+                                                Gamma
+                                            </label>
+                                            <input
+                                                type="number"
+                                                value={config.kernelGamma}
+                                                step="0.01"
+                                                min="0.001"
+                                                onChange={(e) => setConfig({...config, kernelGamma: parseFloat(e.target.value) || 1.0})}
+                                                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
+                                            />
+                                        </div>
+                                        {config.kernelType === 'poly' && (
+                                            <>
+                                                <div>
+                                                    <label className="block text-sm font-medium mb-1">
+                                                        Degree
+                                                    </label>
+                                                    <input
+                                                        type="number"
+                                                        value={config.kernelDegree}
+                                                        min="1"
+                                                        max="10"
+                                                        onChange={(e) => setConfig({...config, kernelDegree: parseInt(e.target.value) || 3})}
+                                                        className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="block text-sm font-medium mb-1">
+                                                        Coef0
+                                                    </label>
+                                                    <input
+                                                        type="number"
+                                                        value={config.kernelCoef0}
+                                                        step="0.1"
+                                                        onChange={(e) => setConfig({...config, kernelCoef0: parseFloat(e.target.value) || 0.0})}
+                                                        className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
+                                                    />
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                                        Note: Kernel PCA uses its own centering in kernel space. Standard preprocessing options will be ignored.
+                                    </p>
+                                </div>
+                            )}
+                            
                             <button
                                 onClick={runPCA}
                                 disabled={loading}

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -43,6 +43,15 @@ export const Biplot: React.FC<BiplotProps> = ({
   
   const [isFullscreen, setIsFullscreen] = useState(false);
   const chartTheme = useChartTheme();
+  
+  // Check if loadings are available (not available for Kernel PCA)
+  if (!pcaResult.loadings || pcaResult.loadings.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center text-gray-400">
+        <p>Biplot is not available for this PCA method (loadings required)</p>
+      </div>
+    );
+  }
 
   // Create color map for groups
   const groupColorMap = useMemo(() => {

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
@@ -29,6 +29,16 @@ export const LoadingsPlot: React.FC<LoadingsPlotProps> = ({
 }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const chartTheme = useChartTheme();
+  
+  // Check if loadings are available (not available for Kernel PCA)
+  if (!pcaResult.loadings || pcaResult.loadings.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center text-gray-400">
+        <p>Loadings are not available for this PCA method</p>
+      </div>
+    );
+  }
+  
   // Auto-detect plot type based on number of variables
   const numVariables = pcaResult.loadings[0]?.length || 0;
   const autoPlotType = numVariables > variableThreshold ? 'line' : 'bar';

--- a/cmd/gopca-desktop/frontend/src/types/index.ts
+++ b/cmd/gopca-desktop/frontend/src/types/index.ts
@@ -18,6 +18,11 @@ export interface PCARequest {
   method: string;
   excludedRows?: number[];
   excludedColumns?: number[];
+  // Kernel PCA parameters
+  kernelType?: string;
+  kernelGamma?: number;
+  kernelDegree?: number;
+  kernelCoef0?: number;
 }
 
 export interface PCAResult {

--- a/docs/kernel-pca.md
+++ b/docs/kernel-pca.md
@@ -1,0 +1,119 @@
+# Kernel PCA in GoPCA
+
+Kernel PCA is a non-linear dimensionality reduction technique that extends traditional PCA by using kernel functions to project data into higher-dimensional feature spaces where linear separation becomes possible.
+
+## When to Use Kernel PCA
+
+Use Kernel PCA when:
+- Your data has non-linear relationships that linear PCA cannot capture
+- You observe circular, spiral, or other complex patterns in your data
+- Traditional PCA results show poor separation between known groups
+- You work with data types that benefit from specific kernels (e.g., text, images, spectroscopy)
+
+## Available Kernels
+
+### RBF (Radial Basis Function) Kernel
+The RBF or Gaussian kernel is the most commonly used kernel for non-linear data:
+- **Formula**: `K(x, y) = exp(-γ ||x - y||²)`
+- **Parameter**: `gamma` (γ) - controls the "reach" of the kernel
+- **Use case**: General non-linear relationships, circular patterns
+
+### Linear Kernel  
+The linear kernel is equivalent to standard PCA:
+- **Formula**: `K(x, y) = x · y`
+- **Parameters**: None
+- **Use case**: Testing, comparison with standard PCA
+
+### Polynomial Kernel
+The polynomial kernel captures polynomial relationships:
+- **Formula**: `K(x, y) = (γ x · y + c₀)^d`
+- **Parameters**: 
+  - `gamma` (γ) - scaling factor
+  - `degree` (d) - polynomial degree
+  - `coef0` (c₀) - independent term
+- **Use case**: Known polynomial relationships
+
+## CLI Usage
+
+### Basic RBF Kernel PCA
+```bash
+gopca-cli analyze --method kernel --kernel-type rbf --kernel-gamma 0.1 data.csv
+```
+
+### Polynomial Kernel with Custom Parameters
+```bash
+gopca-cli analyze --method kernel --kernel-type poly \
+  --kernel-gamma 0.01 --kernel-degree 3 --kernel-coef0 1.0 \
+  -c 5 data.csv
+```
+
+### Linear Kernel (equivalent to standard PCA)
+```bash
+gopca-cli analyze --method kernel --kernel-type linear data.csv
+```
+
+## GUI Usage
+
+1. Load your data file
+2. In the "Configure PCA" section, select "Kernel PCA" from the Method dropdown
+3. Configure kernel parameters:
+   - Select kernel type (RBF, Linear, or Polynomial)
+   - Adjust gamma parameter (for RBF and Polynomial)
+   - Set degree and coef0 (for Polynomial only)
+4. Click "Run PCA Analysis"
+
+**Note**: Standard preprocessing options (mean centering, scaling) are ignored for Kernel PCA as it performs its own centering in kernel space.
+
+## Parameter Guidelines
+
+### Gamma Parameter
+- **Small gamma** (e.g., 0.001-0.01): Smoother decision boundaries, each point has far-reaching influence
+- **Large gamma** (e.g., 0.1-10): More complex boundaries, each point has local influence
+- Start with `gamma = 1/n_features` as a rule of thumb
+
+### Polynomial Degree
+- **Degree 2**: Quadratic relationships
+- **Degree 3**: Cubic relationships (default)
+- Higher degrees risk overfitting
+
+## Interpretation
+
+### Scores
+- Kernel PCA scores represent projections in the kernel-induced feature space
+- Interpret similarly to regular PCA scores for visualization
+- Distance relationships may differ from linear PCA
+
+### Loadings
+- Kernel PCA does not produce traditional loadings
+- Variable contributions cannot be directly interpreted
+- Focus on scores for analysis
+
+### Explained Variance
+- Represents variance captured in kernel space
+- Not directly comparable to linear PCA explained variance
+- Still useful for selecting number of components
+
+## Performance Considerations
+
+- Kernel PCA has O(n²) memory complexity due to kernel matrix
+- Computation time scales with O(n³) for eigendecomposition
+- For datasets >10,000 samples, consider:
+  - Sampling approaches
+  - Approximate kernel methods
+  - Linear PCA as initial exploration
+
+## Example: Circular Data
+
+For data with circular patterns (e.g., two concentric circles):
+```bash
+# RBF kernel will separate the circles effectively
+gopca-cli analyze --method kernel --kernel-type rbf --kernel-gamma 0.5 circles.csv
+
+# Linear kernel (standard PCA) will fail to separate
+gopca-cli analyze --method svd circles.csv
+```
+
+## References
+
+- Schölkopf, B., Smola, A., & Müller, K. R. (1998). Nonlinear component analysis as a kernel eigenvalue problem.
+- For mathematical details, see the implementation in `internal/core/kernel_pca.go`

--- a/internal/core/kernel_pca.go
+++ b/internal/core/kernel_pca.go
@@ -1,0 +1,381 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/bitjungle/gopca/pkg/types"
+	"gonum.org/v1/gonum/mat"
+)
+
+// KernelType represents the type of kernel function to use
+type KernelType string
+
+const (
+	// KernelRBF is the Radial Basis Function (Gaussian) kernel
+	KernelRBF KernelType = "rbf"
+	// KernelLinear is the linear kernel (equivalent to standard PCA)
+	KernelLinear KernelType = "linear"
+	// KernelPoly is the polynomial kernel
+	KernelPoly KernelType = "poly"
+)
+
+// KernelPCAImpl implements the PCAEngine interface for Kernel PCA
+type KernelPCAImpl struct {
+	config       types.PCAConfig
+	kernelType   KernelType
+	eigvals      []float64
+	eigvecs      *mat.Dense
+	trainingData types.Matrix
+	fitted       bool
+	// Precomputed values for centering
+	trainKernelMeans []float64
+	totalKernelMean  float64
+}
+
+// NewKernelPCAEngine creates a new Kernel PCA engine
+func NewKernelPCAEngine() types.PCAEngine {
+	return &KernelPCAImpl{}
+}
+
+// validateKernelConfig validates kernel-specific configuration
+func (kpca *KernelPCAImpl) validateKernelConfig(config types.PCAConfig) error {
+	if config.KernelType == "" {
+		return errors.New("kernel type must be specified for kernel PCA")
+	}
+	
+	switch KernelType(config.KernelType) {
+	case KernelRBF:
+		if config.KernelGamma <= 0 {
+			return errors.New("gamma must be positive for RBF kernel")
+		}
+	case KernelPoly:
+		if config.KernelGamma <= 0 {
+			return errors.New("gamma must be positive for polynomial kernel")
+		}
+		if config.KernelDegree < 1 {
+			return errors.New("degree must be at least 1 for polynomial kernel")
+		}
+	case KernelLinear:
+		// No specific validation needed
+	default:
+		return fmt.Errorf("unsupported kernel type: %s", config.KernelType)
+	}
+	
+	return nil
+}
+
+// computeKernel computes the kernel function between two vectors
+func (kpca *KernelPCAImpl) computeKernel(x, y []float64) (float64, error) {
+	if len(x) != len(y) {
+		return 0, errors.New("vectors must have the same length")
+	}
+
+	switch kpca.kernelType {
+	case KernelRBF:
+		sum := 0.0
+		for i := range x {
+			diff := x[i] - y[i]
+			sum += diff * diff
+		}
+		return math.Exp(-kpca.config.KernelGamma * sum), nil
+		
+	case KernelLinear:
+		sum := 0.0
+		for i := range x {
+			sum += x[i] * y[i]
+		}
+		return sum, nil
+		
+	case KernelPoly:
+		sum := 0.0
+		for i := range x {
+			sum += x[i] * y[i]
+		}
+		return math.Pow(kpca.config.KernelGamma*sum+kpca.config.KernelCoef0, float64(kpca.config.KernelDegree)), nil
+		
+	default:
+		return 0, fmt.Errorf("unsupported kernel type: %s", kpca.kernelType)
+	}
+}
+
+// computeKernelMatrix computes the full kernel matrix
+func (kpca *KernelPCAImpl) computeKernelMatrix(data types.Matrix) (*mat.Dense, error) {
+	n := len(data)
+	K := mat.NewDense(n, n, nil)
+	
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			val, err := kpca.computeKernel(data[i], data[j])
+			if err != nil {
+				return nil, fmt.Errorf("error computing kernel at (%d, %d): %w", i, j, err)
+			}
+			K.Set(i, j, val)
+			if i != j {
+				K.Set(j, i, val) // Kernel matrix is symmetric
+			}
+		}
+	}
+	
+	return K, nil
+}
+
+// centerKernelMatrix centers the kernel matrix
+func (kpca *KernelPCAImpl) centerKernelMatrix(K *mat.Dense) (*mat.Dense, error) {
+	n, _ := K.Dims()
+	
+	// Compute row and column means
+	rowMeans := make([]float64, n)
+	colMeans := make([]float64, n)
+	totalMean := 0.0
+	
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			val := K.At(i, j)
+			rowMeans[i] += val
+			colMeans[j] += val
+			totalMean += val
+		}
+	}
+	
+	for i := 0; i < n; i++ {
+		rowMeans[i] /= float64(n)
+		colMeans[i] /= float64(n)
+	}
+	totalMean /= float64(n * n)
+	
+	// Store for transform method
+	kpca.trainKernelMeans = colMeans
+	kpca.totalKernelMean = totalMean
+	
+	// Center the kernel matrix
+	Kc := mat.NewDense(n, n, nil)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			val := K.At(i, j) - rowMeans[i] - colMeans[j] + totalMean
+			Kc.Set(i, j, val)
+		}
+	}
+	
+	return Kc, nil
+}
+
+// eigenDecomposition performs eigendecomposition and returns top k components
+func (kpca *KernelPCAImpl) eigenDecomposition(K *mat.Dense, k int) ([]float64, *mat.Dense, error) {
+	// Convert to symmetric matrix for eigendecomposition
+	n, _ := K.Dims()
+	symK := mat.NewSymDense(n, nil)
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			symK.SetSym(i, j, K.At(i, j))
+		}
+	}
+	
+	var eig mat.EigenSym
+	if ok := eig.Factorize(symK, true); !ok {
+		return nil, nil, errors.New("eigendecomposition failed")
+	}
+	
+	vals := eig.Values(nil)
+	var vecs mat.Dense
+	eig.VectorsTo(&vecs)
+	
+	// Sort by descending eigenvalue
+	nVals := len(vals)
+	idx := make([]int, nVals)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool {
+		return vals[idx[i]] > vals[idx[j]]
+	})
+	
+	// Extract top k components
+	if k > nVals {
+		k = nVals
+	}
+	
+	sortedVals := make([]float64, k)
+	sortedVecs := mat.NewDense(nVals, k, nil)
+	
+	for i := 0; i < k; i++ {
+		sortedVals[i] = vals[idx[i]]
+		// Handle near-zero or negative eigenvalues
+		if sortedVals[i] < 1e-10 {
+			sortedVals[i] = 1e-10
+		}
+		for j := 0; j < nVals; j++ {
+			sortedVecs.Set(j, i, vecs.At(j, idx[i]))
+		}
+	}
+	
+	return sortedVals, sortedVecs, nil
+}
+
+// Fit trains the Kernel PCA model on the provided data
+func (kpca *KernelPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types.PCAResult, error) {
+	// Validate configuration
+	if err := kpca.validateKernelConfig(config); err != nil {
+		return nil, fmt.Errorf("invalid kernel configuration: %w", err)
+	}
+	
+	kpca.config = config
+	kpca.kernelType = KernelType(config.KernelType)
+	
+	// Validate data
+	if len(data) == 0 || len(data[0]) == 0 {
+		return nil, errors.New("empty data matrix")
+	}
+	
+	nSamples := len(data)
+	nFeatures := len(data[0])
+	
+	if config.Components > nSamples {
+		return nil, fmt.Errorf("number of components (%d) cannot exceed number of samples (%d)", 
+			config.Components, nSamples)
+	}
+	
+	// Store training data for transform
+	kpca.trainingData = make(types.Matrix, nSamples)
+	for i := range data {
+		kpca.trainingData[i] = make([]float64, nFeatures)
+		copy(kpca.trainingData[i], data[i])
+	}
+	
+	// Compute kernel matrix
+	K, err := kpca.computeKernelMatrix(data)
+	if err != nil {
+		return nil, fmt.Errorf("error computing kernel matrix: %w", err)
+	}
+	
+	// Center kernel matrix
+	Kc, err := kpca.centerKernelMatrix(K)
+	if err != nil {
+		return nil, fmt.Errorf("error centering kernel matrix: %w", err)
+	}
+	
+	// Perform eigendecomposition
+	eigvals, eigvecs, err := kpca.eigenDecomposition(Kc, config.Components)
+	if err != nil {
+		return nil, fmt.Errorf("error in eigendecomposition: %w", err)
+	}
+	
+	kpca.eigvals = eigvals
+	kpca.eigvecs = eigvecs
+	kpca.fitted = true
+	
+	// Compute projections for training data
+	scores := mat.NewDense(nSamples, config.Components, nil)
+	for i := 0; i < config.Components; i++ {
+		norm := math.Sqrt(eigvals[i])
+		for j := 0; j < nSamples; j++ {
+			scores.Set(j, i, eigvecs.At(j, i)/norm)
+		}
+	}
+	
+	// Convert scores to Matrix type
+	scoresMatrix := make(types.Matrix, nSamples)
+	for i := 0; i < nSamples; i++ {
+		scoresMatrix[i] = make([]float64, config.Components)
+		for j := 0; j < config.Components; j++ {
+			scoresMatrix[i][j] = scores.At(i, j)
+		}
+	}
+	
+	// Calculate explained variance
+	totalVar := 0.0
+	for _, v := range eigvals {
+		totalVar += v
+	}
+	
+	explainedVar := make([]float64, config.Components)
+	explainedVarRatio := make([]float64, config.Components)
+	cumulativeVar := make([]float64, config.Components)
+	cumSum := 0.0
+	
+	for i := 0; i < config.Components; i++ {
+		explainedVar[i] = eigvals[i]
+		explainedVarRatio[i] = eigvals[i] / totalVar * 100
+		cumSum += explainedVarRatio[i]
+		cumulativeVar[i] = cumSum
+	}
+	
+	// Note: Loadings are not meaningful for Kernel PCA
+	// We'll return an empty matrix for compatibility
+	loadings := make(types.Matrix, 0)
+	
+	return &types.PCAResult{
+		Scores:              scoresMatrix,
+		Loadings:            loadings,
+		ExplainedVar:        explainedVar,
+		ExplainedVarRatio:   explainedVarRatio,
+		CumulativeVar:       cumulativeVar,
+		ComponentsComputed:  config.Components,
+		Method:              "kernel",
+		PreprocessingApplied: false, // Kernel PCA doesn't use standard preprocessing
+	}, nil
+}
+
+// Transform projects new data into the kernel PCA space
+func (kpca *KernelPCAImpl) Transform(data types.Matrix) (types.Matrix, error) {
+	if !kpca.fitted {
+		return nil, errors.New("model must be fitted before transform")
+	}
+	
+	nTest := len(data)
+	nTrain := len(kpca.trainingData)
+	nComponents := kpca.config.Components
+	
+	// Compute kernel matrix between test and training data
+	K := mat.NewDense(nTest, nTrain, nil)
+	for i := 0; i < nTest; i++ {
+		for j := 0; j < nTrain; j++ {
+			val, err := kpca.computeKernel(data[i], kpca.trainingData[j])
+			if err != nil {
+				return nil, fmt.Errorf("error computing kernel at (%d, %d): %w", i, j, err)
+			}
+			K.Set(i, j, val)
+		}
+	}
+	
+	// Center the test kernel matrix using training statistics
+	for i := 0; i < nTest; i++ {
+		rowMean := 0.0
+		for j := 0; j < nTrain; j++ {
+			rowMean += K.At(i, j)
+		}
+		rowMean /= float64(nTrain)
+		
+		for j := 0; j < nTrain; j++ {
+			val := K.At(i, j) - rowMean - kpca.trainKernelMeans[j] + kpca.totalKernelMean
+			K.Set(i, j, val)
+		}
+	}
+	
+	// Project onto eigenvectors
+	result := make(types.Matrix, nTest)
+	for i := 0; i < nTest; i++ {
+		result[i] = make([]float64, nComponents)
+		for j := 0; j < nComponents; j++ {
+			sum := 0.0
+			norm := math.Sqrt(kpca.eigvals[j])
+			for k := 0; k < nTrain; k++ {
+				sum += K.At(i, k) * kpca.eigvecs.At(k, j)
+			}
+			result[i][j] = sum / norm
+		}
+	}
+	
+	return result, nil
+}
+
+// FitTransform fits the model and transforms the data in one step
+func (kpca *KernelPCAImpl) FitTransform(data types.Matrix, config types.PCAConfig) (*types.PCAResult, error) {
+	result, err := kpca.Fit(data, config)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/core/kernel_pca_test.go
+++ b/internal/core/kernel_pca_test.go
@@ -1,0 +1,355 @@
+package core
+
+import (
+	"math"
+	"testing"
+
+	"github.com/bitjungle/gopca/pkg/types"
+)
+
+// Test data: simple 2D data that should benefit from RBF kernel
+func generateCircleData() types.Matrix {
+	// Generate points in a circle pattern
+	n := 20
+	data := make(types.Matrix, n*2)
+	
+	// Inner circle (class 1)
+	for i := 0; i < n; i++ {
+		angle := float64(i) * 2 * math.Pi / float64(n)
+		data[i] = []float64{
+			0.3 * math.Cos(angle),
+			0.3 * math.Sin(angle),
+		}
+	}
+	
+	// Outer circle (class 2)
+	for i := 0; i < n; i++ {
+		angle := float64(i) * 2 * math.Pi / float64(n)
+		data[n+i] = []float64{
+			math.Cos(angle),
+			math.Sin(angle),
+		}
+	}
+	
+	return data
+}
+
+// Test linear separable data
+func generateLinearData() types.Matrix {
+	// Simple linearly separable data
+	return types.Matrix{
+		{1.0, 2.0},
+		{2.0, 3.0},
+		{3.0, 4.0},
+		{4.0, 5.0},
+		{5.0, 6.0},
+		{6.0, 7.0},
+	}
+}
+
+func TestKernelPCA_LinearKernel(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := generateLinearData()
+	
+	config := types.PCAConfig{
+		Components:   2,
+		Method:       "kernel",
+		KernelType:   "linear",
+	}
+	
+	result, err := engine.Fit(data, config)
+	if err != nil {
+		t.Fatalf("Failed to fit linear kernel PCA: %v", err)
+	}
+	
+	// Check result structure
+	if result == nil {
+		t.Fatal("Result is nil")
+	}
+	
+	if len(result.Scores) != len(data) {
+		t.Errorf("Expected %d scores, got %d", len(data), len(result.Scores))
+	}
+	
+	if result.ComponentsComputed != 2 {
+		t.Errorf("Expected 2 components, got %d", result.ComponentsComputed)
+	}
+	
+	// Linear kernel PCA should give similar results to regular PCA for linear data
+	// Check that variance is captured
+	if result.ExplainedVarRatio[0] < 90.0 {
+		t.Errorf("First component should explain most variance, got %.2f%%", result.ExplainedVarRatio[0])
+	}
+}
+
+func TestKernelPCA_RBFKernel(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := generateCircleData()
+	
+	config := types.PCAConfig{
+		Components:   2,
+		Method:       "kernel",
+		KernelType:   "rbf",
+		KernelGamma:  1.0,
+	}
+	
+	result, err := engine.Fit(data, config)
+	if err != nil {
+		t.Fatalf("Failed to fit RBF kernel PCA: %v", err)
+	}
+	
+	// Check that it successfully separates the circular data
+	if len(result.Scores) != len(data) {
+		t.Errorf("Expected %d scores, got %d", len(data), len(result.Scores))
+	}
+	
+	// RBF kernel should capture non-linear patterns
+	if result.CumulativeVar[1] < 50.0 {
+		t.Errorf("RBF kernel should capture significant variance, got %.2f%%", result.CumulativeVar[1])
+	}
+}
+
+func TestKernelPCA_PolynomialKernel(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := generateLinearData()
+	
+	config := types.PCAConfig{
+		Components:   2,
+		Method:       "kernel",
+		KernelType:   "poly",
+		KernelGamma:  0.1,
+		KernelDegree: 2,
+		KernelCoef0:  1.0,
+	}
+	
+	result, err := engine.Fit(data, config)
+	if err != nil {
+		t.Fatalf("Failed to fit polynomial kernel PCA: %v", err)
+	}
+	
+	if result.Method != "kernel" {
+		t.Errorf("Expected method 'kernel', got %s", result.Method)
+	}
+	
+	// Loadings should be empty for kernel PCA
+	if len(result.Loadings) != 0 {
+		t.Error("Kernel PCA should not produce loadings")
+	}
+}
+
+func TestKernelPCA_InvalidConfig(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := generateLinearData()
+	
+	tests := []struct {
+		name   string
+		config types.PCAConfig
+	}{
+		{
+			name: "Missing kernel type",
+			config: types.PCAConfig{
+				Components: 2,
+				Method:     "kernel",
+			},
+		},
+		{
+			name: "Invalid kernel type",
+			config: types.PCAConfig{
+				Components: 2,
+				Method:     "kernel",
+				KernelType: "invalid",
+			},
+		},
+		{
+			name: "RBF with zero gamma",
+			config: types.PCAConfig{
+				Components:  2,
+				Method:      "kernel",
+				KernelType:  "rbf",
+				KernelGamma: 0.0,
+			},
+		},
+		{
+			name: "Poly with zero degree",
+			config: types.PCAConfig{
+				Components:   2,
+				Method:       "kernel",
+				KernelType:   "poly",
+				KernelGamma:  1.0,
+				KernelDegree: 0,
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := engine.Fit(data, tt.config)
+			if err == nil {
+				t.Error("Expected error for invalid configuration")
+			}
+		})
+	}
+}
+
+func TestKernelPCA_Transform(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	trainData := generateLinearData()
+	
+	config := types.PCAConfig{
+		Components:  2,
+		Method:      "kernel",
+		KernelType:  "rbf",
+		KernelGamma: 0.5,
+	}
+	
+	// Fit the model
+	_, err := engine.Fit(trainData, config)
+	if err != nil {
+		t.Fatalf("Failed to fit kernel PCA: %v", err)
+	}
+	
+	// Transform new data
+	testData := types.Matrix{
+		{1.5, 2.5},
+		{3.5, 4.5},
+	}
+	
+	transformed, err := engine.Transform(testData)
+	if err != nil {
+		t.Fatalf("Failed to transform data: %v", err)
+	}
+	
+	if len(transformed) != len(testData) {
+		t.Errorf("Expected %d transformed samples, got %d", len(testData), len(transformed))
+	}
+	
+	if len(transformed[0]) != 2 {
+		t.Errorf("Expected 2 components, got %d", len(transformed[0]))
+	}
+}
+
+func TestKernelPCA_FitTransform(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := generateCircleData()
+	
+	config := types.PCAConfig{
+		Components:  3,
+		Method:      "kernel",
+		KernelType:  "rbf",
+		KernelGamma: 2.0,
+	}
+	
+	result, err := engine.FitTransform(data, config)
+	if err != nil {
+		t.Fatalf("Failed to fit-transform: %v", err)
+	}
+	
+	// Scores should match the training data size
+	if len(result.Scores) != len(data) {
+		t.Errorf("Expected %d scores, got %d", len(data), len(result.Scores))
+	}
+	
+	// Check explained variance adds up
+	totalExplained := 0.0
+	for _, v := range result.ExplainedVarRatio {
+		totalExplained += v
+	}
+	
+	if math.Abs(totalExplained-100.0) > 0.1 {
+		t.Errorf("Explained variance ratios should sum to 100%%, got %.2f%%", totalExplained)
+	}
+}
+
+func TestKernelPCA_TransformBeforeFit(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := types.Matrix{{1.0, 2.0}}
+	
+	_, err := engine.Transform(data)
+	if err == nil {
+		t.Error("Expected error when transforming before fit")
+	}
+}
+
+func TestKernelPCA_EmptyData(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	
+	config := types.PCAConfig{
+		Components: 2,
+		Method:     "kernel",
+		KernelType: "linear",
+	}
+	
+	// Empty matrix
+	_, err := engine.Fit(types.Matrix{}, config)
+	if err == nil {
+		t.Error("Expected error for empty data")
+	}
+	
+	// Matrix with empty rows
+	_, err = engine.Fit(types.Matrix{{}}, config)
+	if err == nil {
+		t.Error("Expected error for empty data")
+	}
+}
+
+func TestKernelPCA_MoreComponentsThanSamples(t *testing.T) {
+	engine := NewKernelPCAEngine()
+	data := types.Matrix{
+		{1.0, 2.0},
+		{3.0, 4.0},
+	}
+	
+	config := types.PCAConfig{
+		Components: 5, // More than samples
+		Method:     "kernel",
+		KernelType: "linear",
+	}
+	
+	_, err := engine.Fit(data, config)
+	if err == nil {
+		t.Error("Expected error when components exceed samples")
+	}
+}
+
+func TestNewPCAEngineForMethod(t *testing.T) {
+	tests := []struct {
+		method       string
+		expectKernel bool
+	}{
+		{"kernel", true},
+		{"svd", false},
+		{"nipals", false},
+		{"", false},
+		{"unknown", false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			engine := NewPCAEngineForMethod(tt.method)
+			
+			// Try to fit with kernel-specific config
+			config := types.PCAConfig{
+				Components: 2,
+				Method:     "kernel",
+				KernelType: "rbf",
+				KernelGamma: 1.0,
+			}
+			
+			data := generateLinearData()
+			_, err := engine.Fit(data, config)
+			
+			if tt.expectKernel {
+				// Should work for kernel engine
+				if err != nil && err.Error() == "kernel type must be specified for kernel PCA" {
+					t.Error("Kernel PCA engine should accept kernel configuration")
+				}
+			} else {
+				// Regular PCA should work but ignore kernel params
+				if err != nil {
+					// Regular PCA might fail for other reasons, but not because of kernel params
+					t.Logf("Regular PCA error (expected): %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/types/pca.go
+++ b/pkg/types/pca.go
@@ -5,22 +5,31 @@ type Matrix [][]float64
 
 // PCAConfig holds configuration for PCA analysis
 type PCAConfig struct {
-	Components      int    `json:"components"`
-	MeanCenter      bool   `json:"mean_center"`
-	StandardScale   bool   `json:"standard_scale"`
-	Method          string `json:"method"` // "svd" or "eigen"
-	ExcludedRows    []int  `json:"excluded_rows,omitempty"`    // 0-based indices of rows to exclude
-	ExcludedColumns []int  `json:"excluded_columns,omitempty"` // 0-based indices of columns to exclude
+	Components      int     `json:"components"`
+	MeanCenter      bool    `json:"mean_center"`
+	StandardScale   bool    `json:"standard_scale"`
+	Method          string  `json:"method"` // "svd", "eigen", "nipals", or "kernel"
+	ExcludedRows    []int   `json:"excluded_rows,omitempty"`    // 0-based indices of rows to exclude
+	ExcludedColumns []int   `json:"excluded_columns,omitempty"` // 0-based indices of columns to exclude
+	// Kernel PCA specific parameters
+	KernelType   string  `json:"kernel_type,omitempty"`   // "rbf", "linear", "poly"
+	KernelGamma  float64 `json:"kernel_gamma,omitempty"`  // RBF/Poly parameter
+	KernelDegree int     `json:"kernel_degree,omitempty"` // Poly parameter
+	KernelCoef0  float64 `json:"kernel_coef0,omitempty"`  // Poly parameter
 }
 
 // PCAResult contains the results of PCA analysis
 type PCAResult struct {
-	Scores          Matrix    `json:"scores"`
-	Loadings        Matrix    `json:"loadings"`
-	ExplainedVar    []float64 `json:"explained_variance"`
-	CumulativeVar   []float64 `json:"cumulative_variance"`
-	ComponentLabels []string  `json:"component_labels"`
-	VariableLabels  []string  `json:"variable_labels,omitempty"` // Original variable names
+	Scores               Matrix    `json:"scores"`
+	Loadings             Matrix    `json:"loadings"`
+	ExplainedVar         []float64 `json:"explained_variance"`
+	ExplainedVarRatio    []float64 `json:"explained_variance_ratio"` // Percentage of variance explained
+	CumulativeVar        []float64 `json:"cumulative_variance"`
+	ComponentLabels      []string  `json:"component_labels"`
+	VariableLabels       []string  `json:"variable_labels,omitempty"` // Original variable names
+	ComponentsComputed   int       `json:"components_computed"`       // Number of components actually computed
+	Method               string    `json:"method"`                    // Method used (svd, nipals, kernel)
+	PreprocessingApplied bool      `json:"preprocessing_applied"`     // Whether preprocessing was applied
 	// Preprocessing statistics
 	Means   []float64 `json:"means,omitempty"`   // Original feature means
 	StdDevs []float64 `json:"stddevs,omitempty"` // Original feature std devs


### PR DESCRIPTION
## Summary
- Implements Kernel PCA with RBF, Linear, and Polynomial kernels
- Extends both CLI and GUI to support kernel PCA configuration
- Adds comprehensive tests and documentation

## Implementation Details

### Core Implementation
- Created `KernelPCAImpl` that implements the `PCAEngine` interface
- Supports three kernel types: RBF (Gaussian), Linear, and Polynomial
- Uses eigendecomposition of centered kernel matrix
- Proper error handling and parameter validation
- Transform method for projecting new data

### CLI Updates
- Added `--method kernel` option
- New flags: `--kernel-type`, `--kernel-gamma`, `--kernel-degree`, `--kernel-coef0`
- Automatic preprocessing skip for kernel PCA
- Updated help with kernel PCA examples

### GUI Updates
- Added "Kernel PCA" to method dropdown
- Dynamic kernel parameter UI that shows/hides based on kernel type
- Graceful handling of missing loadings in visualizations
- Informative messages for unsupported plot types

### Type System
- Extended `PCAConfig` with kernel parameters
- Added missing fields to `PCAResult` for better compatibility
- Updated both Go and TypeScript type definitions

## Test Plan
- [x] Unit tests for kernel PCA implementation (all passing)
- [x] CLI tests with iris dataset (RBF, Linear, Polynomial kernels)
- [x] All existing tests pass
- [x] Linting passes with no issues
- [ ] GUI manual testing with kernel PCA
- [ ] Performance benchmarking on larger datasets

## Performance Considerations
- Kernel PCA has O(n²) memory and O(n³) time complexity
- Suitable for datasets up to ~10,000 samples
- Future optimization opportunities noted in code

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)