### PR TITLE
Fix Windows installer version parsing for release versions

### DIFF
--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -73,18 +73,16 @@ ShowUnInstDetails show
 ; Version Information
 
 ; VIProductVersion requires X.X.X.X format
-; Extract numeric part for VIProductVersion, keep full version for display
-!searchparse "${VERSION}" "" VersionMajor "." VersionMinor "." VersionPatch "-" VersionSuffix
-!searchparse "${VERSION}" "" NumericVersion "-"
+; Parse version components - handle both regular (0.9.6) and test versions (0.9.6-test)
+!searchparse /noerrors "${VERSION}" "" VersionMajor "." VersionMinor "." VersionPatch "-" VersionSuffix
 
-; Always provide VIProductVersion (required by NSIS when using other VI functions)
-!ifdef VersionSuffix
-  ; Test version (e.g., 0.9.5-test) - use numeric part for VIProductVersion
-  VIProductVersion "${VersionMajor}.${VersionMinor}.${VersionPatch}.0"
-!else
-  ; Regular version (e.g., 0.9.5) - append .0 for Windows format
-  VIProductVersion "${VERSION}.0"
+; If no hyphen found (regular version), parse without suffix
+!ifndef VersionPatch
+  !searchparse "${VERSION}" "" VersionMajor "." VersionMinor "." VersionPatch
 !endif
+
+; Always provide VIProductVersion in X.X.X.X format (required by NSIS)
+VIProductVersion "${VersionMajor}.${VersionMinor}.${VersionPatch}.0"
 VIAddVersionKey "ProductName" "${PRODUCT_NAME}"
 VIAddVersionKey "ProductVersion" "${VERSION}"
 VIAddVersionKey "CompanyName" "${PRODUCT_PUBLISHER}"


### PR DESCRIPTION
## Summary
Fixes the Windows installer build failure in the v0.9.6 release workflow.

## Problem
The NSIS installer script was failing for regular release versions (e.g., `0.9.6`) with the error:
```
\!searchparse: string "-" not found, aborted search\!
Error in script "installer.nsi" on line 77
```

The script required a hyphen in the version string, which exists in test versions (`0.9.6-test`) but not in regular releases.

## Solution
- Use `\!searchparse` with `/noerrors` flag to handle optional suffix gracefully
- Fall back to parsing without suffix for regular versions
- Both formats now work correctly:
  - Regular: `0.9.6` → parses as Major=0, Minor=9, Patch=6
  - Test: `0.9.6-test` → parses as Major=0, Minor=9, Patch=6, Suffix=test

## Testing
Tested locally with both version formats:
- `makensis -DVERSION=0.9.6 installer.nsi` ✅ (passes version parsing)
- `makensis -DVERSION=0.9.6-test installer.nsi` ✅ (passes version parsing)

## Impact
This fix will allow:
1. The v0.9.6 release workflow to complete successfully
2. Future releases to build Windows installers without manual intervention
3. Both test and release versions to work with the same script

Fixes the installer build failure seen in: https://github.com/bitjungle/gopca/actions/runs/16878135364/job/47807678246

🤖 Generated with [Claude Code](https://claude.ai/code)