### PR TITLE
feat: Rename binaries to match product names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,8 +140,8 @@ jobs:
     - name: Upload CLI artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: gopca-cli-binaries
-        path: build/gopca-cli-*
+        name: pca-binaries
+        path: build/pca-*
         retention-days: 7
 
   build-desktop:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         GOARCH: ${{ matrix.goarch }}
         VERSION: ${{ steps.get_version.outputs.version }}
       run: |
-        BINARY_NAME="gopca-cli-${GOOS}-${GOARCH}"
+        BINARY_NAME="pca-${GOOS}-${GOARCH}"
         if [ "$GOOS" = "windows" ]; then
           BINARY_NAME="${BINARY_NAME}.exe"
         fi
@@ -90,7 +90,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: gopca-cli-${{ matrix.goos }}-${{ matrix.goarch }}
+        name: pca-${{ matrix.goos }}-${{ matrix.goarch }}
         path: build/${{ env.BINARY_NAME }}
         retention-days: 1
 
@@ -161,7 +161,7 @@ jobs:
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
       run: |
-        ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
+        ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
     
     - name: Notarize Desktop app (macOS)
       if: matrix.os == 'macos-latest'
@@ -170,16 +170,16 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
+        ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
     
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: gopca-desktop-${{ matrix.os }}
         path: |
-          cmd/gopca-desktop/build/bin/gopca-desktop.app
-          cmd/gopca-desktop/build/bin/gopca-desktop.exe
-          cmd/gopca-desktop/build/bin/gopca-desktop
+          cmd/gopca-desktop/build/bin/GoPCA.app
+          cmd/gopca-desktop/build/bin/GoPCA.exe
+          cmd/gopca-desktop/build/bin/GoPCA
         retention-days: 1
 
   build-gocsv:
@@ -249,7 +249,7 @@ jobs:
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
       run: |
-        ./scripts/ci/sign-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
+        ./scripts/ci/sign-macos-ci.sh cmd/gocsv/build/bin/GoCSV.app
     
     - name: Notarize GoCSV app (macOS)
       if: matrix.os == 'macos-latest'
@@ -258,16 +258,16 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        ./scripts/ci/notarize-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
+        ./scripts/ci/notarize-macos-ci.sh cmd/gocsv/build/bin/GoCSV.app
     
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: gocsv-${{ matrix.os }}
         path: |
-          cmd/gocsv/build/bin/gocsv.app
-          cmd/gocsv/build/bin/gocsv.exe
-          cmd/gocsv/build/bin/gocsv
+          cmd/gocsv/build/bin/GoCSV.app
+          cmd/gocsv/build/bin/GoCSV.exe
+          cmd/gocsv/build/bin/GoCSV
         retention-days: 1
 
   create-release:
@@ -289,43 +289,43 @@ jobs:
         cd artifacts
         
         # CLI binaries - just move them to the root
-        mv gopca-cli-*/* .
+        mv pca-*/* .
         
         # Desktop apps - create proper packages
         if [ -d "gopca-desktop-macos-latest" ]; then
           cd gopca-desktop-macos-latest
-          zip -r ../gopca-desktop-macos.zip gopca-desktop.app
+          zip -r ../GoPCA-macos.zip GoPCA.app
           cd ..
         fi
         
-        if [ -f "gopca-desktop-windows-latest/gopca-desktop.exe" ]; then
-          mv gopca-desktop-windows-latest/gopca-desktop.exe gopca-desktop-windows.exe
+        if [ -f "gopca-desktop-windows-latest/GoPCA.exe" ]; then
+          mv gopca-desktop-windows-latest/GoPCA.exe GoPCA-windows.exe
         fi
         
-        if [ -f "gopca-desktop-ubuntu-latest/gopca-desktop" ]; then
-          mv gopca-desktop-ubuntu-latest/gopca-desktop gopca-desktop-linux
+        if [ -f "gopca-desktop-ubuntu-latest/GoPCA" ]; then
+          mv gopca-desktop-ubuntu-latest/GoPCA GoPCA-linux
         fi
         
         # GoCSV apps - create proper packages
         if [ -d "gocsv-macos-latest" ]; then
           cd gocsv-macos-latest
-          zip -r ../gocsv-macos.zip gocsv.app
+          zip -r ../GoCSV-macos.zip GoCSV.app
           cd ..
         fi
         
