### PR TITLE
feat: add self-signed certificate support for Windows binary signing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# GoPCA Environment Configuration Example
+# Copy this file to .env and update with your values
+
+# macOS Code Signing (for local signing)
+# APPLE_ID=your-apple-id@example.com
+# APPLE_APP_SPECIFIC_PASSWORD=your-app-specific-password
+# APPLE_TEAM_ID=YOUR_TEAM_ID
+# APPLE_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+
+# Windows Code Signing (for local testing with self-signed certificates)
+# To generate a test certificate, run: ./scripts/generate-test-cert.sh
+WINDOWS_CERT_FILE=.certs/test-cert.p12
+WINDOWS_CERT_PASSWORD=test-password
+
+# SignPath.io Configuration (for production Windows signing in CI/CD)
+# SIGNPATH_API_TOKEN=your-signpath-api-token
+# SIGNPATH_ORG_ID=your-signpath-org-id

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ __pycache__/
 Skjermbilde*.png
 Screenshot*.png
 *.tmp.png
+
+# Certificate files (never commit!)
+.certs/
+*.p12
+*.pfx

--- a/scripts/generate-test-cert.sh
+++ b/scripts/generate-test-cert.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -e
+
+# Script to generate self-signed certificates for Windows code signing testing
+# WARNING: These certificates are for TESTING ONLY and should NEVER be used in production!
+
+echo "=================================================="
+echo "Windows Code Signing Test Certificate Generator"
+echo "=================================================="
+echo ""
+echo "⚠️  WARNING: This creates a SELF-SIGNED certificate"
+echo "⚠️  For TESTING purposes only!"
+echo "⚠️  Production releases should use SignPath.io"
+echo ""
+
+# Check for OpenSSL
+if ! command -v openssl &> /dev/null; then
+    echo "Error: OpenSSL is not installed."
+    echo "Please install OpenSSL first:"
+    echo "  macOS: brew install openssl"
+    echo "  Ubuntu/Debian: sudo apt-get install openssl"
+    echo "  Windows: Use Git Bash or WSL with OpenSSL"
+    exit 1
+fi
+
+# Configuration
+CERT_DIR=".certs"
+CERT_NAME="test-cert"
+CERT_PASSWORD="${WINDOWS_CERT_PASSWORD:-test-password}"
+DAYS_VALID=365
+
+# Create certificate directory
+mkdir -p "$CERT_DIR"
+
+echo "Creating test certificate..."
+echo ""
+
+# Generate private key
+echo "1. Generating private key..."
+openssl genrsa -out "$CERT_DIR/$CERT_NAME.key" 2048 2>/dev/null
+
+# Generate certificate signing request
+echo "2. Creating certificate signing request..."
+openssl req -new \
+    -key "$CERT_DIR/$CERT_NAME.key" \
+    -out "$CERT_DIR/$CERT_NAME.csr" \
+    -subj "/C=US/ST=Test/L=Test/O=GoPCA Test/CN=GoPCA Test Certificate" 2>/dev/null
+
+# Generate self-signed certificate
+echo "3. Generating self-signed certificate..."
+openssl x509 -req \
+    -days $DAYS_VALID \
+    -in "$CERT_DIR/$CERT_NAME.csr" \
+    -signkey "$CERT_DIR/$CERT_NAME.key" \
+    -out "$CERT_DIR/$CERT_NAME.crt" 2>/dev/null
+
+# Create PKCS#12 file for osslsigncode
+echo "4. Creating PKCS#12 file for code signing..."
+openssl pkcs12 -export \
+    -out "$CERT_DIR/$CERT_NAME.p12" \
+    -inkey "$CERT_DIR/$CERT_NAME.key" \
+    -in "$CERT_DIR/$CERT_NAME.crt" \
+    -password "pass:$CERT_PASSWORD" 2>/dev/null
+
+# Clean up intermediate files
+rm -f "$CERT_DIR/$CERT_NAME.csr"
+
+echo ""
+echo "✅ Test certificate created successfully!"
+echo ""
+echo "Certificate details:"
+echo "  Location: $CERT_DIR/$CERT_NAME.p12"
+echo "  Password: $CERT_PASSWORD"
+echo "  Valid for: $DAYS_VALID days"
+echo ""
+echo "To use this certificate:"
+echo ""
+echo "1. Create a .env file with:"
+echo "   WINDOWS_CERT_FILE=$CERT_DIR/$CERT_NAME.p12"
+echo "   WINDOWS_CERT_PASSWORD=$CERT_PASSWORD"
+echo ""
+echo "2. Run: make sign-windows"
+echo ""
+echo "⚠️  Remember: This certificate will trigger Windows security warnings!"
+echo "⚠️  Only use for testing - never distribute binaries signed with this!"
+echo ""


### PR DESCRIPTION
## Summary
This PR adds support for self-signed certificates to enable local testing of Windows binary signing. Developers can now test the signing process locally without requiring a paid SignPath subscription.

## Changes
- ✨ Added `scripts/generate-test-cert.sh` to generate self-signed test certificates
- 🔧 Updated Makefile `sign-windows` target to use certificate files via environment variables
- 📝 Added `.env.example` with certificate configuration examples
- 📚 Added comprehensive documentation in `docs/devel/code-signing.md` for local Windows testing
- 🔒 Added certificate files to `.gitignore` for security

## Testing
Tested locally:
1. Generated test certificate using the script
2. Built Windows binary with `make build-windows-amd64`
3. Successfully signed the binary with `make sign-windows`
4. Verified signature with `osslsigncode verify`

The signature verification shows the self-signed certificate details as expected.

## Screenshots
```
$ make sign-windows
Signing Windows binaries...
Found osslsigncode
Using certificate: .certs/test-cert.p12
Signing binaries...
✅ Signed: pca-windows-amd64.exe
✅ Windows binaries signed successfully\!
⚠️  Note: Self-signed certificates will trigger Windows security warnings
```

## Security Considerations
- Self-signed certificates are for **TESTING ONLY**
- Certificate files are gitignored to prevent accidental commits
- Clear warnings in documentation and script output
- Production releases continue to use SignPath.io

Closes #207