### PR TITLE
feat: add row labels to plots and redesign control area

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1097,6 +1097,7 @@ function AppContent() {
                                             pcaResult={pcaResponse.result}
                                             xComponent={selectedXComponent}
                                             yComponent={selectedYComponent}
+                                            threshold={guiConfig?.visualization?.correlation_threshold || 0.3}
                                             maxVariables={guiConfig?.visualization?.circle_max_variables || 100}
                                         />
                                     ) : selectedPlot === 'diagnostics' ? (

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -40,6 +40,8 @@ function AppContent() {
     const [selectedGroupColumn, setSelectedGroupColumn] = useState<string | null>(null);
     const [showEllipses, setShowEllipses] = useState(false);
     const [confidenceLevel, setConfidenceLevel] = useState<0.90 | 0.95 | 0.99>(0.95);
+    const [showRowLabels, setShowRowLabels] = useState(false);
+    const [maxLabelsToShow, setMaxLabelsToShow] = useState(10);
     const [showDocumentation, setShowDocumentation] = useState(false);
     const [datasetId, setDatasetId] = useState(0); // Force DataTable re-render on dataset change
     
@@ -834,14 +836,45 @@ function AppContent() {
                             
                             {/* Plot Selector and Visualization */}
                             <div className="mt-6">
-                                <div className="flex items-center justify-between mb-4">
-                                    <h3 className="text-lg font-semibold">Visualizations</h3>
+                                {/* Tier 1: Primary Controls */}
+                                <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200 dark:border-gray-600">
                                     <div className="flex items-center gap-4">
-                                        {/* Group selection for color coding */}
+                                        <h3 className="text-lg font-semibold">Visualizations</h3>
+                                        <HelpWrapper helpKey={`${selectedPlot}-plot`}>
+                                            <select
+                                                value={selectedPlot}
+                                                onChange={(e) => setSelectedPlot(e.target.value as 'scores' | 'scree' | 'loadings' | 'biplot' | 'correlations' | 'diagnostics' | 'eigencorrelation')}
+                                                className="px-3 py-1.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white font-medium"
+                                            >
+                                                <option value="scores">Scores Plot</option>
+                                                <option value="scree">Scree Plot</option>
+                                                <option value="loadings">Loadings Plot</option>
+                                                {pcaResponse.result.preprocessing_applied && (
+                                                    <option value="biplot">Biplot</option>
+                                                )}
+                                                {pcaResponse.result.preprocessing_applied && (
+                                                    <option value="correlations">Circle of Correlations</option>
+                                                )}
+                                                <option value="diagnostics">Diagnostic Plot</option>
+                                                {pcaResponse.result.eigencorrelations && (
+                                                    <option value="eigencorrelation">Eigencorrelation Plot</option>
+                                                )}
+                                            </select>
+                                        </HelpWrapper>
+                                    </div>
+                                    {selectedGroupColumn && (
+                                        <PaletteSelector />
+                                    )}
+                                </div>
+                                
+                                {/* Tier 2: Context-Sensitive Controls */}
+                                <div className="mb-4">
+                                    <div className="flex flex-wrap items-center gap-4">
+                                        {/* Data Display Group */}
                                         {(selectedPlot === 'scores' || selectedPlot === 'biplot') && fileData && 
                                          ((fileData.categoricalColumns && Object.keys(fileData.categoricalColumns).length > 0) ||
                                           (fileData.numericTargetColumns && Object.keys(fileData.numericTargetColumns).length > 0)) && (
-                                            <>
+                                            <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
                                                 <HelpWrapper helpKey="group-coloring" className="flex items-center gap-2">
                                                     <label className="text-sm text-gray-600 dark:text-gray-400">Color by:</label>
                                                     <select
@@ -887,15 +920,43 @@ function AppContent() {
                                                         )}
                                                     </select>
                                                 </HelpWrapper>
-                                                {selectedGroupColumn && (
-                                                    <PaletteSelector />
+                                            </div>
+                                        )}
+                                        
+                                        {/* Plot Options Group - For Scores Plot, Biplot, and Diagnostic Plot */}
+                                        {(selectedPlot === 'scores' || selectedPlot === 'biplot' || selectedPlot === 'diagnostics') && (
+                                            <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                                                <HelpWrapper helpKey="row-labels" className="flex items-center gap-2">
+                                                    <label className="text-sm text-gray-600 dark:text-gray-400">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={showRowLabels}
+                                                            onChange={(e) => setShowRowLabels(e.target.checked)}
+                                                            className="mr-1"
+                                                        />
+                                                        Show labels
+                                                    </label>
+                                                </HelpWrapper>
+                                                {showRowLabels && (
+                                                    <div className="flex items-center gap-2">
+                                                        <label className="text-sm text-gray-600 dark:text-gray-400">Max:</label>
+                                                        <input
+                                                            type="number"
+                                                            min="5"
+                                                            max="50"
+                                                            value={maxLabelsToShow}
+                                                            onChange={(e) => setMaxLabelsToShow(parseInt(e.target.value) || 10)}
+                                                            className="w-12 px-1 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
+                                                        />
+                                                    </div>
                                                 )}
-                                                {selectedPlot === 'scores' && 
-                                                 fileData.categoricalColumns && 
+                                                {fileData?.categoricalColumns && 
                                                  Object.keys(fileData.categoricalColumns).length > 0 && 
                                                  selectedGroupColumn && 
-                                                 getColumnData(selectedGroupColumn).type === 'categorical' && (
+                                                 getColumnData(selectedGroupColumn).type === 'categorical' && 
+                                                 (selectedPlot === 'scores' || selectedPlot === 'biplot') && (
                                                     <>
+                                                        <div className="w-px h-5 bg-gray-300 dark:bg-gray-600 mx-1" />
                                                         <HelpWrapper helpKey="confidence-ellipses" className="flex items-center gap-2">
                                                             <label className="text-sm text-gray-600 dark:text-gray-400">
                                                                 <input
@@ -904,35 +965,34 @@ function AppContent() {
                                                                     onChange={(e) => setShowEllipses(e.target.checked)}
                                                                     className="mr-1"
                                                                 />
-                                                                Confidence ellipses
+                                                                Ellipses
                                                             </label>
                                                         </HelpWrapper>
                                                         {showEllipses && (
-                                                            <div className="flex items-center gap-2">
-                                                                <label className="text-sm text-gray-600 dark:text-gray-400">Level:</label>
-                                                                <select
-                                                                    value={confidenceLevel}
-                                                                    onChange={(e) => setConfidenceLevel(parseFloat(e.target.value) as 0.90 | 0.95 | 0.99)}
-                                                                    className="px-2 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
-                                                                >
-                                                                    <option value="0.90">90%</option>
-                                                                    <option value="0.95">95%</option>
-                                                                    <option value="0.99">99%</option>
-                                                                </select>
-                                                            </div>
+                                                            <select
+                                                                value={confidenceLevel}
+                                                                onChange={(e) => setConfidenceLevel(parseFloat(e.target.value) as 0.90 | 0.95 | 0.99)}
+                                                                className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
+                                                            >
+                                                                <option value="0.90">90%</option>
+                                                                <option value="0.95">95%</option>
+                                                                <option value="0.99">99%</option>
+                                                            </select>
                                                         )}
                                                     </>
                                                 )}
-                                            </>
+                                            </div>
                                         )}
+                                        
+                                        {/* Component Selectors Group */}
                                         {(selectedPlot === 'scores' || selectedPlot === 'biplot' || selectedPlot === 'correlations') && pcaResponse.result.scores[0]?.length > 2 && (
-                                            <>
-                                                <HelpWrapper helpKey="component-selector" className="flex items-center gap-2">
-                                                    <label className="text-sm text-gray-600 dark:text-gray-400">X-axis:</label>
+                                            <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                                                <div className="flex items-center gap-2">
+                                                    <label className="text-sm text-gray-600 dark:text-gray-400">X:</label>
                                                     <select
                                                         value={selectedXComponent}
                                                         onChange={(e) => setSelectedXComponent(parseInt(e.target.value))}
-                                                        className="px-2 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
+                                                        className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
                                                     >
                                                         {pcaResponse.result.component_labels?.map((label, i) => (
                                                             <option key={i} value={i}>
@@ -940,13 +1000,13 @@ function AppContent() {
                                                             </option>
                                                         ))}
                                                     </select>
-                                                </HelpWrapper>
-                                                <HelpWrapper helpKey="component-selector" className="flex items-center gap-2">
-                                                    <label className="text-sm text-gray-600 dark:text-gray-400">Y-axis:</label>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <label className="text-sm text-gray-600 dark:text-gray-400">Y:</label>
                                                     <select
                                                         value={selectedYComponent}
                                                         onChange={(e) => setSelectedYComponent(parseInt(e.target.value))}
-                                                        className="px-2 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
+                                                        className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-white"
                                                     >
                                                         {pcaResponse.result.component_labels?.map((label, i) => (
                                                             <option key={i} value={i}>
@@ -954,11 +1014,13 @@ function AppContent() {
                                                             </option>
                                                         ))}
                                                     </select>
-                                                </HelpWrapper>
-                                            </>
+                                                </div>
+                                            </div>
                                         )}
+                                        
+                                        {/* Loadings Plot Component Selector */}
                                         {selectedPlot === 'loadings' && (
-                                            <div className="flex items-center gap-2">
+                                            <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
                                                 <label className="text-sm text-gray-600 dark:text-gray-400">Component:</label>
                                                 <select
                                                     value={selectedLoadingComponent}
@@ -973,21 +1035,6 @@ function AppContent() {
                                                 </select>
                                             </div>
                                         )}
-                                        <HelpWrapper helpKey={`${selectedPlot}-plot`}>
-                                            <select
-                                                value={selectedPlot}
-                                                onChange={(e) => setSelectedPlot(e.target.value as 'scores' | 'scree' | 'loadings' | 'biplot' | 'correlations' | 'diagnostics' | 'eigencorrelation')}
-                                                className="px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
-                                            >
-                                                <option value="scores">Scores Plot</option>
-                                                <option value="scree">Scree Plot</option>
-                                                <option value="loadings">Loadings Plot</option>
-                                                <option value="biplot">Biplot</option>
-                                                <option value="correlations">Circle of Correlations</option>
-                                                <option value="diagnostics">Diagnostics (Mahalanobis vs RSS)</option>
-                                                <option value="eigencorrelation">Eigencorrelation Plot</option>
-                                            </select>
-                                        </HelpWrapper>
                                     </div>
                                 </div>
                                 
@@ -1009,6 +1056,8 @@ function AppContent() {
                                             }
                                             showEllipses={showEllipses && !!selectedGroupColumn && getColumnData(selectedGroupColumn).type === 'categorical'}
                                             confidenceLevel={confidenceLevel}
+                                            showRowLabels={showRowLabels}
+                                            maxLabelsToShow={maxLabelsToShow}
                                         />
                                     ) : selectedPlot === 'scree' ? (
                                         <ScreePlot
@@ -1028,10 +1077,19 @@ function AppContent() {
                                             rowNames={fileData?.rowNames || []}
                                             xComponent={selectedXComponent}
                                             yComponent={selectedYComponent}
+                                            showRowLabels={showRowLabels}
+                                            maxRowLabelsToShow={maxLabelsToShow}
                                             groupColumn={selectedGroupColumn}
                                             groupLabels={getColumnData(selectedGroupColumn).type === 'categorical' ? getColumnData(selectedGroupColumn).values as string[] : undefined}
                                             groupValues={getColumnData(selectedGroupColumn).type === 'continuous' ? getColumnData(selectedGroupColumn).values as number[] : undefined}
                                             groupType={getColumnData(selectedGroupColumn).type}
+                                            groupEllipses={
+                                                confidenceLevel === 0.90 ? pcaResponse.groupEllipses90 :
+                                                confidenceLevel === 0.95 ? pcaResponse.groupEllipses95 :
+                                                pcaResponse.groupEllipses99
+                                            }
+                                            showEllipses={showEllipses && !!selectedGroupColumn && getColumnData(selectedGroupColumn).type === 'categorical'}
+                                            confidenceLevel={confidenceLevel}
                                             maxVariables={guiConfig?.visualization?.biplot_max_variables || 100}
                                         />
                                     ) : selectedPlot === 'correlations' ? (
@@ -1045,6 +1103,8 @@ function AppContent() {
                                         <DiagnosticScatterPlot
                                             pcaResult={pcaResponse.result}
                                             rowNames={fileData?.rowNames || []}
+                                            showRowLabels={showRowLabels}
+                                            maxRowLabelsToShow={maxLabelsToShow}
                                         />
                                     ) : selectedPlot === 'eigencorrelation' ? (
                                         <EigencorrelationPlot

--- a/cmd/gopca-desktop/frontend/src/components/CustomPointWithLabel.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/CustomPointWithLabel.tsx
@@ -1,0 +1,77 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+import React from 'react';
+import { getLabelPosition } from '../utils/labelUtils';
+
+/**
+ * Reusable custom dot component that can render labels
+ * Used in ScoresPlot, Biplot, and DiagnosticScatterPlot
+ * Follows DRY principle - single implementation for all plots
+ */
+interface CustomPointWithLabelProps {
+  cx?: number;
+  cy?: number;
+  payload?: any;
+  topPoints: Set<number>;
+  hoveredPoint: number | null;
+  showLabels: boolean;
+  onMouseEnter: (index: number) => void;
+  onMouseLeave: () => void;
+  chartTheme: any;
+  fontSize?: number;
+}
+
+export const CustomPointWithLabel: React.FC<CustomPointWithLabelProps> = ({
+  cx = 0,
+  cy = 0,
+  payload,
+  topPoints,
+  hoveredPoint,
+  showLabels,
+  onMouseEnter,
+  onMouseLeave,
+  chartTheme,
+  fontSize = 11
+}) => {
+  if (!payload) return null;
+  
+  const isTopPoint = topPoints.has(payload.index);
+  const isHovered = hoveredPoint === payload.index;
+  const shouldShowLabel = showLabels && (isTopPoint || isHovered);
+  
+  // Get label position based on quadrant
+  const { textAnchor, dx, dy } = getLabelPosition(payload.x, payload.y);
+  
+  return (
+    <g>
+      <circle
+        cx={cx}
+        cy={cy}
+        r={4}
+        fill={payload.color || '#3B82F6'}
+        fillOpacity={0.8}
+        stroke={payload.color || '#1E40AF'}
+        strokeWidth={1}
+        onMouseEnter={() => onMouseEnter(payload.index)}
+        onMouseLeave={onMouseLeave}
+        style={{ cursor: 'pointer' }}
+      />
+      {shouldShowLabel && (
+        <text
+          x={cx + dx}
+          y={cy + dy}
+          fill={chartTheme.textColor}
+          fontSize={fontSize}
+          fontWeight={isHovered ? '600' : '400'}
+          textAnchor={textAnchor}
+          dominantBaseline="middle"
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          {payload.name}
+        </text>
+      )}
+    </g>
+  );
+};

--- a/cmd/gopca-desktop/frontend/src/components/EllipseOverlay.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/EllipseOverlay.tsx
@@ -1,0 +1,67 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+import React, { useMemo } from 'react';
+import { EllipseParams } from '../types';
+import { generateEllipsePoints, createScale, pointsToPath } from '../utils/ellipseUtils';
+
+/**
+ * Reusable component for rendering confidence ellipses as an SVG overlay
+ * Used in ScoresPlot and Biplot
+ * Follows DRY principle - single implementation for all plots with ellipses
+ */
+interface EllipseOverlayProps {
+  groupEllipses: Record<string, EllipseParams>;
+  groupColorMap: Map<string, string>;
+  xDomain: [number, number];
+  yDomain: [number, number];
+  containerSize: { width: number; height: number };
+  margins?: { top: number; right: number; bottom: number; left: number };
+}
+
+export const EllipseOverlay: React.FC<EllipseOverlayProps> = ({
+  groupEllipses,
+  groupColorMap,
+  xDomain,
+  yDomain,
+  containerSize,
+  margins = { top: 20, right: 20, bottom: 60, left: 80 }
+}) => {
+  // Calculate scale functions
+  const { xScale, yScale } = useMemo(() => {
+    const plotWidth = containerSize.width - margins.left - margins.right;
+    const plotHeight = containerSize.height - margins.top - margins.bottom;
+    
+    return {
+      xScale: createScale(xDomain, plotWidth, margins.left, false),
+      yScale: createScale(yDomain, plotHeight, margins.top, true) // Y is inverted in SVG
+    };
+  }, [xDomain, yDomain, containerSize, margins]);
+  
+  return (
+    <svg 
+      className="absolute inset-0 pointer-events-none" 
+      style={{ width: '100%', height: '100%' }}
+    >
+      {Object.entries(groupEllipses).map(([group, ellipse]) => {
+        const color = groupColorMap.get(group) || '#888888';
+        const points = generateEllipsePoints(ellipse);
+        const pathData = pointsToPath(points, xScale, yScale);
+        
+        return (
+          <path
+            key={`ellipse-${group}`}
+            d={pathData}
+            fill={color}
+            fillOpacity={0.1}
+            stroke={color}
+            strokeWidth={2}
+            strokeOpacity={0.8}
+            strokeDasharray="5,5"
+          />
+        );
+      })}
+    </svg>
+  );
+};

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -246,9 +246,10 @@ export const Biplot: React.FC<BiplotProps> = ({
     : allLoadingsData;
 
   // Sort loadings by magnitude and get top N for labeling
+  // Show all labels for small datasets, otherwise show top 15
   const topLoadings = [...loadingsData]
     .sort((a, b) => b.magnitude - a.magnitude)
-    .slice(0, 8); // Show labels for top 8 variables
+    .slice(0, loadingsData.length <= 20 ? loadingsData.length : 15);
 
   // Set symmetric axis ranges based on plot bounds
   const axisRange = plotMax;
@@ -389,45 +390,6 @@ export const Biplot: React.FC<BiplotProps> = ({
       fontSize={10}
     />
   ), [topPoints, hoveredPoint, showRowLabels, chartTheme]);
-
-  // Custom shape to draw loading arrows from origin
-  const LoadingArrows = () => {
-    return (
-      <g>
-        {loadingsData.map(loading => {
-          const isHovered = hoveredVariable === loading.index;
-          const angle = Math.atan2(loading.y, loading.x);
-          const arrowLength = 0.3;
-          const arrowAngle = 0.4;
-          
-          // Calculate arrow head points
-          const headX1 = loading.x - arrowLength * Math.cos(angle - arrowAngle);
-          const headY1 = loading.y - arrowLength * Math.sin(angle - arrowAngle);
-          const headX2 = loading.x - arrowLength * Math.cos(angle + arrowAngle);
-          const headY2 = loading.y - arrowLength * Math.sin(angle + arrowAngle);
-          
-          return (
-            <g key={`arrow-${loading.index}`}>
-              <line
-                x1={0}
-                y1={0}
-                x2={loading.x}
-                y2={loading.y}
-                stroke={isHovered ? "#EF4444" : "#10B981"}
-                strokeWidth={isHovered ? 3 : 2}
-                onMouseEnter={() => setHoveredVariable(loading.index)}
-                onMouseLeave={() => setHoveredVariable(null)}
-              />
-              <path
-                d={`M ${loading.x} ${loading.y} L ${headX1} ${headY1} L ${headX2} ${headY2} Z`}
-                fill={isHovered ? "#EF4444" : "#10B981"}
-              />
-            </g>
-          );
-        })}
-      </g>
-    );
-  };
 
   // Custom tooltip
   const CustomTooltip = ({ active, payload }: TooltipProps) => {

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -16,13 +16,17 @@ import {
   ReferenceLine,
   Cell
 } from 'recharts';
-import { PCAResult } from '../../types';
+import { PCAResult, EllipseParams } from '../../types';
 import { TooltipProps, LoadingEndpointProps } from '../../types/recharts';
 import { ExportButton } from '../ExportButton';
 import { PlotControls } from '../PlotControls';
+import { CustomPointWithLabel } from '../CustomPointWithLabel';
+import { calculateTopPoints } from '../../utils/labelUtils';
 import { useZoomPan } from '../../hooks/useZoomPan';
 import { useChartTheme } from '../../hooks/useChartTheme';
 import { usePalette } from '../../contexts/PaletteContext';
+import { useEllipses } from '../../hooks/useEllipses';
+import { EllipseOverlay } from '../EllipseOverlay';
 import { getQualitativeColor, getSequentialColor, createQualitativeColorMap, getSequentialColorScale } from '../../utils/colorPalettes';
 
 interface BiplotProps {
@@ -31,10 +35,15 @@ interface BiplotProps {
   xComponent?: number; // 0-based index
   yComponent?: number; // 0-based index
   showLoadingLabels?: boolean;
+  showRowLabels?: boolean;
+  maxRowLabelsToShow?: number;
   groupColumn?: string | null;
   groupLabels?: string[];
   groupValues?: number[]; // For continuous columns
   groupType?: 'categorical' | 'continuous';
+  groupEllipses?: Record<string, EllipseParams>;
+  showEllipses?: boolean;
+  confidenceLevel?: 0.90 | 0.95 | 0.99;
   maxVariables?: number; // Maximum number of variables to display
 }
 
@@ -44,18 +53,25 @@ export const Biplot: React.FC<BiplotProps> = ({
   xComponent = 0, 
   yComponent = 1,
   showLoadingLabels = true,
+  showRowLabels = false,
+  maxRowLabelsToShow = 10,
   groupColumn,
   groupLabels,
   groupValues,
   groupType = 'categorical',
+  groupEllipses,
+  showEllipses = false,
+  confidenceLevel = 0.95,
   maxVariables = 100
 }) => {
   const [hoveredVariable, setHoveredVariable] = useState<number | null>(null);
+  const [hoveredPoint, setHoveredPoint] = useState<number | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const fullscreenRef = useRef<HTMLDivElement>(null);
   
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
   const chartTheme = useChartTheme();
   const { mode, qualitativePalette, sequentialPalette } = usePalette();
   
@@ -75,6 +91,31 @@ export const Biplot: React.FC<BiplotProps> = ({
     }
     return null;
   }, [groupLabels, groupColumn, qualitativePalette, groupType]);
+  
+  // Calculate ellipses dynamically if not provided
+  const shouldCalculateEllipses = !!(showEllipses && groupType === 'categorical' && groupLabels && !groupEllipses);
+  const { 
+    ellipses90: dynamicEllipses90,
+    ellipses95: dynamicEllipses95,
+    ellipses99: dynamicEllipses99,
+    isLoading: ellipsesLoading,
+    error: ellipsesError
+  } = useEllipses({
+    scores: pcaResult.scores,
+    groupLabels: groupLabels || [],
+    xComponent,
+    yComponent,
+    enabled: shouldCalculateEllipses
+  });
+  
+  // Use provided ellipses or dynamically calculated ones based on confidence level
+  const effectiveGroupEllipses = groupEllipses || 
+    (showEllipses && (
+      confidenceLevel === 0.90 ? dynamicEllipses90 :
+      confidenceLevel === 0.95 ? dynamicEllipses95 :
+      dynamicEllipses99
+    )) || 
+    undefined;
   
   // Calculate min/max for continuous values
   const continuousRange = useMemo(() => {
@@ -128,9 +169,16 @@ export const Biplot: React.FC<BiplotProps> = ({
       type: 'score',
       group: group,
       color: color,
-      value: value
+      value: value,
+      index: index
     };
   });
+
+  // Calculate top points for labeling using shared utility
+  const topPoints = useMemo(() => 
+    calculateTopPoints(scoresData as Array<{ x: number; y: number; index: number }>, showRowLabels, maxRowLabelsToShow),
+    [scoresData, showRowLabels, maxRowLabelsToShow]
+  );
 
   // Calculate scores range for plot bounds
   const scoreXValues = scoresData.map(d => d.x);
@@ -258,6 +306,26 @@ export const Biplot: React.FC<BiplotProps> = ({
       document.removeEventListener('webkitfullscreenchange', handleFullscreenChange);
     };
   }, []);
+  
+  // Update container size on resize
+  React.useEffect(() => {
+    if (!containerRef.current) return;
+    
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerSize({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height
+        });
+      }
+    });
+    
+    resizeObserver.observe(containerRef.current);
+    
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   // Get variance percentages for axis labels
   const xVariance = pcaResult.explained_variance_ratio[xComponent]?.toFixed(1) || '0';
@@ -307,6 +375,20 @@ export const Biplot: React.FC<BiplotProps> = ({
     ...loading,
     isLoadingEnd: true
   }));
+
+  // Create custom dot using shared component
+  const CustomScoreDot = useCallback((props: any) => (
+    <CustomPointWithLabel
+      {...props}
+      topPoints={topPoints}
+      hoveredPoint={hoveredPoint}
+      showLabels={showRowLabels}
+      onMouseEnter={setHoveredPoint}
+      onMouseLeave={() => setHoveredPoint(null)}
+      chartTheme={chartTheme}
+      fontSize={10}
+    />
+  ), [topPoints, hoveredPoint, showRowLabels, chartTheme]);
 
   // Custom shape to draw loading arrows from origin
   const LoadingArrows = () => {
@@ -463,13 +545,37 @@ export const Biplot: React.FC<BiplotProps> = ({
       
       <div 
         ref={containerRef} 
-        className={`w-full ${isZoomed ? (isPanning ? 'cursor-grabbing' : 'cursor-grab') : ''}`}
+        className={`w-full relative ${isZoomed ? (isPanning ? 'cursor-grabbing' : 'cursor-grab') : ''}`}
         style={{ height: isFullscreen ? 'calc(100vh - 80px)' : 'calc(100% - 40px)' }}
         onMouseDown={handlePanStart}
         onMouseMove={handlePanMove}
         onMouseUp={handlePanEnd}
         onMouseLeave={handlePanEnd}
       >
+        {/* Show ellipse error if any */}
+        {showEllipses && ellipsesError && (
+          <div className="absolute top-2 left-2 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-200 px-3 py-1 rounded text-sm z-10">
+            {ellipsesError}
+          </div>
+        )}
+        
+        {/* Show loading indicator for ellipses */}
+        {showEllipses && ellipsesLoading && (
+          <div className="absolute top-2 left-2 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200 px-3 py-1 rounded text-sm z-10">
+            Calculating ellipses...
+          </div>
+        )}
+        
+        {/* SVG Overlay for confidence ellipses */}
+        {showEllipses && effectiveGroupEllipses && groupColorMap && !ellipsesError && (
+          <EllipseOverlay
+            groupEllipses={effectiveGroupEllipses}
+            groupColorMap={groupColorMap}
+            xDomain={zoomDomain.x || defaultDomain}
+            yDomain={zoomDomain.y || defaultDomain}
+            containerSize={containerSize}
+          />
+        )}
         <ResponsiveContainer width="100%" height="100%">
         <ScatterChart
           margin={{ top: 20, right: 20, bottom: 60, left: 80 }}
@@ -539,8 +645,9 @@ export const Biplot: React.FC<BiplotProps> = ({
             fillOpacity={0.8}
             strokeWidth={1}
             stroke="#1E40AF"
+            shape={showRowLabels ? <CustomScoreDot /> : 'circle'}
           >
-            {groupColumn ? (
+            {!showRowLabels && groupColumn ? (
               scoresData.map((entry, index) => {
                 const fillColor = entry?.color || '#3B82F6';
                 return (

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
@@ -4,7 +4,7 @@
 // The author respectfully requests that it not be used for
 // military, warfare, or surveillance applications.
 
-import React, { useRef, useState, useCallback, useEffect } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import { PCAResult } from '../../types';
 import { ExportButton } from '../ExportButton';
@@ -268,8 +268,8 @@ export const CircleOfCorrelations: React.FC<CircleOfCorrelationsProps> = ({
                   </marker>
                 </defs>
                 
-                {/* Variable label (only for significant loadings) */}
-                {loading.magnitude > threshold && (
+                {/* Variable label - show all for small datasets, filter by threshold for large ones */}
+                {(loadings.length <= 20 || loading.magnitude > threshold) && (
                   <text
                     x={endX}
                     y={endY}

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
@@ -189,7 +189,7 @@ export const LoadingsPlot: React.FC<LoadingsPlotProps> = ({
               angle={-45}
               textAnchor="end"
               height={60}
-              interval={numVariables <= 20 ? 0 : 'preserveStartEnd'}
+              interval={numVariables <= 30 ? 0 : Math.ceil(numVariables / 20)}
             />
             
             <YAxis 

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
@@ -95,16 +95,13 @@ export const ScoresPlot: React.FC<ScoresPlotProps> = ({
   const continuousRange = useMemo(() => {
     if (groupType === 'continuous' && groupValues) {
       const validValues = groupValues.filter(v => v !== null && v !== undefined && !isNaN(v) && isFinite(v));
-      console.log(`Continuous values - Total: ${groupValues.length}, Valid: ${validValues.length}`);
       if (validValues.length > 0) {
         const range = {
           min: Math.min(...validValues),
           max: Math.max(...validValues)
         };
-        console.log(`Range: min=${range.min}, max=${range.max}`);
         return range;
       }
-      console.log('No valid values found for continuous range');
     }
     return null;
   }, [groupValues, groupType]);

--- a/cmd/gopca-desktop/frontend/src/utils/ellipseUtils.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/ellipseUtils.ts
@@ -1,0 +1,85 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+/**
+ * Utility functions for ellipse rendering in plots
+ * Follows DRY principle - shared across ScoresPlot and Biplot
+ */
+
+import { EllipseParams } from '../types';
+
+/**
+ * Generate SVG path points for an ellipse
+ * @param ellipse Ellipse parameters (center, axes, angle)
+ * @param steps Number of points to generate (default 50)
+ * @returns Array of {x, y} points forming the ellipse path
+ */
+export function generateEllipsePoints(ellipse: EllipseParams, steps: number = 50): Array<{ x: number; y: number }> {
+  const { centerX, centerY, majorAxis, minorAxis, angle } = ellipse;
+  const points = [];
+  
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * 2 * Math.PI;
+    // Ellipse in local coordinates
+    const x = majorAxis * Math.cos(t);
+    const y = minorAxis * Math.sin(t);
+    
+    // Apply rotation
+    const rotatedX = x * Math.cos(angle) - y * Math.sin(angle);
+    const rotatedY = x * Math.sin(angle) + y * Math.cos(angle);
+    
+    // Translate to center
+    points.push({
+      x: centerX + rotatedX,
+      y: centerY + rotatedY
+    });
+  }
+  
+  return points;
+}
+
+/**
+ * Create scale functions to convert data coordinates to pixel coordinates
+ * @param domain Current domain [min, max]
+ * @param range Pixel range (width or height minus margins)
+ * @param margin Leading margin (left for X, top for Y)
+ * @param inverted Whether to invert the scale (true for Y axis in SVG)
+ * @returns Scale function that converts data value to pixel coordinate
+ */
+export function createScale(
+  domain: [number, number],
+  range: number,
+  margin: number,
+  inverted: boolean = false
+): (value: number) => number {
+  return (value: number) => {
+    const ratio = (value - domain[0]) / (domain[1] - domain[0]);
+    if (inverted) {
+      return margin + range - ratio * range;
+    } else {
+      return margin + ratio * range;
+    }
+  };
+}
+
+/**
+ * Convert ellipse points to SVG path data string
+ * @param points Array of {x, y} points
+ * @param xScale Scale function for X coordinates
+ * @param yScale Scale function for Y coordinates
+ * @returns SVG path data string
+ */
+export function pointsToPath(
+  points: Array<{ x: number; y: number }>,
+  xScale: (value: number) => number,
+  yScale: (value: number) => number
+): string {
+  return points
+    .map((point, index) => {
+      const x = xScale(point.x);
+      const y = yScale(point.y);
+      return index === 0 ? `M ${x} ${y}` : `L ${x} ${y}`;
+    })
+    .join(' ') + ' Z';
+}

--- a/cmd/gopca-desktop/frontend/src/utils/labelUtils.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/labelUtils.ts
@@ -1,0 +1,67 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+/**
+ * Utility functions for label display in plots
+ * Follows DRY principle - shared across ScoresPlot, Biplot, and DiagnosticScatterPlot
+ */
+
+/**
+ * Calculate which points should have labels based on distance from origin
+ * @param data Array of points with x, y coordinates and index
+ * @param showLabels Whether labels should be shown at all
+ * @param maxLabels Maximum number of labels to show
+ * @returns Set of indices for points that should have labels
+ */
+export function calculateTopPoints(
+  data: Array<{ x: number; y: number; index: number }>,
+  showLabels: boolean,
+  maxLabels: number
+): Set<number> {
+  if (!showLabels) return new Set<number>();
+  
+  const pointsWithDistance = data.map(point => ({
+    index: point.index,
+    distance: Math.sqrt(point.x ** 2 + point.y ** 2)
+  }));
+  
+  // Sort by distance and get top N
+  const topIndices = pointsWithDistance
+    .sort((a, b) => b.distance - a.distance)
+    .slice(0, maxLabels)
+    .map(p => p.index);
+  
+  return new Set(topIndices);
+}
+
+/**
+ * Determine label position based on point quadrant to avoid overlaps
+ * @param x X coordinate of the point
+ * @param y Y coordinate of the point
+ * @returns Object with textAnchor, dx, and dy values for label positioning
+ */
+export function getLabelPosition(x: number, y: number): {
+  textAnchor: 'start' | 'end' | 'middle';
+  dx: number;
+  dy: number;
+} {
+  let textAnchor: 'start' | 'end' | 'middle' = 'start';
+  let dx = 8;
+  let dy = 0;
+  
+  // Adjust horizontal position based on x coordinate
+  if (x < 0) {
+    textAnchor = 'end';
+    dx = -8;
+  }
+  
+  // Adjust vertical position based on y coordinate
+  if (y < 0) {
+    dy = 12;
+  } else {
+    dy = -5;
+  }
+  
+  return { textAnchor, dx, dy };
+}


### PR DESCRIPTION
## Summary
- Adds optional row labels to Scores Plot, Biplot, and Diagnostic Plot
- Redesigns the plot control area to fix UI crowding issues
- Implements ellipse support for Biplot
- Creates shared components following DRY principles

## Changes Made

### Row Labels Feature
- Added row label functionality to all three main plots (Scores, Biplot, Diagnostic)
- Smart label positioning based on quadrant to avoid overlaps
- Configurable maximum number of labels (default 10)
- Labels shown for points furthest from origin

### UI Redesign
- Two-tier control layout to fix crowding issues where plot selector was cut off
- Tier 1: Primary controls (plot selector, palette)
- Tier 2: Context-sensitive controls (labels, colors, ellipses, components)
- Visual grouping with background colors for better organization
- Removed duplicate component selector dropdown

### Code Quality Improvements (DRY Principles)
Created shared utilities and components:
- `labelUtils.ts`: Functions for calculating top points and label positioning
- `CustomPointWithLabel.tsx`: Reusable component for points with labels
- `ellipseUtils.ts`: Ellipse path generation and coordinate scaling
- `EllipseOverlay.tsx`: Reusable SVG overlay for confidence ellipses

### Bug Fixes
- Fixed missing ellipse functionality in Biplot
- Fixed ellipses checkbox showing incorrectly for diagnostic plot
- Ellipses now properly require categorical group column selection

## Screenshots
User provided screenshots showing:
- UI crowding issue (before)
- Duplicate component selectors (fixed)
- Confidence level control in diagnostic plot (preserved as intended)

## Testing
- Tested row labels on all three plots with various datasets
- Verified ellipses work correctly in both Scores Plot and Biplot
- Confirmed diagnostic plot confidence level control works as intended
- Tested with different preprocessing options and data configurations

## Notes
The confidence level control in the diagnostic plot is intentionally preserved as it controls statistical outlier detection thresholds (Q-limit and T² limit), which is different from the confidence ellipses in scores/biplot.

Fixes #181

🤖 Generated with [Claude Code](https://claude.ai/code)