### PR TITLE
Fix: Shorten scree plot threshold label to prevent truncation

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScreePlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScreePlot.tsx
@@ -181,7 +181,7 @@ export const ScreePlot: React.FC<ScreePlotProps> = ({
               stroke="#EF4444" 
               strokeDasharray="5 5"
               label={{ 
-                value: `${elbowThreshold}% threshold`, 
+                value: `${elbowThreshold}%`, 
                 position: 'right',
                 style: { fill: '#EF4444' }
               }}


### PR DESCRIPTION
## Summary
This PR fixes the truncated "80% threshold" label in the Scree Plot by shortening it to just "80%".

## Changes
- Changed the reference line label from `${elbowThreshold}% threshold` to `${elbowThreshold}%`
- This prevents text truncation at the left edge of the plot while maintaining clarity

## Screenshots
The label is now fully visible and not cut off at the edge of the plot area.

## Testing
- Built the frontend successfully with no compilation errors
- All tests pass
- The shorter label is still clear in context (the red dashed line on the cumulative variance axis)

Closes #110