### PR TITLE
Add confidence ellipses to PCA visualizations

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ConfidenceEllipses.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ConfidenceEllipses.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+
+interface EllipseParams {
+  centerX: number;
+  centerY: number;
+  majorAxis: number;
+  minorAxis: number;
+  angle: number;
+  confidenceLevel: number;
+}
+
+interface ConfidenceEllipsesProps {
+  ellipses: Record<string, EllipseParams>;
+  colorMap: Map<string, string>;
+  xDomain: [number, number];
+  yDomain: [number, number];
+  // These are injected by Recharts Customized component
+  xAxisMap?: any;
+  yAxisMap?: any;
+  width?: number;
+  height?: number;
+  offset?: { top: number; right: number; bottom: number; left: number };
+}
+
+export const ConfidenceEllipses: React.FC<ConfidenceEllipsesProps> = (props) => {
+  const { 
+    ellipses, 
+    colorMap,
+    xDomain,
+    yDomain,
+    xAxisMap,
+    yAxisMap,
+    width = 0,
+    height = 0,
+    offset = { top: 20, right: 20, bottom: 60, left: 80 }
+  } = props;
+  
+  // If Recharts doesn't provide the necessary props, return null
+  if (!xAxisMap || !yAxisMap || !width || !height) {
+    console.log('ConfidenceEllipses: Missing required Recharts props', { xAxisMap, yAxisMap, width, height });
+    return null;
+  }
+  
+  // Get the first axis from the map (there's usually only one)
+  const xAxis = xAxisMap && Object.values(xAxisMap)[0] as any;
+  const yAxis = yAxisMap && Object.values(yAxisMap)[0] as any;
+  
+  if (!xAxis || !yAxis) {
+    console.log('ConfidenceEllipses: No axis found in map');
+    return null;
+  }
+  
+  // Use the axis scale functions if available
+  const xScale = xAxis.scale || ((value: number) => {
+    const plotWidth = width - offset.left - offset.right;
+    const xRange = xDomain[1] - xDomain[0];
+    const xRatio = (value - xDomain[0]) / xRange;
+    return offset.left + xRatio * plotWidth;
+  });
+  
+  const yScale = yAxis.scale || ((value: number) => {
+    const plotHeight = height - offset.top - offset.bottom;
+    const yRange = yDomain[1] - yDomain[0];
+    const yRatio = (value - yDomain[0]) / yRange;
+    // Y axis is inverted in SVG
+    return offset.top + plotHeight - yRatio * plotHeight;
+  });
+
+  if (!ellipses || Object.keys(ellipses).length === 0) {
+    return null;
+  }
+
+  // Convert ellipse parameters to SVG path
+  const ellipseToPath = (ellipse: EllipseParams, group: string): string => {
+    const { centerX, centerY, majorAxis, minorAxis, angle } = ellipse;
+    
+    // Convert data coordinates to pixel coordinates
+    const cx = xScale(centerX);
+    const cy = yScale(centerY);
+    
+    // Scale the axes - need to account for the scale transformation
+    // Calculate the scale factor from data units to pixels
+    const xScaleFactor = Math.abs(xScale(1) - xScale(0));
+    const yScaleFactor = Math.abs(yScale(0) - yScale(1)); // Y is inverted
+    
+    const rx = majorAxis * xScaleFactor;
+    const ry = minorAxis * yScaleFactor;
+    
+    // Convert angle from radians to degrees
+    const angleDegrees = (angle * 180) / Math.PI;
+    
+    // Create SVG path for rotated ellipse
+    // Using parametric equations for an ellipse
+    const steps = 50;
+    const points: [number, number][] = [];
+    
+    for (let i = 0; i <= steps; i++) {
+      const t = (i / steps) * 2 * Math.PI;
+      // Ellipse in local coordinates
+      const x = rx * Math.cos(t);
+      const y = ry * Math.sin(t);
+      
+      // Apply rotation
+      const rotatedX = x * Math.cos(angle) - y * Math.sin(angle);
+      const rotatedY = x * Math.sin(angle) + y * Math.cos(angle);
+      
+      // Translate to center
+      points.push([cx + rotatedX, cy + rotatedY]);
+    }
+    
+    // Create path string
+    const pathData = points
+      .map((point, index) => (index === 0 ? `M ${point[0]} ${point[1]}` : `L ${point[0]} ${point[1]}`))
+      .join(' ') + ' Z';
+    
+    return pathData;
+  };
+
+  return (
+    <g className="confidence-ellipses">
+      {Object.entries(ellipses).map(([group, ellipse]) => {
+        const color = colorMap.get(group) || '#888888';
+        const path = ellipseToPath(ellipse, group);
+        
+        return (
+          <g key={`ellipse-${group}`}>
+            <path
+              d={path}
+              fill={color}
+              fillOpacity={0.1}
+              stroke={color}
+              strokeWidth={2}
+              strokeOpacity={0.8}
+              strokeDasharray="5,5"
+            />
+          </g>
+        );
+      })}
+    </g>
+  );
+};

