### PR TITLE
Fix: Rename PCA button to 'Go PCA\!' and add smooth scroll to results

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import './App.css';
 import { ParseCSV, RunPCA, LoadIrisDataset } from "../wailsjs/go/main/App";
 import { DataTable, ThemeToggle } from './components';
@@ -22,6 +22,10 @@ function App() {
     const [selectedYComponent, setSelectedYComponent] = useState(1);
     const [selectedLoadingComponent, setSelectedLoadingComponent] = useState(0);
     const [selectedGroupColumn, setSelectedGroupColumn] = useState<string | null>(null);
+    
+    // Refs for smooth scrolling
+    const pcaErrorRef = useRef<HTMLDivElement>(null);
+    const pcaResultsRef = useRef<HTMLDivElement>(null);
     
     // PCA configuration
     const [config, setConfig] = useState({
@@ -104,9 +108,23 @@ function App() {
                 setSelectedYComponent(1);
                 // Clear any previous errors
                 setPcaError(null);
+                // Smooth scroll to results
+                setTimeout(() => {
+                    pcaResultsRef.current?.scrollIntoView({ 
+                        behavior: 'smooth', 
+                        block: 'start' 
+                    });
+                }, 100);
             } else {
                 setPcaError(result.error || 'PCA analysis failed');
                 setPcaResponse(null);
+                // Smooth scroll to error
+                setTimeout(() => {
+                    pcaErrorRef.current?.scrollIntoView({ 
+                        behavior: 'smooth', 
+                        block: 'start' 
+                    });
+                }, 100);
             }
         } catch (err) {
             setPcaError(`Failed to run PCA: ${err}`);
@@ -355,21 +373,21 @@ function App() {
                                 disabled={loading}
                                 className="mt-4 px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 dark:disabled:bg-gray-600 rounded-lg font-medium text-white"
                             >
-                                {loading ? 'Running...' : 'Run PCA Analysis'}
+                                {loading ? 'Running...' : 'Go PCA!'}
                             </button>
                         </div>
                     )}
                     
                     {/* PCA Error Display - shown between Step 2 and Results */}
                     {pcaError && fileData && (
-                        <div className="bg-red-100 dark:bg-red-800 border border-red-300 dark:border-red-600 rounded-lg p-4">
+                        <div ref={pcaErrorRef} className="bg-red-100 dark:bg-red-800 border border-red-300 dark:border-red-600 rounded-lg p-4">
                             <p className="text-red-700 dark:text-red-200">{pcaError}</p>
                         </div>
                     )}
                     
                     {/* PCA Results */}
                     {pcaResponse?.success && pcaResponse.result && (
-                        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg border border-gray-200 dark:border-gray-700">
+                        <div ref={pcaResultsRef} className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg border border-gray-200 dark:border-gray-700">
                             <h2 className="text-xl font-semibold mb-4">PCA Results</h2>
                             
                             {/* Info message about missing data handling */}


### PR DESCRIPTION
Closes #39

## Summary
- Renamed the "Run PCA Analysis" button to "Go PCA\!" to match the application branding
- Implemented smooth scrolling that automatically navigates users to results or errors after PCA execution
- Added React refs to enable targeted scrolling to specific sections

## Changes
1. **Button Text Update**: Changed button label from "Run PCA Analysis" to "Go PCA\!"
2. **Smooth Scrolling Implementation**:
   - Added `useRef` import and created `pcaErrorRef` and `pcaResultsRef`
   - Attached refs to error and results div elements
   - Updated `runPCA` function to trigger smooth scroll after state updates
   - Used `scrollIntoView` with smooth behavior and 'start' block positioning
   - Added 100ms timeout to ensure DOM updates before scrolling

## Benefits
- **Better Branding**: "Go PCA\!" is more engaging and matches the app name
- **Improved UX**: Users are automatically guided to the relevant content
- **Accessibility**: Reduces the need for manual scrolling, especially helpful on smaller screens
- **Professional Feel**: Smooth animations enhance the perceived quality of the application

## Testing
- ✅ Button text displays correctly as "Go PCA\!"
- ✅ Smooth scrolling works when PCA analysis succeeds (scrolls to results)
- ✅ Smooth scrolling works when PCA analysis fails (scrolls to error message)
- ✅ All existing tests pass
- ✅ GUI builds successfully

## Screenshots
The implementation follows the exact specifications from the issue, enhancing the user experience by automatically guiding attention to results or errors after PCA execution.