### PR TITLE
Fix release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,7 @@ jobs:
     - name: Create signing status artifact
       if: always()
       run: |
-        if [ "${{ steps.check_signpath.outputs.configured }}" = "true" ]; then
+        if [ "${{ steps.check_signpath.outputs.configured }}" = "true" ] && [ "${{ steps.sign-cli.outcome }}" = "success" ]; then
           echo "signed" > signing-status.txt
         else
           echo "unsigned" > signing-status.txt
@@ -494,11 +494,14 @@ jobs:
           mv gocsv-ubuntu-latest/GoCSV GoCSV-linux
         fi
         
-        # Remove temporary directories
-        rm -rf pca-* gopca-desktop-* gocsv-* windows-signed signing-status unsigned-*
+        # Clean up - remove directories but keep files
+        find . -maxdepth 1 -type d -name "pca-*" -exec rm -rf {} \;
+        find . -maxdepth 1 -type d -name "gopca-desktop-*" -exec rm -rf {} \;
+        find . -maxdepth 1 -type d -name "gocsv-*" -exec rm -rf {} \;
+        rm -rf windows-signed signing-status unsigned-*
         
-        # Generate checksums
-        shasum -a 256 pca-* GoPCA* GoCSV* > checksums.txt
+        # Generate checksums (only for files that exist)
+        ls pca-* GoPCA* GoCSV* 2>/dev/null | xargs shasum -a 256 > checksums.txt
         
         # List all artifacts for debugging
         echo "Final artifacts:"


### PR DESCRIPTION
## Summary
- Fix signing status detection to check actual signing success
- Fix artifact organization to prevent file deletion
- Prevent checksum generation failure

## Problem
The v0.9.1 release workflow failed because:
1. Signing status was incorrectly set to 'signed' even when SignPath authentication failed
2. The cleanup step was removing binary files along with directories
3. Checksum generation failed on missing files

## Solution
- Check both SignPath configuration AND signing success before marking as 'signed'
- Use find to remove only directories, not files
- Handle missing files gracefully in checksum generation

## Testing
After merging this fix, we can retry the v0.9.1 release.