--- a/cmd/gopca-desktop/frontend/src/types/index.ts
+++ b/cmd/gopca-desktop/frontend/src/types/index.ts
@@ -29,6 +29,9 @@ export interface PCARequest {
   kernelGamma?: number;
   kernelDegree?: number;
   kernelCoef0?: number;
+  // Grouping parameters for confidence ellipses
+  groupColumn?: string;
+  groupLabels?: string[];
 }
 
 export interface SampleMetrics {
@@ -70,9 +73,21 @@ export interface PCAMetrics {
   };
 }
 
+export interface EllipseParams {
+  centerX: number;
+  centerY: number;
+  majorAxis: number;
+  minorAxis: number;
+  angle: number;
+  confidenceLevel: number;
+}
+
 export interface PCAResponse {
   success: boolean;
   error?: string;
   result?: PCAResult;
   info?: string;
+  groupEllipses90?: Record<string, EllipseParams>;
+  groupEllipses95?: Record<string, EllipseParams>;
+  groupEllipses99?: Record<string, EllipseParams>;
 }

--- a/internal/core/statistics.go
+++ b/internal/core/statistics.go
@@ -1,0 +1,166 @@
+package core
+
+import (
+	"fmt"
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat"
+)
+
+// CalculateConfidenceEllipse computes the parameters for a confidence ellipse
+// for a 2D set of points at the specified confidence level.
+// Returns center coordinates, semi-major/minor axes, and rotation angle.
+//
+// Reference: Johnson & Wichern (2007) Applied Multivariate Statistical Analysis
+func CalculateConfidenceEllipse(x, y []float64, confidenceLevel float64) (centerX, centerY, majorAxis, minorAxis, angle float64, err error) {
+	if len(x) != len(y) {
+		return 0, 0, 0, 0, 0, fmt.Errorf("x and y must have the same length")
+	}
+
+	n := len(x)
+	if n < 3 {
+		return 0, 0, 0, 0, 0, fmt.Errorf("need at least 3 points to calculate confidence ellipse")
+	}
+
+	// Calculate means (center of ellipse)
+	centerX = stat.Mean(x, nil)
+	centerY = stat.Mean(y, nil)
+
+	// Build covariance matrix
+	cov := mat.NewSymDense(2, nil)
+	cov.SetSym(0, 0, stat.Variance(x, nil))
+	cov.SetSym(1, 1, stat.Variance(y, nil))
+	cov.SetSym(0, 1, stat.Covariance(x, y, nil))
+
+	// Calculate eigenvalues and eigenvectors
+	var eig mat.EigenSym
+	ok := eig.Factorize(cov, true)
+	if !ok {
+		return 0, 0, 0, 0, 0, fmt.Errorf("failed to compute eigenvalues")
+	}
+
+	values := eig.Values(nil)
+	vectors := mat.NewDense(2, 2, nil)
+	eig.VectorsTo(vectors)
+
+	// Ensure eigenvalues are positive
+	if values[0] <= 0 || values[1] <= 0 {
+		return 0, 0, 0, 0, 0, fmt.Errorf("covariance matrix is not positive definite")
+	}
+
+	// Sort eigenvalues (largest first)
+	if values[0] < values[1] {
+		values[0], values[1] = values[1], values[0]
+		// Swap eigenvector columns
+		v1 := mat.Col(nil, 0, vectors)
+		v2 := mat.Col(nil, 1, vectors)
+		vectors.SetCol(0, v2)
+		vectors.SetCol(1, v1)
+	}
+
+	// Calculate chi-square value for the confidence level
+	// For 2D data, degrees of freedom = 2
+	chiSquare := chiSquareValue(confidenceLevel, 2)
+
+	// Calculate semi-axes lengths
+	majorAxis = math.Sqrt(chiSquare * values[0])
+	minorAxis = math.Sqrt(chiSquare * values[1])
+
+	// Calculate rotation angle from the first eigenvector
+	angle = math.Atan2(vectors.At(1, 0), vectors.At(0, 0))
+
+	return centerX, centerY, majorAxis, minorAxis, angle, nil
+}
+
+// chiSquareValue returns the chi-square value for a given confidence level and degrees of freedom.
+// This is a simplified approximation for common confidence levels.
+func chiSquareValue(confidenceLevel float64, df int) float64 {
+	if df != 2 {
+		// For now, we only support 2D ellipses
+		return 5.991 // 95% confidence for df=2
+	}
+
+	// Chi-square values for df=2
+	switch confidenceLevel {
+	case 0.90:
+		return 4.605
+	case 0.95:
+		return 5.991
+	case 0.99:
+		return 9.210
+	default:
+		// Default to 95% confidence
+		return 5.991
+	}
+}
+
+// CalculateGroupEllipses computes confidence ellipse parameters for each group in the data.
+// scores is a 2D matrix where each row is an observation, columns are PC scores.
+// groups is a slice indicating the group membership of each observation.
+// pcX and pcY are the indices of the principal components to use (0-based).
+func CalculateGroupEllipses(scores mat.Matrix, groups []string, pcX, pcY int, confidenceLevel float64) (map[string]EllipseParams, error) {
+	rows, cols := scores.Dims()
+	if pcX >= cols || pcY >= cols {
+		return nil, fmt.Errorf("PC indices out of bounds")
+	}
+
+	// Group the data
+	groupData := make(map[string]struct {
+		x []float64
+		y []float64
+	})
+
+	for i := 0; i < rows; i++ {
+		group := groups[i]
+		if _, exists := groupData[group]; !exists {
+			groupData[group] = struct {
+				x []float64
+				y []float64
+			}{
+				x: make([]float64, 0),
+				y: make([]float64, 0),
+			}
+		}
+		data := groupData[group]
+		data.x = append(data.x, scores.At(i, pcX))
+		data.y = append(data.y, scores.At(i, pcY))
+		groupData[group] = data
+	}
+
+	// Calculate ellipse for each group
+	ellipses := make(map[string]EllipseParams)
+	for group, data := range groupData {
+		if len(data.x) < 3 {
+			// Skip groups with too few points
+			continue
+		}
+
+		centerX, centerY, majorAxis, minorAxis, angle, err := CalculateConfidenceEllipse(data.x, data.y, confidenceLevel)
+		if err != nil {
+			// Skip this group if ellipse calculation fails
+			continue
+		}
+
+		ellipses[group] = EllipseParams{
+			CenterX:         centerX,
+			CenterY:         centerY,
+			MajorAxis:       majorAxis,
+			MinorAxis:       minorAxis,
+			Angle:           angle,
+			ConfidenceLevel: confidenceLevel,
+		}
+	}
+
+	return ellipses, nil
+}
+
+// EllipseParams contains parameters for drawing a confidence ellipse
+type EllipseParams struct {
+	CenterX         float64
+	CenterY         float64
+	MajorAxis       float64
+	MinorAxis       float64
+	Angle           float64 // in radians
+	ConfidenceLevel float64
+}

