### PR TITLE
Release v0.9.5

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.4",
+    "productVersion": "0.9.5",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.4",
+    "productVersion": "0.9.5",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },

--- a/pkg/integration/app_integration.go
+++ b/pkg/integration/app_integration.go
@@ -210,9 +210,10 @@ func CheckApp(config AppConfig) *AppStatus {
 	possibleNames := []string{config.Name}
 
 	// Add alternative names based on app
-	if config.Name == "gocsv" {
+	switch config.Name {
+	case "gocsv":
 		possibleNames = append(possibleNames, "GoCSV")
-	} else if config.Name == "gopca-desktop" {
+	case "gopca-desktop":
 		possibleNames = append(possibleNames, "GoPCA")
 	}
 
@@ -334,10 +335,8 @@ func LaunchWithFile(appPath, filePath string) error {
 	}
 
 	// Detach from the process so it continues running after our app exits
-	if err := cmd.Process.Release(); err != nil {
-		// This is not critical, just log it
-		// The app will still run
-	}
+	// Ignore the error as it's not critical - the app will still run
+	_ = cmd.Process.Release()
 
 	return nil
 }


### PR DESCRIPTION
## Release v0.9.5

This PR prepares the v0.9.5 release of GoPCA.

### Changes in this release
- Fixed linter issues (switch statement and error handling)
- Bug fixes and improvements from recent PRs
- Updated version numbers in wails.json files

### Release checklist
- [x] All tests passing
- [x] Linter checks passing
- [x] Version numbers updated
- [ ] CI checks passing
- [ ] Ready to merge

Once this PR is merged, the release will be created with `./scripts/release.sh v0.9.5`