### PR TITLE
ci: update workflow to run tests on all branches, build only on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '**' ]  # Run tests on all branches
   pull_request:
     branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
@@ -96,6 +96,7 @@ jobs:
   build-cli:
     name: Build CLI
     needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     
     steps:
@@ -133,6 +134,7 @@ jobs:
   build-desktop:
     name: Build Desktop App
     needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     strategy:
       fail-fast: false  # Continue building other platforms even if one fails
       matrix:


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow to optimize CI/CD resource usage:
- Tests now run on all branch pushes for immediate developer feedback
- Build jobs only execute when merging to main branch

## Changes
- Modified push trigger from `branches: [ main ]` to `branches: [ '**' ]` to run tests on all branches
- Added `if: github.ref == 'refs/heads/main' && github.event_name == 'push'` conditions to both build jobs
- Pull request tests remain unchanged (still trigger on PRs to main)

## Benefits
- Developers get immediate test feedback on feature branches
- Reduced CI resource usage - builds only happen when needed
- Faster development cycle - no unnecessary builds on feature branches

## Testing
- The workflow changes are syntactically correct
- Tests will now run on this PR branch push
- Build jobs will be skipped (as intended) since this isn't the main branch

Closes #76