### PR TITLE
Fix: Auto-switch preprocessing to valid option when changing to Kernel PCA

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -456,7 +456,26 @@ function AppContent() {
                                         </label>
                                         <select
                                             value={config.method}
-                                            onChange={(e) => setConfig({...config, method: e.target.value})}
+                                            onChange={(e) => {
+                                                const newMethod = e.target.value;
+                                                const newConfig = {...config, method: newMethod};
+                                                
+                                                // If switching to kernel PCA and current preprocessing is invalid
+                                                if (newMethod === 'kernel') {
+                                                    // Check if current preprocessing is invalid for kernel PCA
+                                                    // Valid options for kernel PCA are: none (all false) or scale-only
+                                                    if (newConfig.meanCenter || newConfig.standardScale || newConfig.robustScale) {
+                                                        // Reset to "None" - the default valid option
+                                                        newConfig.meanCenter = false;
+                                                        newConfig.standardScale = false;
+                                                        newConfig.robustScale = false;
+                                                        newConfig.scaleOnly = false;
+                                                    }
+                                                    // scaleOnly is valid, so we keep it as-is
+                                                }
+                                                
+                                                setConfig(newConfig);
+                                            }}
                                             className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                                         >
                                             <option value="SVD">SVD</option>


### PR DESCRIPTION
## Summary
This PR fixes the preprocessing dropdown behavior when switching to Kernel PCA. Previously, invalid preprocessing options would remain selected (though disabled), creating a confusing UI state.

## Changes
- Modified the PCA method onChange handler to automatically reset invalid preprocessing options when switching to Kernel PCA
- Invalid options (Mean Center, Standard Scale, Robust Scale) now auto-switch to "None (Raw Data)"
- Valid options (None and Variance Scale) remain unchanged

## Testing
- Built frontend successfully with no errors
- All backend tests pass
- Manually verified the fix works as expected:
  - Set preprocessing to "Mean Center Only"
  - Switch method to "Kernel PCA" 
  - Preprocessing automatically switches to "None (Raw Data)"

## Screenshots
Before fix: Invalid option remains selected (as shown in issue #111)
After fix: Invalid options automatically reset to "None"

Closes #111