### PR TITLE
chore: prepare release v0.9.3

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.2",
+    "productVersion": "0.9.3",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.2",
+    "productVersion": "0.9.3",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
## Release v0.9.3

Preparing release v0.9.3 with important fixes:

### Key Changes
- Fixed macOS app bundle permissions in release workflow (#178)
- Changed `cp -r` to `cp -a` to preserve executable permissions
- This resolves the issue where macOS apps showed "cannot be opened" error

### Testing
- Locally verified that `cp -a` preserves executable permissions
- Tested zip/unzip workflow to ensure permissions are maintained

This release will be the first with properly packaged macOS applications in the platform bundles.

---
*Automated release preparation*