### PR TITLE
Fix: Fullscreen mode respects user-selected theme

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -317,7 +317,7 @@ export const Biplot: React.FC<BiplotProps> = ({
   };
 
   return (
-    <div ref={fullscreenRef} className={`w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-gray-900 p-4' : ''}`}>
+    <div ref={fullscreenRef} className={`w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-white dark:bg-gray-900 p-4' : ''}`}>
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-4">
           <h4 className="text-md font-medium text-gray-700 dark:text-gray-300">

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
@@ -146,7 +146,7 @@ export const ScoresPlot: React.FC<ScoresPlotProps> = ({
   }
 
   return (
-    <div ref={fullscreenRef} className={`w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-gray-900 p-4' : ''}`}>
+    <div ref={fullscreenRef} className={`w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-white dark:bg-gray-900 p-4' : ''}`}>
       <div className="flex justify-between items-center mb-2">
         <div className="flex items-center gap-4">
           {/* Group legend */}


### PR DESCRIPTION
## Summary
- Fixed fullscreen mode to respect the user's selected theme (light/dark)
- Updated ScoresPlot and Biplot components to match DiagnosticScatterPlot

## Changes
- Changed hardcoded `bg-gray-900` to theme-aware `bg-white dark:bg-gray-900`
- Now all three visualization components (ScoresPlot, Biplot, DiagnosticScatterPlot) have consistent theme handling

## Test Plan
- [x] Run `go test ./...` - all tests pass
- [x] Build frontend with `npm run build` - builds successfully with no TypeScript errors
- [ ] Manual testing:
  - Load the GoPCA desktop application
  - Switch between light and dark themes
  - Enter fullscreen mode in each visualization component
  - Verify that fullscreen background matches the selected theme

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)