-        if [ -f "gocsv-windows-latest/gocsv.exe" ]; then
-          mv gocsv-windows-latest/gocsv.exe gocsv-windows.exe
+        if [ -f "gocsv-windows-latest/GoCSV.exe" ]; then
+          mv gocsv-windows-latest/GoCSV.exe GoCSV-windows.exe
         fi
         
-        if [ -f "gocsv-ubuntu-latest/gocsv" ]; then
-          mv gocsv-ubuntu-latest/gocsv gocsv-linux
+        if [ -f "gocsv-ubuntu-latest/GoCSV" ]; then
+          mv gocsv-ubuntu-latest/GoCSV GoCSV-linux
         fi
         
         # Remove empty directories
-        rm -rf gopca-cli-* gopca-desktop-* gocsv-*
+        rm -rf pca-* gopca-desktop-* gocsv-*
         
         # Generate checksums
-        shasum -a 256 gopca-cli-* gopca-desktop* gocsv* > checksums.txt
+        shasum -a 256 pca-* GoPCA* GoCSV* > checksums.txt
         
         # List all artifacts for debugging
         echo "Final artifacts:"
@@ -335,13 +335,13 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          artifacts/gopca-cli-*
-          artifacts/gopca-desktop-*.zip
-          artifacts/gopca-desktop-*.exe
-          artifacts/gopca-desktop-linux
-          artifacts/gocsv-*.zip
-          artifacts/gocsv-*.exe
-          artifacts/gocsv-linux
+          artifacts/pca-*
+          artifacts/GoPCA-*.zip
+          artifacts/GoPCA-*.exe
+          artifacts/GoPCA-linux
+          artifacts/GoCSV-*.zip
+          artifacts/GoCSV-*.exe
+          artifacts/GoCSV-linux
           artifacts/checksums.txt
         generate_release_notes: true
         fail_on_unmatched_files: false
@@ -349,21 +349,21 @@ jobs:
           ## Downloads
           
           ### CLI Binaries
-          - **macOS Intel**: `gopca-cli-darwin-amd64`
-          - **macOS Apple Silicon**: `gopca-cli-darwin-arm64`
-          - **Linux x64**: `gopca-cli-linux-amd64`
-          - **Linux ARM64**: `gopca-cli-linux-arm64`
-          - **Windows x64**: `gopca-cli-windows-amd64.exe`
+          - **macOS Intel**: `pca-darwin-amd64`
+          - **macOS Apple Silicon**: `pca-darwin-arm64`
+          - **Linux x64**: `pca-linux-amd64`
+          - **Linux ARM64**: `pca-linux-arm64`
+          - **Windows x64**: `pca-windows-amd64.exe`
           
           ### Desktop Applications
-          - **macOS**: `gopca-desktop-macos.zip` (signed & notarized)
-          - **Windows**: `gopca-desktop-windows.exe`
-          - **Linux**: `gopca-desktop-linux`
+          - **macOS**: `GoPCA-macos.zip` (signed & notarized)
+          - **Windows**: `GoPCA-windows.exe`
+          - **Linux**: `GoPCA-linux`
           
           ### GoCSV Editor
-          - **macOS**: `gocsv-macos.zip` (signed & notarized)
-          - **Windows**: `gocsv-windows.exe`
-          - **Linux**: `gocsv-linux`
+          - **macOS**: `GoCSV-macos.zip` (signed & notarized)
+          - **Windows**: `GoCSV-windows.exe`
+          - **Linux**: `GoCSV-linux`
           
           ### Verification
           SHA-256 checksums for all artifacts: `checksums.txt`

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # This Makefile provides common development tasks for building, testing, and running the PCA toolkit
 
 # Variables
-BINARY_NAME := gopca-cli
-DESKTOP_NAME := gopca-desktop
-CSV_NAME := gocsv
+BINARY_NAME := pca
+DESKTOP_NAME := GoPCA
+CSV_NAME := GoCSV
 BUILD_DIR := build
 CLI_PATH := cmd/gopca-cli/main.go
 DESKTOP_PATH := cmd/gopca-desktop

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Ideal for automation, batch processing, and integration into data pipelines.
 
 ```bash
 # Analyze your data with a single command
-gopca-cli analyze data.csv --components 3 --scale standard --output results/
+pca analyze data.csv --components 3 --scale standard --output results/
 
 # Validate data before analysis
-gopca-cli validate spectra.csv
+pca validate spectra.csv
 
 # Apply a saved PCA model to new data
-gopca-cli transform model.json new_data.csv
+pca transform model.json new_data.csv
 ```
 
 ### TheGoCSV Data Editor
