### PR TITLE
Fix #59: Adjust Step 1 Load Data card to 40-40-20 column widths

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -151,7 +151,7 @@ function App() {
                     {/* File Upload Section */}
                     <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg border border-gray-200 dark:border-gray-700">
                         <h2 className="text-xl font-semibold mb-6">Step 1: Load Data</h2>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[2fr_2fr_1fr] gap-6">
                             {/* Column 1: File Upload */}
                             <div className="flex flex-col justify-center">
                                 <label className="block text-sm font-medium mb-3">
@@ -206,7 +206,7 @@ function App() {
                                         className="w-full px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
                                         disabled={loading}
                                     >
-                                        Corn (NIR spectroscopy of corn)
+                                        Corn (NIR)
                                     </button>
                                     <button
                                         onClick={async () => {
@@ -229,7 +229,7 @@ function App() {
                                         className="w-full px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
                                         disabled={loading}
                                     >
-                                        Iris (classic dataset with species)
+                                        Iris
                                     </button>
                                     <button
                                         onClick={async () => {
@@ -252,7 +252,7 @@ function App() {
                                         className="w-full px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
                                         disabled={loading}
                                     >
-                                        Wine (classic dataset with class)
+                                        Wine
                                     </button>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
Adjusts the three-column layout of the "Step 1: Load Data" card to have 40%, 40%, 20% column widths and shortens the sample dataset button text for better visual balance.

## Changes
- Updated grid layout from `grid-cols-3` to `grid-cols-[2fr_2fr_1fr]` for 40-40-20 ratio
- Shortened button text:
  - "Corn (NIR spectroscopy of corn)" → "Corn (NIR)"
  - "Iris (classic dataset with species)" → "Iris"  
  - "Wine (classic dataset with class)" → "Wine"
- Maintained responsive behavior (single column on mobile, 2 columns on tablet, 3 columns on desktop)

## Testing
- [x] TypeScript compiles without errors
- [x] Layout displays correctly with new column widths
- [x] Button text is shortened as requested
- [x] Responsive behavior still works properly

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)