### PR TITLE
Fix: integrate PaletteSelector with application help system

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -215,7 +215,9 @@ function AppContent() {
                         />
                     </div>
                     <div className="flex items-center gap-2">
-                        <PaletteSelector />
+                        <HelpWrapper helpKey="plot-color-palette">
+                            <PaletteSelector />
+                        </HelpWrapper>
                         <ThemeToggle />
                     </div>
                 </div>

--- a/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
@@ -18,14 +18,11 @@ export const PaletteSelector: React.FC = () => {
   return (
     <div className="flex items-center gap-2">
       <Palette className="w-4 h-4 text-gray-600 dark:text-gray-400" />
-      <div className="relative group">
+      <div className="relative">
         <select
           value={paletteType}
           onChange={handleChange}
           className="appearance-none bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-3 py-1 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
-          title={paletteType === 'qualitative' 
-            ? 'Categorical colors - best for groups and categories' 
-            : 'Sequential colors - best for continuous values'}
         >
           <option value="qualitative">Categorical</option>
           <option value="sequential">Sequential</option>
@@ -34,14 +31,6 @@ export const PaletteSelector: React.FC = () => {
           <svg className="w-4 h-4 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
-        </div>
-        
-        {/* Tooltip */}
-        <div className="absolute z-10 invisible group-hover:visible bg-gray-800 text-white text-xs rounded py-2 px-3 bottom-full left-1/2 transform -translate-x-1/2 mb-2 whitespace-nowrap">
-          {paletteType === 'qualitative' 
-            ? 'Best for groups and categories' 
-            : 'Best for continuous values'}
-          <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
         </div>
       </div>
       

--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -170,6 +170,11 @@
       "text": "Switch between light and dark modes. Preference saved locally.",
       "category": "interface"
     },
+    "plot-color-palette": {
+      "title": "Plot Color Palette",
+      "text": "Choose between Categorical (distinct colors for groups/categories) or Sequential (gradient for continuous values). Categorical is best for group comparisons, Sequential for visualizing gradients or intensities.",
+      "category": "interface"
+    },
     "preprocessing-order": {
       "title": "Preprocessing Order",
       "text": "Row-wise (SNV/L2) applied first, then column-wise (centering/scaling). Order matters!",


### PR DESCRIPTION
## Summary
This PR fixes the PaletteSelector component to use the application's unified help system instead of its own custom tooltip implementation.

## Changes
- Removed custom tooltip div and title attribute from PaletteSelector component
- Added help content entry for "plot-color-palette" in help-content.json
- Wrapped PaletteSelector with HelpWrapper in App.tsx

## Result
- The plot color theme selector now displays help in the header when hovered, consistent with other UI elements
- No more dual popups (browser tooltip + custom tooltip)
- Help content is centralized and easier to maintain

## Testing
- Built frontend successfully
- All tests pass
- Verified help displays correctly in the header when hovering over the palette selector

Closes #99