@@ -131,14 +131,14 @@ All visualizations feature:
 
 ```bash
 # Download the latest release
-wget https://github.com/bitjungle/gopca/releases/latest/download/gopca-cli
-chmod +x gopca-cli
+wget https://github.com/bitjungle/gopca/releases/latest/download/pca
+chmod +x pca
 
 # Basic analysis with automatic settings
-./gopca-cli analyze mydata.csv
+./pca analyze mydata.csv
 
 # Advanced analysis with custom parameters
-./gopca-cli analyze mydata.csv \
+./pca analyze mydata.csv \
   --components 4 \
   --scale standard \
   --preprocessing snv \
@@ -146,7 +146,7 @@ chmod +x gopca-cli
   --output results/
 
 # Validate your data first
-./gopca-cli validate mydata.csv
+./pca validate mydata.csv
 ```
 
 ## Use Cases

--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "gocsv",
-  "outputfilename": "gocsv",
+  "name": "GoCSV",
+  "outputfilename": "GoCSV",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "gopca-desktop",
-  "outputfilename": "gopca-desktop",
+  "name": "GoPCA",
+  "outputfilename": "GoPCA",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,10 +1,10 @@
 # GoPCA CLI Reference
 
-Complete command-line interface documentation for gopca-cli.
+Complete command-line interface documentation for pca.
 
 ## Overview
 
-The GoPCA command-line interface (`gopca-cli`) provides powerful PCA analysis capabilities for automation, batch processing, and integration into data pipelines. It supports multiple PCA algorithms, comprehensive preprocessing options, and flexible output formats.
+The GoPCA command-line interface (`pca`) provides powerful PCA analysis capabilities for automation, batch processing, and integration into data pipelines. It supports multiple PCA algorithms, comprehensive preprocessing options, and flexible output formats.
 
 ## Installation
 
