### PR TITLE
Fix: comprehensive fix for PCA explained variance calculations

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -780,8 +780,7 @@ function AppContent() {
                                     </button>
                                 </div>
                                 <div className="space-y-2">
-                                    {pcaResponse.result.explained_variance.map((variance, i) => {
-                                        const percentage = variance;
+                                    {pcaResponse.result.explained_variance_ratio.map((percentage, i) => {
                                         return (
                                             <div key={i} className="flex justify-between">
                                                 <span>{pcaResponse.result?.component_labels?.[i] || `PC${i+1}`}:</span>
@@ -904,7 +903,7 @@ function AppContent() {
                                                     >
                                                         {pcaResponse.result.component_labels?.map((label, i) => (
                                                             <option key={i} value={i}>
-                                                                {label} ({pcaResponse.result!.explained_variance[i].toFixed(1)}%)
+                                                                {label} ({pcaResponse.result!.explained_variance_ratio[i].toFixed(1)}%)
                                                             </option>
                                                         ))}
                                                     </select>
@@ -918,7 +917,7 @@ function AppContent() {
                                                     >
                                                         {pcaResponse.result.component_labels?.map((label, i) => (
                                                             <option key={i} value={i}>
-                                                                {label} ({pcaResponse.result!.explained_variance[i].toFixed(1)}%)
+                                                                {label} ({pcaResponse.result!.explained_variance_ratio[i].toFixed(1)}%)
                                                             </option>
                                                         ))}
                                                     </select>
@@ -935,7 +934,7 @@ function AppContent() {
                                                 >
                                                     {pcaResponse.result?.component_labels?.map((label, i) => (
                                                         <option key={i} value={i}>
-                                                            {label} ({pcaResponse.result!.explained_variance[i].toFixed(1)}%)
+                                                            {label} ({pcaResponse.result!.explained_variance_ratio[i].toFixed(1)}%)
                                                         </option>
                                                     ))}
                                                 </select>

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -243,8 +243,8 @@ export const Biplot: React.FC<BiplotProps> = ({
   }, []);
 
   // Get variance percentages for axis labels
-  const xVariance = pcaResult.explained_variance[xComponent]?.toFixed(1) || '0';
-  const yVariance = pcaResult.explained_variance[yComponent]?.toFixed(1) || '0';
+  const xVariance = pcaResult.explained_variance_ratio[xComponent]?.toFixed(1) || '0';
+  const yVariance = pcaResult.explained_variance_ratio[yComponent]?.toFixed(1) || '0';
   const xLabel = `PC${xComponent + 1} (${xVariance}%)`;
   const yLabel = `PC${yComponent + 1} (${yVariance}%)`;
 

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
@@ -82,8 +82,8 @@ export const CircleOfCorrelations: React.FC<CircleOfCorrelationsProps> = ({
   // Get component labels and variance
   const xLabel = pcaResult.component_labels?.[xComponent] || `PC${xComponent + 1}`;
   const yLabel = pcaResult.component_labels?.[yComponent] || `PC${yComponent + 1}`;
-  const xVariance = pcaResult.explained_variance[xComponent]?.toFixed(1) || '0';
-  const yVariance = pcaResult.explained_variance[yComponent]?.toFixed(1) || '0';
+  const xVariance = pcaResult.explained_variance_ratio[xComponent]?.toFixed(1) || '0';
+  const yVariance = pcaResult.explained_variance_ratio[yComponent]?.toFixed(1) || '0';
 
   // SVG dimensions
   const width = 500;

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
@@ -79,7 +79,7 @@ export const LoadingsPlot: React.FC<LoadingsPlotProps> = ({
 
   // Get component label and variance
   const componentLabel = pcaResult.component_labels?.[selectedComponent] || `PC${selectedComponent + 1}`;
-  const variance = pcaResult.explained_variance[selectedComponent]?.toFixed(1) || '0';
+  const variance = pcaResult.explained_variance_ratio[selectedComponent]?.toFixed(1) || '0';
 
   // Handle edge cases
   if (!loadingsData || loadingsData.length === 0) {

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
@@ -158,8 +158,8 @@ export const ScoresPlot: React.FC<ScoresPlotProps> = ({
   }, []);
 
   // Get variance percentages for axis labels
-  const xVariance = pcaResult.explained_variance[xComponent]?.toFixed(1) || '0';
-  const yVariance = pcaResult.explained_variance[yComponent]?.toFixed(1) || '0';
+  const xVariance = pcaResult.explained_variance_ratio[xComponent]?.toFixed(1) || '0';
+  const yVariance = pcaResult.explained_variance_ratio[yComponent]?.toFixed(1) || '0';
 
   const xLabel = `PC${xComponent + 1} (${xVariance}%)`;
   const yLabel = `PC${yComponent + 1} (${yVariance}%)`;


### PR DESCRIPTION
## Summary
This PR fixes critical issues with explained variance calculations in both regular and kernel PCA, ensuring mathematically correct results across all PCA methods.

## Problem
1. **Kernel PCA**: Explained variance always summed to 100% regardless of components selected, with individual components sometimes exceeding 100%
2. **Regular PCA**: Double percentage calculation caused incorrect individual component percentages
3. **Frontend**: Displayed raw eigenvalues instead of percentages

## Root Causes
1. **Kernel PCA**: Used only selected k eigenvalues for total variance instead of all n eigenvalues
2. **Regular PCA**: `calculateVariance` returned percentages, but `Fit` method treated them as raw values and calculated percentages again
3. **Frontend**: Used `explained_variance` field instead of `explained_variance_ratio`

## Solution
### Backend Changes:
- Refactored regular PCA to use eigenvalues directly from algorithms (SVD/NIPALS)
- Fixed kernel PCA to return ALL eigenvalues and use them for total variance calculation
- Removed double percentage calculation in regular PCA
- Added `calculateEigenvaluesFromScores` as fallback method
- Ensured NIPALS with missing values shows relative proportions correctly

### Frontend Changes:
- Updated all visualization components to display `explained_variance_ratio`
- Fixed component selectors in plots to show percentages correctly

## Testing
- All existing tests pass
- Added comprehensive test for kernel PCA variance calculation
- Manually verified with Swiss Roll and Iris datasets
- Verified correct behavior across all preprocessing options

## Results
- Individual component percentages are always ≤ 100%
- Cumulative variance for k<n components is < 100%
- All algorithms (SVD, NIPALS, Kernel PCA) produce consistent results
- Frontend displays mathematically correct percentages

Closes #126