### PR TITLE
fix: add notarization to macOS builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,16 @@ jobs:
         ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
       shell: bash
     
+    - name: Notarize desktop app (macOS)
+      if: matrix.os == 'macos-latest'
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
+      shell: bash
+    
     - name: Upload desktop artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -288,6 +298,16 @@ jobs:
         APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
       run: |
         ./scripts/ci/sign-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
+      shell: bash
+    
+    - name: Notarize GoCSV app (macOS)
+      if: matrix.os == 'macos-latest'
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        ./scripts/ci/notarize-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
       shell: bash
     
     - name: Upload GoCSV artifacts


### PR DESCRIPTION
## Problem
macOS builds from the main branch are signed but not notarized, causing Gatekeeper warnings when downloaded and run. This affects the development/testing workflow as shown in the screenshots where both `gopca-desktop` and `gocsv` show:
- ✅ Signed by: Rune Mathisen
- ❌ Notarization: None detected
- ❌ Gatekeeper: Unnotarized Developer ID

## Root Cause
PR #161 intentionally designed the workflows to:
- **Build workflow**: Sign only (fast, for every main branch push)
- **Release workflow**: Sign + Notarize (slower, only for releases)

This was a reasonable design, but in practice causes friction when testing builds from CI.

## Solution
Add notarization steps to the build workflow immediately after signing for both Desktop and GoCSV apps on macOS.

## Changes
- Added "Notarize desktop app (macOS)" step after signing in build-desktop job
- Added "Notarize GoCSV app (macOS)" step after signing in build-gocsv job
- Both use the existing `scripts/ci/notarize-macos-ci.sh` which is non-fatal

## Impact Analysis
### Time Impact
- Adds ~5-10 minutes per app (10-20 minutes total) to macOS builds
- With ~3 PR merges/day = ~60 minutes additional CI time daily

### Apple Service Impact
- ~6 notarization requests/day (3 merges × 2 apps)
- Well within expected usage for CI/CD automation

### Cost Impact
- Moderate increase in GitHub Actions usage for macOS runners
- Acceptable trade-off for improved developer experience

### Risk Assessment
- **Low risk**: Script is already non-fatal (won't break builds)
- **No security change**: Uses same secrets as release workflow
- **Reversible**: Can easily remove if issues arise

## Testing
- Workflow syntax validated
- Script already proven in release workflow
- Will be tested when this PR triggers CI

## Alternative Approaches Considered
1. **Manual trigger**: workflow_dispatch for on-demand notarization
2. **Conditional**: Only notarize when commit contains [notarize]
3. **Selected**: Always notarize (simplest, best developer experience)

## Related
- Original implementation: PR #161
- Previous CI work: PRs #158, #159