### PR TITLE
fix: automatically switch to Scores Plot when Kernel PCA is selected with unsupported visualization

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -182,6 +182,16 @@ function AppContent() {
                 setSelectedYComponent(1);
                 // Clear any previous errors
                 setPcaError(null);
+                
+                // Check if Kernel PCA is selected with unsupported visualization
+                if (config.method === 'kernel' && 
+                    (selectedPlot === 'correlations' || selectedPlot === 'biplot')) {
+                    // Switch to scores plot
+                    setSelectedPlot('scores');
+                    // Alert user about the automatic switch
+                    alert('The selected visualization is not supported for Kernel PCA. Switching to Scores Plot.');
+                }
+                
                 // Smooth scroll to results
                 setTimeout(() => {
                     pcaResultsRef.current?.scrollIntoView({ 


### PR DESCRIPTION
## Summary
- Adds automatic plot switching when Kernel PCA is run with unsupported visualizations
- Prevents blank screen issue when Circle of Correlations or Biplot is pre-selected
- Shows user alert explaining why the plot was switched

## Problem
When users had pre-selected Circle of Correlations or Biplot visualizations and then ran Kernel PCA, the visualization area would go blank because Kernel PCA doesn't compute loadings (returns empty loadings array).

## Solution
Added logic to the `runPCA` function that:
1. Detects when Kernel PCA is run with `selectedPlot` set to 'correlations' or 'biplot'
2. Automatically switches to the Scores Plot
3. Alerts the user about the automatic switch with a clear explanation

## Test Results
- Built frontend successfully with no compilation errors
- All existing Go tests pass with race detection enabled
- Manual testing confirms the fix works as expected:
  - Pre-select Circle of Correlations → Run Kernel PCA → Switches to Scores Plot with alert
  - Pre-select Biplot → Run Kernel PCA → Switches to Scores Plot with alert
  - Other plot types remain unaffected

Closes #118