### PR TITLE
fix: update CI scripts to use new binary names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
       run: |
-        ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
+        ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
       shell: bash
     
     - name: Notarize desktop app (macOS)
@@ -219,7 +219,7 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/gopca-desktop.app
+        ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
       shell: bash
     
     - name: Upload desktop artifacts
@@ -297,7 +297,7 @@ jobs:
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
       run: |
-        ./scripts/ci/sign-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
+        ./scripts/ci/sign-macos-ci.sh cmd/gocsv/build/bin/GoCSV.app
       shell: bash
     
     - name: Notarize GoCSV app (macOS)
@@ -307,7 +307,7 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        ./scripts/ci/notarize-macos-ci.sh cmd/gocsv/build/bin/gocsv.app
+        ./scripts/ci/notarize-macos-ci.sh cmd/gocsv/build/bin/GoCSV.app
       shell: bash
     
     - name: Upload GoCSV artifacts

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -143,15 +143,15 @@ notarize_binary() {
 
 # Notarize CLI binary
 echo "🔧 Processing CLI binary..."
-notarize_binary "build/gopca-cli" "GoPCA CLI" false
+notarize_binary "build/pca" "GoPCA CLI" false
 
 # Notarize GoPCA Desktop app
 echo "🖥️  Processing GoPCA Desktop app..."
-notarize_binary "cmd/gopca-desktop/build/bin/gopca-desktop.app" "GoPCA Desktop" true
+notarize_binary "cmd/gopca-desktop/build/bin/GoPCA.app" "GoPCA Desktop" true
 
 # Notarize GoCSV app
 echo "📊 Processing GoCSV app..."
-notarize_binary "cmd/gocsv/build/bin/gocsv.app" "GoCSV" true
+notarize_binary "cmd/gocsv/build/bin/GoCSV.app" "GoCSV" true
 
 echo -e "${GREEN}✨ Notarization complete!${NC}"
 echo ""

--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -57,15 +57,15 @@ sign_binary() {
 
 # Sign CLI binary
 echo "📦 Signing CLI binary..."
-sign_binary "build/gopca-cli" "GoPCA CLI"
+sign_binary "build/pca" "GoPCA CLI"
 
 # Sign GoPCA Desktop app
 echo "📦 Signing GoPCA Desktop app..."
-sign_binary "cmd/gopca-desktop/build/bin/gopca-desktop.app" "GoPCA Desktop"
+sign_binary "cmd/gopca-desktop/build/bin/GoPCA.app" "GoPCA Desktop"
 
 # Sign GoCSV app
 echo "📦 Signing GoCSV app..."
-sign_binary "cmd/gocsv/build/bin/gocsv.app" "GoCSV"
+sign_binary "cmd/gocsv/build/bin/GoCSV.app" "GoCSV"
 
 echo -e "${GREEN}✨ All binaries signed successfully!${NC}"
 echo ""


### PR DESCRIPTION
## Summary
This PR completes the binary renaming work from #171 by updating the CI scripts to use the new binary names.

## Problem
PR #171 renamed the binaries but the CI workflow was still looking for the old binary names, causing macOS builds to fail with:
```
ERROR: Binary not found at: cmd/gopca-desktop/build/bin/gopca-desktop.app
```

## Changes
- Updated `.github/workflows/build.yml` to reference new binary names in signing/notarization steps
- Updated local scripts (`sign-macos.sh`, `notarize-macos.sh`) to use new binary names
- Fixed references from `gopca-desktop.app` → `GoPCA.app`
- Fixed references from `gocsv.app` → `GoCSV.app`
- Fixed references from `gopca-cli` → `pca`

## Testing
- Built both desktop and CLI locally to verify correct binary names are generated
- All CI builds should now pass on all platforms

Completes #169