### PR TITLE
Fix: Add scroll-to-top functionality when clicking logo

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
     // Refs for smooth scrolling
     const pcaErrorRef = useRef<HTMLDivElement>(null);
     const pcaResultsRef = useRef<HTMLDivElement>(null);
+    const mainScrollRef = useRef<HTMLDivElement>(null);
     
     // PCA configuration
     const [config, setConfig] = useState({
@@ -87,6 +88,15 @@ function App() {
         }
     }, [fileData]);
     
+    const scrollToTop = () => {
+        if (mainScrollRef.current) {
+            mainScrollRef.current.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        }
+    };
+
     const runPCA = async () => {
         if (!fileData) return;
         
@@ -141,12 +151,17 @@ function App() {
             <div className="flex flex-col h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-200">
                 <header className="sticky top-0 z-50 bg-white dark:bg-gray-800 p-4 shadow-lg backdrop-blur-sm bg-opacity-95 dark:bg-opacity-95">
                     <div className="flex items-center justify-between max-w-7xl mx-auto">
-                        <img src={logo} alt="GoPCA - Principal Component Analysis Tool" className="h-12" />
+                        <img 
+                            src={logo} 
+                            alt="GoPCA - Principal Component Analysis Tool" 
+                            className="h-12 cursor-pointer hover:opacity-90 transition-opacity"
+                            onClick={scrollToTop}
+                        />
                         <ThemeToggle />
                     </div>
                 </header>
             
-            <main className="flex-1 overflow-auto p-6">
+            <main ref={mainScrollRef} className="flex-1 overflow-auto p-6">
                 <div className="max-w-7xl mx-auto space-y-6">
                     {/* File Upload Section */}
                     <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg border border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
This PR adds click-to-scroll functionality to the GoPCA logo in the desktop GUI header. When users click the logo, the page smoothly scrolls to the top.

## Changes
- Added `mainScrollRef` to reference the scrollable main container
- Implemented `scrollToTop` function that smoothly scrolls the main element to top
- Made logo clickable with cursor-pointer styling and hover effect (opacity transition)
- Targets the correct scroll container (main element with overflow-auto, not window)

## Testing
1. Load the GUI with a dataset (e.g., iris dataset)
2. Run PCA to generate results
3. Scroll down to view results, visualizations, or scores matrix
4. Click the GoPCA logo in the header
5. Page should smoothly scroll back to the top

## Benefits
- Improves navigation, especially on longer pages with multiple visualizations
- Follows common web UX patterns that users expect
- Provides quick access to return to the top without manual scrolling
- Visual feedback through cursor change and hover effect

Closes #63