### PR TITLE
Fix: correct version display issues in desktop apps

### DIFF
--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 	
+	"github.com/bitjungle/gopca/internal/version"
 	"github.com/bitjungle/gopca/pkg/types"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 	"github.com/xuri/excelize/v2"
@@ -1104,7 +1105,7 @@ func fillWithCustomValue(data *FileData, colIdx int, customValue string) {
 
 // GetVersion returns the application version
 func (a *App) GetVersion() string {
-	return "1.0.0"
+	return version.Get().Short()
 }
 
 // DataQualityReport represents a comprehensive data quality analysis

--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import './App.css';
 import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, ConfirmDialog } from './components';
 import { ThemeProvider, ThemeToggle } from '@gopca/ui-components';
 import logo from './assets/images/GoCSV-logo-1024-transp.png';
-import { LoadCSV, SaveCSV, SaveExcel, ValidateForGoPCA, AnalyzeMissingValues, FillMissingValues, AnalyzeDataQuality, CheckGoPCAStatus, OpenInGoPCA, DownloadGoPCA, ExecuteCellEdit, ExecuteHeaderEdit, ExecuteFillMissingValues, ClearHistory } from '../wailsjs/go/main/App';
+import { LoadCSV, SaveCSV, SaveExcel, ValidateForGoPCA, AnalyzeMissingValues, FillMissingValues, AnalyzeDataQuality, CheckGoPCAStatus, OpenInGoPCA, DownloadGoPCA, ExecuteCellEdit, ExecuteHeaderEdit, ExecuteFillMissingValues, ClearHistory, GetVersion } from '../wailsjs/go/main/App';
 import { EventsOn, OnFileDrop, OnFileDropOff } from '../wailsjs/runtime/runtime';
 import { main } from '../wailsjs/go/models';
 
@@ -34,6 +34,7 @@ function AppContent() {
     const [showTransformDialog, setShowTransformDialog] = useState(false);
     const [showDocumentation, setShowDocumentation] = useState(false);
     const [showDownloadConfirm, setShowDownloadConfirm] = useState(false);
+    const [version, setVersion] = useState<string>('');
     
     // Ref for scrolling to Step 2
     const step2Ref = useRef<HTMLDivElement>(null);
@@ -48,6 +49,13 @@ function AppContent() {
         
         // Check GoPCA status on startup
         checkGoPCAInstallation();
+        
+        // Fetch version on startup
+        GetVersion().then((v) => {
+            setVersion(v);
+        }).catch((err) => {
+            console.error('Failed to get version:', err);
+        });
         
         // Set up drag and drop listener
         OnFileDrop(async (x: number, y: number, paths: string[]) => {
@@ -285,6 +293,11 @@ function AppContent() {
                             className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
                             onClick={scrollToTop}
                         />
+                        {version && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                                {version}
+                            </span>
+                        )}
                         <div>
                             <p className="text-sm text-gray-600 dark:text-gray-400">Data Editor for GoPCA</p>
                         </div>

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -336,7 +336,7 @@ function AppContent() {
                         />
                         {version && (
                             <span className="text-xs text-gray-500 dark:text-gray-400">
-                                v{version}
+                                {version}
                             </span>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
Fixes version display issues in both GoPCA Desktop and GoCSV applications:
- Removed the extra 'v' prefix that was causing "vv0.9.4" to display in GoPCA Desktop
- Implemented proper version display in GoCSV using the shared version package

## Changes
### GoPCA Desktop (`cmd/gopca-desktop/frontend/src/App.tsx`)
- Removed hardcoded 'v' prefix from version display (line 339)
- Version now displays correctly as "v0.9.4" instead of "vv0.9.4"

### GoCSV Backend (`cmd/gocsv/app.go`)
- Added import for `internal/version` package
- Updated `GetVersion()` to use `version.Get().Short()` instead of hardcoded "1.0.0"

### GoCSV Frontend (`cmd/gocsv/frontend/src/App.tsx`)
- Added `GetVersion` import from wailsjs bindings
- Added version state variable
- Fetch version on component mount
- Display version next to logo in header, matching GoPCA Desktop style

## Technical Details
- Both apps now use the same `internal/version` package
- Version is injected at build time via ldflags: `-X github.com/bitjungle/gopca/internal/version.Version=$(VERSION)`
- VERSION is determined from git tags via `git describe --tags --always --dirty`
- Both desktop apps share the same build flags in the Makefile

## Testing
- Built both applications with version injection
- Verified version displays correctly in both apps
- All tests pass (`make test`)
- Code formatted (`make fmt`)
- Linter passes (`make lint`)

Closes #189