### PR TITLE
fix: add target/category column support and eigencorrelation analysis to CLI

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -43,7 +43,7 @@ func (a *App) SetFileToOpen(path string) {
 // so we can call the runtime methods
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
-	
+
 	// If a file was specified via --open, emit an event to load it
 	if a.fileToOpen != "" {
 		// Give the frontend a moment to set up event listeners
@@ -67,7 +67,7 @@ func (a *App) LoadCSVFile(filePath string) (*FileDataJSON, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
-	
+
 	// Parse the CSV content
 	return a.ParseCSV(string(content))
 }
@@ -1022,7 +1022,8 @@ func (a *App) ExportPCAModel(request ExportPCAModelRequest) error {
 	}
 
 	// Convert to PCAOutputData using the CLI function
-	outputData := cli.ConvertToPCAOutputData(request.PCAResult, csvData, true, pcaConfig, preprocessor)
+	// Note: We don't have categorical/target data in the export request, so pass nil
+	outputData := cli.ConvertToPCAOutputData(request.PCAResult, csvData, true, pcaConfig, preprocessor, nil, nil)
 
 	// Marshal to JSON
 	jsonData, err := json.MarshalIndent(outputData, "", "  ")

--- a/cmd/gopca-desktop/main.go
+++ b/cmd/gopca-desktop/main.go
@@ -20,7 +20,7 @@ func main() {
 	openFile := flag.String("open", "", "CSV file to open on startup")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
-	
+
 	// Handle version flag
 	if *showVersion {
 		fmt.Println(version.Get().Short())
@@ -29,7 +29,7 @@ func main() {
 
 	// Create an instance of the app structure
 	app := NewApp()
-	
+
 	// Pass the file to open if provided
 	if *openFile != "" {
 		app.SetFileToOpen(*openFile)

--- a/internal/cli/analyze_mixed_test.go
+++ b/internal/cli/analyze_mixed_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitjungle/gopca/pkg/types"
+)
+
+func TestAnalyzeMixedColumns(t *testing.T) {
+	// Create test directory
+	testDir := t.TempDir()
+
+	// Create test CSV with mixed columns
+	csvContent := `sample,var1,var2,var3,group,concentration#target
+A1,1.2,2.3,3.4,control,10.5
+A2,1.3,2.5,3.2,control,10.2
+A3,1.1,2.4,3.5,control,11.0
+B1,2.2,3.3,4.4,treatment,15.5
+B2,2.3,3.5,4.2,treatment,15.2
+B3,2.1,3.4,4.5,treatment,16.0`
+
+	csvFile := filepath.Join(testDir, "mixed.csv")
+	if err := os.WriteFile(csvFile, []byte(csvContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run analyze command with eigencorrelations
+	app := NewApp()
+	err := app.Run([]string{
+		"gopca-cli",
+		"analyze",
+		"-c", "2",
+		"--eigencorrelations",
+		"--group-column", "group",
+		"-f", "json",
+		"-o", testDir,
+		"--verbose",
+		csvFile,
+	})
+
+	if err != nil {
+		t.Fatalf("analyze command failed: %v", err)
+	}
+
+	// Check output file exists
+	outputFile := filepath.Join(testDir, "mixed_pca.json")
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Fatal("output file not created")
+	}
+
+	// Read and parse output
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output types.PCAOutputData
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check preserved columns
+	if output.PreservedColumns == nil {
+		t.Fatal("preserved columns not included in output")
+	}
+
+	// Check categorical data
+	if len(output.PreservedColumns.Categorical) != 1 {
+		t.Fatalf("expected 1 categorical column, got %d", len(output.PreservedColumns.Categorical))
+	}
+
+	groupData, ok := output.PreservedColumns.Categorical["group"]
+	if !ok {
+		t.Fatal("group column not found in categorical data")
+	}
+
+	if len(groupData) != 6 {
+		t.Fatalf("expected 6 group values, got %d", len(groupData))
+	}
+
+	// Check target data
+	if len(output.PreservedColumns.NumericTarget) != 1 {
+		t.Fatalf("expected 1 target column, got %d", len(output.PreservedColumns.NumericTarget))
+	}
+
+	targetData, ok := output.PreservedColumns.NumericTarget["concentration#target"]
+	if !ok {
+		t.Fatal("concentration#target column not found in target data")
+	}
+
+	if len(targetData) != 6 {
+		t.Fatalf("expected 6 target values, got %d", len(targetData))
+	}
+
+	// Check eigencorrelations
+	if output.Eigencorrelations == nil {
+		t.Fatal("eigencorrelations not included in output")
+	}
+
+	if len(output.Eigencorrelations.Variables) < 2 {
+		t.Fatalf("expected at least 2 variables in eigencorrelations, got %d",
+			len(output.Eigencorrelations.Variables))
+	}
+
+	// Check that concentration#target is correlated with PC1
+	concCorr, ok := output.Eigencorrelations.Correlations["concentration#target"]
+	if !ok {
+		t.Fatal("concentration#target not found in correlations")
+	}
+
+	// PC1 should have high correlation with concentration
+	if concCorr[0] < 0.9 {
+		t.Errorf("expected high correlation between PC1 and concentration, got %f", concCorr[0])
+	}
+}
+
+func TestAnalyzeTargetColumnAutoDetection(t *testing.T) {
+	// Create test directory
+	testDir := t.TempDir()
+
+	// Create test CSV with auto-detectable target column
+	csvContent := `sample,var1,var2,var3,pH #target
+S1,1.2,2.3,3.4,7.5
+S2,1.3,2.5,3.2,7.2
+S3,1.1,2.4,3.5,7.8`
+
+	csvFile := filepath.Join(testDir, "target.csv")
+	if err := os.WriteFile(csvFile, []byte(csvContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run analyze command without specifying target columns
+	app := NewApp()
+	err := app.Run([]string{
+		"gopca-cli",
+		"analyze",
+		"-c", "2",
+		"-f", "json",
+		"-o", testDir,
+		csvFile,
+	})
+
+	if err != nil {
+		t.Fatalf("analyze command failed: %v", err)
+	}
+
+	// Read and parse output
+	outputFile := filepath.Join(testDir, "target_pca.json")
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output types.PCAOutputData
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that target column was auto-detected and excluded
+	if output.PreservedColumns == nil {
+		t.Fatal("preserved columns not included in output")
+	}
+
+	targetData, ok := output.PreservedColumns.NumericTarget["pH #target"]
+	if !ok {
+		t.Fatal("pH #target column not auto-detected as target column")
+	}
+
+	if len(targetData) != 3 {
+		t.Fatalf("expected 3 target values, got %d", len(targetData))
+	}
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -77,7 +77,8 @@ func generateOutputPaths(inputFile, outputDir, format string) map[string]string 
 
 // ConvertToPCAOutputData converts PCAResult and CSVData to PCAOutputData
 func ConvertToPCAOutputData(result *types.PCAResult, data *CSVData, includeMetrics bool,
-	config types.PCAConfig, preprocessor *core.Preprocessor) *types.PCAOutputData {
+	config types.PCAConfig, preprocessor *core.Preprocessor,
+	categoricalData map[string][]string, targetData map[string][]float64) *types.PCAOutputData {
 
 	// Create timestamp
 	createdAt := time.Now().Format(time.RFC3339)
@@ -169,6 +170,15 @@ func ConvertToPCAOutputData(result *types.PCAResult, data *CSVData, includeMetri
 		QLimit99:  result.QLimit99,
 	}
 
+	// Add preserved columns if provided
+	var preservedColumns *types.PreservedColumns
+	if len(categoricalData) > 0 || len(targetData) > 0 {
+		preservedColumns = &types.PreservedColumns{
+			Categorical:   categoricalData,
+			NumericTarget: targetData,
+		}
+	}
+
 	return &types.PCAOutputData{
 		Metadata:          metadata,
 		Preprocessing:     preprocessingInfo,
@@ -176,6 +186,7 @@ func ConvertToPCAOutputData(result *types.PCAResult, data *CSVData, includeMetri
 		Results:           resultsData,
 		Diagnostics:       diagnostics,
 		Eigencorrelations: result.Eigencorrelations,
+		PreservedColumns:  preservedColumns,
 	}
 }
 
@@ -326,10 +337,11 @@ func outputTableFormat(result *types.PCAResult, data *CSVData,
 // outputJSONFormat outputs results in JSON format
 func outputJSONFormat(result *types.PCAResult, data *CSVData, inputFile, outputDir string,
 	outputScores, outputLoadings, outputVariance, includeMetrics bool,
-	config types.PCAConfig, preprocessor *core.Preprocessor) error {
+	config types.PCAConfig, preprocessor *core.Preprocessor,
+	categoricalData map[string][]string, targetData map[string][]float64) error {
 
 	// Convert to PCAOutputData
-	outputData := ConvertToPCAOutputData(result, data, includeMetrics, config, preprocessor)
+	outputData := ConvertToPCAOutputData(result, data, includeMetrics, config, preprocessor, categoricalData, targetData)
 
 	// Generate output paths
 	paths := generateOutputPaths(inputFile, outputDir, "json")

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -71,7 +71,7 @@ func TestConvertToPCAOutputData(t *testing.T) {
 	)
 
 	// Convert to output data
-	outputData := ConvertToPCAOutputData(result, csvData, false, config, preprocessor)
+	outputData := ConvertToPCAOutputData(result, csvData, false, config, preprocessor, nil, nil)
 
 	// Test metadata
 	if outputData.Metadata.Version != "1.0" {
@@ -151,7 +151,7 @@ func TestJSONSerialization(t *testing.T) {
 	preprocessor := core.NewPreprocessor(true, false, false)
 
 	// Convert to output data
-	outputData := ConvertToPCAOutputData(result, csvData, false, config, preprocessor)
+	outputData := ConvertToPCAOutputData(result, csvData, false, config, preprocessor, nil, nil)
 
 	// Test JSON marshaling
 	jsonData, err := json.MarshalIndent(outputData, "", "  ")

--- a/pkg/types/pca.go
+++ b/pkg/types/pca.go
@@ -92,6 +92,7 @@ type PCAOutputData struct {
 	Results           ResultsData             `json:"results"`
 	Diagnostics       DiagnosticLimits        `json:"diagnostics,omitempty"`
 	Eigencorrelations *EigencorrelationResult `json:"eigencorrelations,omitempty"`
+	PreservedColumns  *PreservedColumns       `json:"preservedColumns,omitempty"`
 }
 
 // SampleData contains sample-space results
@@ -207,4 +208,10 @@ type DiagnosticLimits struct {
 	T2Limit99 float64 `json:"t2_limit_99,omitempty"`
 	QLimit95  float64 `json:"q_limit_95,omitempty"`
 	QLimit99  float64 `json:"q_limit_99,omitempty"`
+}
+
+// PreservedColumns contains columns that were excluded from PCA but preserved in output
+type PreservedColumns struct {
+	Categorical   map[string][]string  `json:"categorical,omitempty"`
+	NumericTarget map[string][]float64 `json:"numericTarget,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Added support for target and category columns in CLI to match desktop functionality
- Implemented eigencorrelation analysis for CLI users
- Ensured consistent JSON output format between CLI and desktop applications
- Maintained backward compatibility while adding new features

## Changes Made
- **Backend**: 
  - Switched from `ParseCSV` to `ParseCSVMixedWithTargets` for consistent CSV parsing across applications
  - Added new command-line flags: `--group-column`, `--metadata-cols`, `--target-columns`, `--eigencorrelations`
  - Implemented eigencorrelation calculation using existing core functionality
  - Updated `ConvertToPCAOutputData` to include preserved column data
- **Data Structure**: 
  - Added `PreservedColumns` type to `PCAOutputData` for categorical and numeric target data
  - Ensures JSON output format matches between CLI and desktop applications
- **Tests**: 
  - Added comprehensive tests for mixed column functionality
  - Tests for eigencorrelation calculation
  - Tests for target column auto-detection
- **Documentation**: 
  - Updated CLI help text with new examples
  - Added documentation for new flags

## Technical Details
- Target columns (ending with `#target`) are auto-detected and excluded from PCA
- Category columns are identified during parsing and preserved in output
- Eigencorrelation analysis calculates Pearson correlations between PC scores and metadata variables
- All changes maintain backward compatibility - existing CLI workflows continue to work unchanged

## Testing
- Run the new tests: `go test ./internal/cli -run TestAnalyzeMixed`
- Test eigencorrelation: `gopca-cli analyze --eigencorrelations --group-column species -f json data/iris_data.csv`
- Test target column auto-detection: `gopca-cli analyze -f json data/test_with_targets.csv`
- Verify JSON output structure matches desktop app

Fixes #147

🤖 Generated with [Claude Code](https://claude.ai/code)