@@ -12,11 +12,11 @@ Download the latest binary for your platform from the [GitHub Releases](https://
 
 ```bash
 # Linux/macOS
-wget https://github.com/bitjungle/gopca/releases/latest/download/gopca-cli
-chmod +x gopca-cli
+wget https://github.com/bitjungle/gopca/releases/latest/download/pca
+chmod +x pca
 
 # Add to PATH (optional)
-sudo mv gopca-cli /usr/local/bin/
+sudo mv pca /usr/local/bin/
 ```
 
 ## Global Options
@@ -35,7 +35,7 @@ The main command for running PCA analysis on your data.
 #### Basic Usage
 
 ```bash
-gopca-cli analyze [OPTIONS] <input.csv>
+pca analyze [OPTIONS] <input.csv>
 ```
 
 **Important:** The input CSV file must be specified as the last argument. All options must come before the filename.
@@ -109,73 +109,73 @@ gopca-cli analyze [OPTIONS] <input.csv>
 ##### Basic Analysis
 ```bash
 # Simple 2-component PCA with default settings
-gopca-cli analyze data.csv
+pca analyze data.csv
 
 # 3 components with standard scaling
-gopca-cli analyze --components 3 --scale standard data.csv
+pca analyze --components 3 --scale standard data.csv
 
 # Save results to specific directory
-gopca-cli analyze -o results/ data.csv
+pca analyze -o results/ data.csv
 ```
 
 ##### Advanced Preprocessing
 ```bash
 # SNV preprocessing for spectroscopic data
-gopca-cli analyze --snv --scale standard spectral_data.csv
+pca analyze --snv --scale standard spectral_data.csv
 
 # Robust scaling for data with outliers
-gopca-cli analyze --scale robust --components 4 data.csv
+pca analyze --scale robust --components 4 data.csv
 
 # Vector normalization
-gopca-cli analyze --vector-norm data.csv
+pca analyze --vector-norm data.csv
 ```
 
 ##### Kernel PCA
 ```bash
 # RBF kernel with custom gamma
-gopca-cli analyze --method kernel --kernel-type rbf --kernel-gamma 0.5 data.csv
+pca analyze --method kernel --kernel-type rbf --kernel-gamma 0.5 data.csv
 
 # Polynomial kernel of degree 3
-gopca-cli analyze --method kernel --kernel-type poly --kernel-degree 3 data.csv
+pca analyze --method kernel --kernel-type poly --kernel-degree 3 data.csv
 
 # Linear kernel PCA
-gopca-cli analyze --method kernel --kernel-type linear data.csv
+pca analyze --method kernel --kernel-type linear data.csv
 ```
 
 ##### Missing Data
 ```bash
 # Drop rows with missing values
-gopca-cli analyze --missing-strategy drop data.csv
+pca analyze --missing-strategy drop data.csv
 
 # Use NIPALS with native missing data handling
-gopca-cli analyze --method nipals --missing-strategy native data.csv
+pca analyze --method nipals --missing-strategy native data.csv
 
 # Replace missing with mean
-gopca-cli analyze --missing-strategy mean data.csv
+pca analyze --missing-strategy mean data.csv
 ```
 
 ##### Group Analysis
 ```bash
 # Specify grouping column
-gopca-cli analyze --group-column sample_type data.csv
+pca analyze --group-column sample_type data.csv
 
 # Calculate eigencorrelations with metadata
-gopca-cli analyze --metadata-cols age,weight --eigencorrelations -f json data.csv
+pca analyze --metadata-cols age,weight --eigencorrelations -f json data.csv
 
 # Include target columns
-gopca-cli analyze --target-columns concentration,pH --eigencorrelations data.csv
+pca analyze --target-columns concentration,pH --eigencorrelations data.csv
 ```
 
 ##### Output Formats
 ```bash
 # JSON output with all results
-gopca-cli analyze -f json --output-all data.csv
+pca analyze -f json --output-all data.csv
 
 # Table format with scores and variance
-gopca-cli analyze --output-scores --output-variance data.csv
+pca analyze --output-scores --output-variance data.csv
 
 # Include diagnostic metrics
-gopca-cli analyze --include-metrics -f json data.csv
+pca analyze --include-metrics -f json data.csv
 ```
 
 ### `validate` - Validate Input Data
@@ -185,7 +185,7 @@ Check your data for issues before running PCA analysis.
 #### Basic Usage
 
 ```bash
-gopca-cli validate [OPTIONS] <input.csv>
+pca validate [OPTIONS] <input.csv>
 ```
 
 #### Options
@@ -211,16 +211,16 @@ The validate command performs these checks:
 
 ```bash
 # Basic validation
-gopca-cli validate data.csv
+pca validate data.csv
 
 # Show detailed summary statistics
-gopca-cli validate --summary data.csv
+pca validate --summary data.csv
 
 # Strict mode - fail on any warnings
-gopca-cli validate --strict data.csv
+pca validate --strict data.csv
 
 # Custom delimiter and missing values
-gopca-cli validate --delimiter semicolon --na-values "?,unknown" data.csv
+pca validate --delimiter semicolon --na-values "?,unknown" data.csv
 ```
 
 ### `transform` - Apply PCA Model to New Data
@@ -230,7 +230,7 @@ Apply a previously trained PCA model to transform new data.
 #### Basic Usage
 
 ```bash
-gopca-cli transform [OPTIONS] <model.json> <input.csv>
+pca transform [OPTIONS] <model.json> <input.csv>
 ```
 
 **Note:** Both the model file and input CSV must be specified as the last two arguments.
@@ -260,16 +260,16 @@ gopca-cli transform [OPTIONS] <model.json> <input.csv>
 
 ```bash
 # Basic transformation
-gopca-cli transform model.json new_data.csv
+pca transform model.json new_data.csv
 
 # Save to specific file with JSON format
-gopca-cli transform -f json -o results/ model.json new_data.csv
+pca transform -f json -o results/ model.json new_data.csv
 
 # Exclude specific rows
-gopca-cli transform --exclude-rows 1,5-10 model.json new_data.csv
+pca transform --exclude-rows 1,5-10 model.json new_data.csv
 
 # Include diagnostic metrics
-gopca-cli transform --include-metrics model.json new_data.csv
+pca transform --include-metrics model.json new_data.csv
 ```
 
 ## Output Formats
@@ -360,7 +360,7 @@ The preprocessing steps are applied in this order:
 ## Best Practices
 
 ### Data Preparation
-1. Validate your data first: `gopca-cli validate data.csv`
+1. Validate your data first: `pca validate data.csv`
 2. Handle missing values appropriately for your domain
 3. Consider scaling for mixed-unit variables
 4. Use SNV for spectroscopic data
@@ -413,7 +413,7 @@ The preprocessing steps are applied in this order:
 #!/bin/bash
 # Batch process multiple files
 for file in data/*.csv; do
-    gopca-cli analyze -f json -o results/ "$file"
+    pca analyze -f json -o results/ "$file"
 done
 ```
 
@@ -424,7 +424,7 @@ import json
 
 # Run PCA analysis
 result = subprocess.run(
-    ['gopca-cli', 'analyze', '-f', 'json', '--output-all', 'data.csv'],
+    ['pca', 'analyze', '-f', 'json', '--output-all', 'data.csv'],
     capture_output=True, text=True
 )
 
@@ -436,11 +436,11 @@ variance = pca_results['explainedVariance']
 
 ### R Integration
 ```r
-# Run gopca-cli from R
+# Run pca from R
 library(jsonlite)
 
 output <- system2(
-  "gopca-cli",
+  "pca",
   args = c("analyze", "-f", "json", "--output-all", "data.csv"),
   stdout = TRUE
 )
@@ -460,12 +460,12 @@ scores <- results$scores
 
 ```bash
 # General help
-gopca-cli --help
+pca --help
 
 # Command-specific help
-gopca-cli analyze --help
-gopca-cli validate --help
-gopca-cli transform --help
+pca analyze --help
+pca validate --help
+pca transform --help
 ```
 
 For issues or questions, visit the [GitHub repository](https://github.com/bitjungle/gopca).

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -201,7 +201,7 @@ S003,180.2,85.1,45,26.2,M,Treatment,3.8
 Use the GoPCA CLI to validate your data format:
 
 ```bash
-gopca-cli validate yourdata.csv
+pca validate yourdata.csv
 ```
 
 This will report:

--- a/docs/devel/release-guide.md
+++ b/docs/devel/release-guide.md
@@ -117,21 +117,21 @@ Check that:
 Each release includes:
 
 ### CLI Binaries (5 files)
-- `gopca-cli-darwin-amd64` - macOS Intel
-- `gopca-cli-darwin-arm64` - macOS Apple Silicon
-- `gopca-cli-linux-amd64` - Linux x64
-- `gopca-cli-linux-arm64` - Linux ARM64
-- `gopca-cli-windows-amd64.exe` - Windows x64
+- `pca-darwin-amd64` - macOS Intel
+- `pca-darwin-arm64` - macOS Apple Silicon
+- `pca-linux-amd64` - Linux x64
+- `pca-linux-arm64` - Linux ARM64
+- `pca-windows-amd64.exe` - Windows x64
 
 ### Desktop Applications (3 files)
-- `gopca-desktop-macos.zip` - macOS app (signed & notarized)
-- `gopca-desktop-windows.exe` - Windows executable
-- `gopca-desktop-linux` - Linux executable
+- `GoPCA-macos.zip` - macOS app (signed & notarized)
+- `GoPCA-windows.exe` - Windows executable
+- `GoPCA-linux` - Linux executable
 
 ### GoCSV Editor (3 files)
-- `gocsv-macos.zip` - macOS app (signed & notarized)
-- `gocsv-windows.exe` - Windows executable
-- `gocsv-linux` - Linux executable
+- `GoCSV-macos.zip` - macOS app (signed & notarized)
+- `GoCSV-windows.exe` - Windows executable
+- `GoCSV-linux` - Linux executable
 
 ### Verification
 - `checksums.txt` - SHA-256 checksums for all artifacts
@@ -218,13 +218,13 @@ If self-hosted runner is offline:
 
 Check the version using:
 ```bash
-gopca-cli --version  # Shows version number only (e.g., "0.9.0")
-gopca-cli version    # Shows detailed version information
+pca --version  # Shows version number only (e.g., "0.9.0")
+pca version    # Shows detailed version information
 ```
 
 Example output:
 ```
-$ gopca-cli version
+$ pca version
 GoPCA 0.9.0 (abc123) built on 2025-01-01T00:00:00Z with go1.24.5 for darwin/arm64
 ```
 

--- a/docs/intro_to_pca.md
+++ b/docs/intro_to_pca.md
@@ -304,11 +304,11 @@ The Swiss Roll dataset, included with GoPCA, perfectly demonstrates Kernel PCA's
 
 ```bash
 # Using CLI with RBF kernel
-gopca-cli analyze --method kernel --kernel-type rbf \
+pca analyze --method kernel --kernel-type rbf \
   --kernel-gamma 0.333 swiss_roll.csv
 
 # Compare with standard PCA
-gopca-cli analyze swiss_roll.csv  # SVD is the default method
+pca analyze swiss_roll.csv  # SVD is the default method
 ```
 
 In the GUI:

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -25,50 +25,50 @@ func analyzeCommand() *cli.Command {
 		Description: `The analyze command performs Principal Component Analysis on the input CSV file.
 
 USAGE:
-  gopca-cli analyze [OPTIONS] <input.csv>
+  pca analyze [OPTIONS] <input.csv>
 
   The input CSV file should be specified as the last argument.
   All options must come BEFORE the filename.
 
 EXAMPLES:
   # Basic analysis with default settings (2 components, table output)
-  gopca-cli analyze data/iris_data.csv
+  pca analyze data/iris_data.csv
 
   # Standard scaling with 3 components
-  gopca-cli analyze --scale standard -c 3 data/iris_data.csv
+  pca analyze --scale standard -c 3 data/iris_data.csv
 
   # JSON output with all results
-  gopca-cli analyze -f json --output-all data/iris_data.csv
+  pca analyze -f json --output-all data/iris_data.csv
 
   # JSON output to specific directory
-  gopca-cli analyze -f json -o results/ data/iris_data.csv
+  pca analyze -f json -o results/ data/iris_data.csv
 
   # Exclude specific rows and columns
-  gopca-cli analyze --exclude-rows 1,5-10 --exclude-cols 3,4 data/iris_data.csv
+  pca analyze --exclude-rows 1,5-10 --exclude-cols 3,4 data/iris_data.csv
 
   # Kernel PCA with RBF kernel
-  gopca-cli analyze --method kernel --kernel-type rbf --kernel-gamma 0.5 data/iris_data.csv
+  pca analyze --method kernel --kernel-type rbf --kernel-gamma 0.5 data/iris_data.csv
 
   # Kernel PCA with polynomial kernel
-  gopca-cli analyze --method kernel --kernel-type poly --kernel-degree 3 data/iris_data.csv
+  pca analyze --method kernel --kernel-type poly --kernel-degree 3 data/iris_data.csv
 
   # Apply SNV preprocessing (useful for spectral data)
-  gopca-cli analyze --snv --scale standard data/spectral_data.csv
+  pca analyze --snv --scale standard data/spectral_data.csv
 
   # Apply L2 vector normalization
-  gopca-cli analyze --vector-norm data/data.csv
+  pca analyze --vector-norm data/data.csv
 
   # Kernel PCA with variance scaling (divide by std dev, no mean centering)
-  gopca-cli analyze --method kernel --kernel-type rbf --scale-only data/data.csv
+  pca analyze --method kernel --kernel-type rbf --scale-only data/data.csv
 
   # Specify group column and calculate eigencorrelations
-  gopca-cli analyze --group-column sample_type --eigencorrelations -f json data/data.csv
+  pca analyze --group-column sample_type --eigencorrelations -f json data/data.csv
 
   # Include metadata columns for correlation analysis
-  gopca-cli analyze --metadata-cols age,weight --eigencorrelations -f json data/data.csv
+  pca analyze --metadata-cols age,weight --eigencorrelations -f json data/data.csv
 
   # Explicitly specify target columns (in addition to auto-detection)
-  gopca-cli analyze --target-columns concentration,pH --eigencorrelations -f json data/data.csv
+  pca analyze --target-columns concentration,pH --eigencorrelations -f json data/data.csv
 
 The analysis includes:
   - Data preprocessing (SNV, vector normalization, mean centering, scaling)

--- a/internal/cli/analyze_mixed_test.go
+++ b/internal/cli/analyze_mixed_test.go
@@ -36,7 +36,7 @@ B3,2.1,3.4,4.5,treatment,16.0`
 	// Run analyze command with eigencorrelations
 	app := NewApp()
 	err := app.Run([]string{
-		"gopca-cli",
+		"pca",
 		"analyze",
 		"-c", "2",
 		"--eigencorrelations",
@@ -141,7 +141,7 @@ S3,1.1,2.4,3.5,7.8`
 	// Run analyze command without specifying target columns
 	app := NewApp()
 	err := app.Run([]string{
-		"gopca-cli",
+		"pca",
 		"analyze",
 		"-c", "2",
 		"-f", "json",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	AppName = "gopca-cli"
+	AppName = "pca"
 )
 
 // NewApp creates and configures the CLI application
@@ -36,13 +36,13 @@ A focused, professional-grade tool that excels at one thing: PCA analysis.
 This CLI tool provides fast, scriptable PCA for power users and automation.
 
 QUICK START:
-  Analyze a CSV file:     gopca-cli analyze data.csv
-  With options:           gopca-cli analyze --scale standard -c 3 data.csv
-  Save results:           gopca-cli analyze -f json -o results/ data.csv
-  Validate data first:    gopca-cli validate data.csv
-  Apply saved model:      gopca-cli transform model.json new_data.csv
+  Analyze a CSV file:     pca analyze data.csv
+  With options:           pca analyze --scale standard -c 3 data.csv
+  Save results:           pca analyze -f json -o results/ data.csv
+  Validate data first:    pca validate data.csv
+  Apply saved model:      pca transform model.json new_data.csv
 
-For detailed help on any command, use: gopca-cli <command> --help`,
+For detailed help on any command, use: pca <command> --help`,
 		Commands: []*cli.Command{
 			analyzeCommand(),
 			validateCommand(),

--- a/internal/cli/transform.go
+++ b/internal/cli/transform.go
@@ -26,23 +26,23 @@ func transformCommand() *cli.Command {
 		Description: `The transform command applies a trained PCA model to new data.
 
 USAGE:
-  gopca-cli transform [OPTIONS] <model.json> <input.csv>
+  pca transform [OPTIONS] <model.json> <input.csv>
 
   The model JSON file and input CSV file must be specified as the last two arguments.
   All options must come BEFORE the filenames.
 
 EXAMPLES:
   # Basic transformation
-  gopca-cli transform model.json new_data.csv
+  pca transform model.json new_data.csv
 
   # Save results to specific file
-  gopca-cli transform -o transformed_scores.csv model.json new_data.csv
+  pca transform -o transformed_scores.csv model.json new_data.csv
 
   # JSON output format
-  gopca-cli transform -f json -o results/ model.json new_data.csv
+  pca transform -f json -o results/ model.json new_data.csv
 
   # Exclude specific rows from new data
-  gopca-cli transform --exclude-rows 1,5-10 model.json new_data.csv
+  pca transform --exclude-rows 1,5-10 model.json new_data.csv
 
 NOTES:
   - The new data must have the same number of features as the training data

--- a/internal/cli/transform_test.go
+++ b/internal/cli/transform_test.go
@@ -28,7 +28,7 @@ func TestTransformCommand(t *testing.T) {
 	// Run analyze to create model
 	app := NewApp()
 	err := app.Run([]string{
-		"gopca-cli", "analyze",
+		"pca", "analyze",
 		"-f", "json",
 		"-o", tempDir,
 		"../datasets/iris.csv",
@@ -53,7 +53,7 @@ func TestTransformCommand(t *testing.T) {
 		{
 			name: "basic transform table output",
 			args: []string{
-				"gopca-cli", "transform",
+				"pca", "transform",
 				modelFile,
 				"../datasets/iris.csv",
 			},
@@ -62,7 +62,7 @@ func TestTransformCommand(t *testing.T) {
 		{
 			name: "transform with JSON output",
 			args: []string{
-				"gopca-cli", "transform",
+				"pca", "transform",
 				"-f", "json",
 				"-o", tempDir,
 				modelFile,
@@ -105,7 +105,7 @@ func TestTransformCommand(t *testing.T) {
 		{
 			name: "transform with excluded rows",
 			args: []string{
-				"gopca-cli", "transform",
+				"pca", "transform",
 				"--exclude-rows", "1-10",
 				modelFile,
 				"../datasets/iris.csv",
@@ -115,7 +115,7 @@ func TestTransformCommand(t *testing.T) {
 		{
 			name: "missing model file",
 			args: []string{
-				"gopca-cli", "transform",
+				"pca", "transform",
 				"nonexistent.json",
 				"../datasets/iris.csv",
 			},
@@ -125,7 +125,7 @@ func TestTransformCommand(t *testing.T) {
 		{
 			name: "missing data file",
 			args: []string{
-				"gopca-cli", "transform",
+				"pca", "transform",
 				modelFile,
 				"nonexistent.csv",
 			},
@@ -162,7 +162,7 @@ func TestTransformScoresMatchOriginal(t *testing.T) {
 	// Create model
 	app := NewApp()
 	err := app.Run([]string{
-		"gopca-cli", "analyze",
+		"pca", "analyze",
 		"-f", "json",
 		"-o", tempDir,
 		"../datasets/iris.csv",
@@ -179,7 +179,7 @@ func TestTransformScoresMatchOriginal(t *testing.T) {
 
 	// Transform the same data
 	err = app.Run([]string{
-		"gopca-cli", "transform",
+		"pca", "transform",
 		"-f", "json",
 		"-o", tempDir,
 		filepath.Join(tempDir, "iris_pca.json"),
@@ -223,7 +223,7 @@ func TestTransformWithPreprocessing(t *testing.T) {
 	// Create model with standard scaling
 	app := NewApp()
 	err := app.Run([]string{
-		"gopca-cli", "analyze",
+		"pca", "analyze",
 		"--scale", "standard",
 		"-f", "json",
 		"-o", tempDir,
@@ -233,7 +233,7 @@ func TestTransformWithPreprocessing(t *testing.T) {
 
 	// Transform should apply the same preprocessing
 	err = app.Run([]string{
-		"gopca-cli", "transform",
+		"pca", "transform",
 		"-f", "json",
 		"-o", tempDir,
 		filepath.Join(tempDir, "iris_pca.json"),

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -22,17 +22,17 @@ func validateCommand() *cli.Command {
 		Description: `The validate command checks the input CSV file for common issues before PCA analysis.
 
 USAGE:
-  gopca-cli validate [OPTIONS] <input.csv>
+  pca validate [OPTIONS] <input.csv>
 
 EXAMPLES:
   # Basic validation
-  gopca-cli validate data/iris_data.csv
+  pca validate data/iris_data.csv
 
   # Show detailed summary
-  gopca-cli validate --summary data/iris_data.csv
+  pca validate --summary data/iris_data.csv
 
   # Strict mode (fail on warnings)
-  gopca-cli validate --strict data/iris_data.csv
+  pca validate --strict data/iris_data.csv
 
 The validation includes:
   - File format and structure


### PR DESCRIPTION
## Summary
Renames the built binaries to better match their product names and improve user experience.

## Changes
- **CLI**: `gopca-cli` → `pca` (simpler command, easier to type)
- **Desktop**: `gopca-desktop` → `GoPCA` (matches product branding)
- **CSV Editor**: `gocsv` → `GoCSV` (consistent capitalization)

## Implementation Details

### Build System
- Updated Makefile binary name variables
- Modified Wails configuration files (`name` and `outputfilename` fields)
- Both desktop apps now generate properly named executables and app bundles

### CI/CD Workflows
- Updated `.github/workflows/release.yml` for new artifact naming
- Updated `.github/workflows/build.yml` for build artifacts
- Release artifacts now use the new names (e.g., `pca-darwin-arm64`, `GoPCA-macos.zip`)

### Documentation
- Updated all CLI examples in README.md, docs/, and CLAUDE.md
- Modified CLI reference documentation
- Updated release guide with new artifact names

### Code Changes
- Changed `AppName` constant in CLI code
- Updated all help text and examples
- Modified test files to use new binary names

## Testing
- ✅ CLI builds and runs as `pca`
- ✅ Version command shows correct output
- ✅ All tests pass
- ✅ Desktop apps build with correct names
- ✅ Pre-commit hooks pass

## Release Impact
Future releases will have renamed artifacts:
- `pca-darwin-amd64` instead of `gopca-cli-darwin-amd64`
- `GoPCA-macos.zip` instead of `gopca-desktop-macos.zip`
- `GoCSV-windows.exe` instead of `gocsv-windows.exe`
- etc.

No migration guide needed as there are no existing users yet.

Closes #169