--- a/internal/core/statistics_test.go
+++ b/internal/core/statistics_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestCalculateConfidenceEllipse(t *testing.T) {
+	tests := []struct {
+		name            string
+		x               []float64
+		y               []float64
+		confidenceLevel float64
+		wantErr         bool
+	}{
+		{
+			name:            "valid circular data",
+			x:               []float64{0, 1, 0, -1, 0.5, -0.5, 0.5, -0.5},
+			y:               []float64{1, 0, -1, 0, 0.5, 0.5, -0.5, -0.5},
+			confidenceLevel: 0.95,
+			wantErr:         false,
+		},
+		{
+			name:            "valid elliptical data",
+			x:               []float64{0, 2, 0, -2, 1, -1, 1, -1},
+			y:               []float64{0.5, 0, -0.5, 0, 0.25, 0.25, -0.25, -0.25},
+			confidenceLevel: 0.95,
+			wantErr:         false,
+		},
+		{
+			name:            "too few points",
+			x:               []float64{0, 1},
+			y:               []float64{0, 1},
+			confidenceLevel: 0.95,
+			wantErr:         true,
+		},
+		{
+			name:            "mismatched lengths",
+			x:               []float64{0, 1, 2},
+			y:               []float64{0, 1},
+			confidenceLevel: 0.95,
+			wantErr:         true,
+		},
+		{
+			name:            "90% confidence",
+			x:               []float64{0, 1, 0, -1, 0.5, -0.5, 0.5, -0.5},
+			y:               []float64{1, 0, -1, 0, 0.5, 0.5, -0.5, -0.5},
+			confidenceLevel: 0.90,
+			wantErr:         false,
+		},
+		{
+			name:            "99% confidence",
+			x:               []float64{0, 1, 0, -1, 0.5, -0.5, 0.5, -0.5},
+			y:               []float64{1, 0, -1, 0, 0.5, 0.5, -0.5, -0.5},
+			confidenceLevel: 0.99,
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			centerX, centerY, majorAxis, minorAxis, angle, err := CalculateConfidenceEllipse(tt.x, tt.y, tt.confidenceLevel)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CalculateConfidenceEllipse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Check that center is approximately at the mean
+				meanX := mean(tt.x)
+				meanY := mean(tt.y)
+				if math.Abs(centerX-meanX) > 1e-10 || math.Abs(centerY-meanY) > 1e-10 {
+					t.Errorf("Center mismatch: got (%f, %f), want (%f, %f)", centerX, centerY, meanX, meanY)
+				}
+
+				// Check that axes are positive
+				if majorAxis <= 0 || minorAxis <= 0 {
+					t.Errorf("Invalid axes: majorAxis=%f, minorAxis=%f", majorAxis, minorAxis)
+				}
+
+				// Check that major axis is larger than minor axis
+				if majorAxis < minorAxis {
+					t.Errorf("Major axis should be larger than minor axis: majorAxis=%f, minorAxis=%f", majorAxis, minorAxis)
+				}
+
+				// Check that angle is in valid range
+				if angle < -math.Pi || angle > math.Pi {
+					t.Errorf("Invalid angle: %f", angle)
+				}
+			}
+		})
+	}
+}
+
+func TestCalculateGroupEllipses(t *testing.T) {
+	// Create test data with two groups
+	scores := mat.NewDense(10, 2, []float64{
+		// Group A - centered around (1, 1)
+		1.2, 1.1,
+		0.9, 1.3,
+		1.1, 0.8,
+		0.8, 1.2,
+		1.0, 1.0,
+		// Group B - centered around (-1, -1)
+		-1.1, -0.9,
+		-0.8, -1.2,
+		-1.2, -1.1,
+		-0.9, -0.8,
+		-1.0, -1.0,
+	})
+
+	groups := []string{"A", "A", "A", "A", "A", "B", "B", "B", "B", "B"}
+
+	ellipses, err := CalculateGroupEllipses(scores, groups, 0, 1, 0.95)
+	if err != nil {
+		t.Fatalf("CalculateGroupEllipses() error = %v", err)
+	}
+
+	// Check that we got ellipses for both groups
+	if len(ellipses) != 2 {
+		t.Errorf("Expected 2 ellipses, got %d", len(ellipses))
+	}
+
+	// Check group A ellipse
+	if ellipseA, ok := ellipses["A"]; ok {
+		if math.Abs(ellipseA.CenterX-1.0) > 0.2 || math.Abs(ellipseA.CenterY-1.0) > 0.2 {
+			t.Errorf("Group A center mismatch: got (%f, %f), expected near (1, 1)", ellipseA.CenterX, ellipseA.CenterY)
+		}
+		if ellipseA.MajorAxis <= 0 || ellipseA.MinorAxis <= 0 {
+			t.Errorf("Group A invalid axes: majorAxis=%f, minorAxis=%f", ellipseA.MajorAxis, ellipseA.MinorAxis)
+		}
+	} else {
+		t.Error("Missing ellipse for group A")
+	}
+
+	// Check group B ellipse
+	if ellipseB, ok := ellipses["B"]; ok {
+		if math.Abs(ellipseB.CenterX+1.0) > 0.2 || math.Abs(ellipseB.CenterY+1.0) > 0.2 {
+			t.Errorf("Group B center mismatch: got (%f, %f), expected near (-1, -1)", ellipseB.CenterX, ellipseB.CenterY)
+		}
+		if ellipseB.MajorAxis <= 0 || ellipseB.MinorAxis <= 0 {
+			t.Errorf("Group B invalid axes: majorAxis=%f, minorAxis=%f", ellipseB.MajorAxis, ellipseB.MinorAxis)
+		}
+	} else {
+		t.Error("Missing ellipse for group B")
+	}
+}
+
+func TestCalculateGroupEllipsesEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		scores mat.Matrix
+		groups []string
+		pcX    int
+		pcY    int
+	}{
+		{
+			name: "group with too few points",
+			scores: mat.NewDense(5, 2, []float64{
+				1.0, 1.1,
+				1.2, 0.9,
+				3.0, 3.0, // Group B has only 1 point
+				0.8, 1.3,
+				1.1, 1.0,
+			}),
+			groups: []string{"A", "A", "B", "A", "A"},
+			pcX:    0,
+			pcY:    1,
+		},
+		{
+			name: "PC indices out of bounds",
+			scores: mat.NewDense(3, 2, []float64{
+				1, 1,
+				2, 2,
+				3, 3,
+			}),
+			groups: []string{"A", "A", "A"},
+			pcX:    2, // Out of bounds
+			pcY:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ellipses, err := CalculateGroupEllipses(tt.scores, tt.groups, tt.pcX, tt.pcY, 0.95)
+
+			if tt.name == "PC indices out of bounds" {
+				if err == nil {
+					t.Error("Expected error for out of bounds PC indices")
+				}
+			} else if tt.name == "group with too few points" {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				// Should only have ellipse for group A
+				if len(ellipses) != 1 {
+					t.Errorf("Expected 1 ellipse, got %d", len(ellipses))
+				}
+				if _, ok := ellipses["A"]; !ok {
+					t.Error("Missing ellipse for group A")
+				}
+				if _, ok := ellipses["B"]; ok {
+					t.Error("Should not have ellipse for group B (too few points)")
+				}
+			}
+		})
+	}
+}
+
+// Helper function for testing
+func mean(x []float64) float64 {
+	sum := 0.0
+	for _, v := range x {
+		sum += v
+	}
+	return sum / float64(len(x))
+}


