### PR TITLE
feat: remove Scores Matrix card from GUI

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -864,16 +864,6 @@ function AppContent() {
                                 </div>
                             </div>
                             
-                            {/* Scores Matrix */}
-                            <div className="mt-6">
-                                <DataTable
-                                    headers={pcaResponse.result.component_labels || []}
-                                    rowNames={fileData?.rowNames || []}
-                                    data={pcaResponse.result.scores}
-                                    title="Scores Matrix"
-                                />
-                            </div>
-                            
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
This PR removes the raw numerical Scores Matrix display from the GUI to maintain focus on visual representations, as requested in issue #89.

## Changes
- Removed the "Scores Matrix" section from `App.tsx` (lines 867-875)
- The scores data remains accessible through various plot visualizations

## Rationale
- Aligns with the project's mission to create a user-friendly, visually-focused PCA application
- Raw numerical matrices can be overwhelming for users
- Users requiring numerical output can use the CLI tool
- The scores are already well-represented in multiple visual formats (Scores Plot, Biplot)

## Testing
- ✅ Frontend builds successfully (`npm run build`)
- ✅ All Go tests pass
- ✅ TypeScript compilation has no errors
- ✅ Pre-commit hooks pass

## Screenshots
The Scores Matrix table has been removed from the PCA results section. All visualization options remain functional.

Closes #89