### PR TITLE
fix: Windows installer build issues with workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
     
     - name: Get version from tag or input
       id: get_version
+      shell: bash
       run: |
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           VERSION="${{ github.event.inputs.test_version }}"
@@ -251,6 +252,7 @@ jobs:
     
     - name: Get version from tag or input
       id: get_version
+      shell: bash
       run: |
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           VERSION="${{ github.event.inputs.test_version }}"
@@ -577,9 +579,13 @@ jobs:
         VERSION="${{ steps.get_version.outputs.version }}"
         echo "Building Windows installer for version ${VERSION}..."
         
+        # Strip the 'v' prefix for NSIS (installer.nsi adds it back)
+        VERSION_NO_V="${VERSION#v}"
+        echo "Version for NSIS: ${VERSION_NO_V}"
+        
         # Build the installer using NSIS
         cd scripts/windows
-        makensis -V2 -DVERSION=${VERSION} installer.nsi
+        makensis -V2 -DVERSION=${VERSION_NO_V} installer.nsi
         
         # Check if installer was created
         INSTALLER_PATH="../../build/windows-installer/GoPCA-Setup-${VERSION}.exe"

--- a/docs/devel/release-guide.md
+++ b/docs/devel/release-guide.md
@@ -158,6 +158,31 @@ Follow [Semantic Versioning](https://semver.org/):
 - Beta releases: `v1.0.0-beta.1`
 - Alpha releases: `v1.0.0-alpha.1`
 
+## Testing the Release Workflow
+
+You can test the release workflow without creating actual releases using the workflow_dispatch trigger:
+
+### Manual Testing Steps
+1. Go to [GitHub Actions](https://github.com/bitjungle/gopca/actions)
+2. Select "Release" workflow from the left sidebar
+3. Click "Run workflow" button
+4. Configure the test run:
+   - **Branch**: Select branch to test from (e.g., main or feature branch)
+   - **Test version**: Use default `v0.9.5-test` or enter custom version
+5. Click the green "Run workflow" button
+
+### What Happens in Test Mode
+- ✅ All binaries and installers are built
+- ✅ Artifacts are uploaded and downloadable from the workflow run
+- ✅ Clear "TEST MODE" notification appears in logs
+- ❌ No GitHub release is created (intentional)
+- ❌ No tag is created or pushed
+
+This is useful for:
+- Testing workflow changes before merging
+- Verifying Windows installer builds correctly
+- Checking cross-platform builds without creating releases
+
 ## Hotfix Releases
 
 For urgent fixes to the current release:

--- a/docs/devel/windows-installer-guide.md
+++ b/docs/devel/windows-installer-guide.md
@@ -192,6 +192,32 @@ For automated builds in CI/CD:
     path: build/windows-installer/GoPCA-Setup-*.exe
 ```
 
+## Testing the Installer Build
+
+You can test the Windows installer build without creating a release:
+
+1. **Via GitHub Actions UI** (workflow_dispatch):
+   - Go to Actions → Release workflow
+   - Click "Run workflow"
+   - Select branch and test version (e.g., v0.9.5-test)
+   - Download the installer artifact after completion
+
+2. **Locally** (requires NSIS):
+   ```bash
+   make windows-installer
+   # or for signed version (requires certificates):
+   make windows-installer-signed
+   ```
+
+The installer build is automatically tested in CI/CD when:
+- Pushing version tags (production releases)
+- Using workflow_dispatch trigger (test builds)
+
+### Version Handling
+- Production versions: `v0.9.5` → creates `GoPCA-Setup-v0.9.5.exe`
+- Test versions: `v0.9.5-test` → creates `GoPCA-Setup-v0.9.5-test.exe`
+- The 'v' prefix is stripped internally for NSIS processing
+
 ## Security Considerations
 
 - The installer requires administrator privileges to install to Program Files

--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -72,9 +72,19 @@ ShowUnInstDetails show
 ;--------------------------------
 ; Version Information
 
-; Use a fixed version format for VIProductVersion
-; This requires X.X.X.X format
-VIProductVersion "0.9.5.0"
+; VIProductVersion requires X.X.X.X format
+; Extract numeric part for VIProductVersion, keep full version for display
+!searchparse "${VERSION}" "" VersionMajor "." VersionMinor "." VersionPatch "-" VersionSuffix
+!searchparse "${VERSION}" "" NumericVersion "-"
+
+; Always provide VIProductVersion (required by NSIS when using other VI functions)
+!ifdef VersionSuffix
+  ; Test version (e.g., 0.9.5-test) - use numeric part for VIProductVersion
+  VIProductVersion "${VersionMajor}.${VersionMinor}.${VersionPatch}.0"
+!else
+  ; Regular version (e.g., 0.9.5) - append .0 for Windows format
+  VIProductVersion "${VERSION}.0"
+!endif
 VIAddVersionKey "ProductName" "${PRODUCT_NAME}"
 VIAddVersionKey "ProductVersion" "${VERSION}"
 VIAddVersionKey "CompanyName" "${PRODUCT_PUBLISHER}"


### PR DESCRIPTION
## Summary
Fixes Windows installer build failures when using workflow_dispatch with test versions.

## Problems Fixed

### 1. PowerShell Parser Errors
- **Issue**: Version extraction steps failed on GitHub-hosted Windows runners
- **Cause**: Windows runners default to PowerShell, not bash
- **Fix**: Added `shell: bash` to version extraction steps in build-desktop and build-gocsv jobs

### 2. Version Naming Issues  
- **Issue**: Double 'v' in output filename (e.g., `GoPCA-Setup-vv0.9.5-test.exe`)
- **Cause**: VERSION already had 'v' prefix, installer.nsi added another
- **Fix**: Strip 'v' prefix before passing to makensis

### 3. NSIS VIProductVersion Requirement
- **Issue**: `Error: VIProductVersion is required when other version information functions are used`
- **Cause**: Cannot skip VIProductVersion when using other VI functions
- **Fix**: Always provide VIProductVersion, extract numeric part from test versions

## Changes
- Added `shell: bash` directive to 2 version extraction steps
- Strip 'v' prefix in build-windows-installer job before calling makensis
- Updated installer.nsi to handle test versions properly for VIProductVersion
- Added comprehensive documentation for workflow_dispatch testing

## Testing
Successfully tested with workflow_dispatch:
- ✅ All binaries build correctly
- ✅ Windows installer creates `GoPCA-Setup-v0.9.5-test.exe`
- ✅ No PowerShell parser errors
- ✅ No NSIS version format errors

## Documentation
Added sections to both guides explaining:
- How to use workflow_dispatch for testing
- Version handling for test vs production builds
- What to expect in test mode

## Related
- Completes fix for #211
- Follows up on PR #213 which was merged prematurely

The workflow now handles both production releases (v0.9.5) and test versions (v0.9.5-test) correctly.