### PR DESCRIPTION
## Summary
This PR implements confidence ellipses for PCA visualizations, allowing users to see statistical confidence regions for grouped data in scores plots.

Closes #24

## Features
- ✅ Confidence ellipses for grouped data at 90%, 95%, and 99% levels
- ✅ Instant toggling without re-running PCA 
- ✅ Real-time confidence level switching
- ✅ Proper handling of zoom/pan and window resizing
- ✅ Robust edge case handling

## Implementation Details

### Backend
- Added `statistics.go` with functions to calculate confidence ellipse parameters
- Calculates ellipses using covariance matrix and chi-square distribution
- Pre-calculates all three confidence levels during PCA analysis
- Returns `groupEllipses90`, `groupEllipses95`, and `groupEllipses99` in response

### Frontend  
- New `ConfidenceEllipses.tsx` component (initially attempted but not used)
- SVG overlay approach in `ScoresPlot.tsx` for rendering ellipses
- Manual coordinate transformation from data space to pixel space
- ResizeObserver for responsive updates

### User Experience
- Toggle ellipses on/off instantly via checkbox
- Switch confidence levels without re-running analysis
- Visual feedback with semi-transparent fills and dashed borders
- Colors match group colors for consistency

## Testing
Tested with:
- Iris dataset (3 groups)
- Various confidence levels
- Zoom/pan interactions
- Window resizing
- Edge cases (groups with <3 points)

## Screenshots
Confidence ellipses are shown as dashed outlines with semi-transparent fills around each group of points in the PCA scores plot.

🤖 Generated with [Claude Code](https://claude.ai/code)