### PR TITLE
Release v0.9.7

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.6",
+    "productVersion": "0.9.7",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.6",
+    "productVersion": "0.9.7",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
## Release v0.9.7

This PR prepares the v0.9.7 release, which includes the Windows installer fix.

### Key Changes Since v0.9.6
- Fixed Windows installer version parsing to handle regular release versions (PR #216)
- The installer now correctly builds for both test versions (0.9.7-test) and release versions (0.9.7)

### Version Updates
- Updated version to 0.9.7 in `cmd/gopca-desktop/wails.json`
- Updated version to 0.9.7 in `cmd/gocsv/wails.json`

### Tests
- ✅ All tests passed
- ✅ Linter passed
- ✅ Pre-commit checks passed

### Next Steps
After this PR is merged:
1. Checkout main: `git checkout main && git pull`
2. Create release tag: `./scripts/release.sh v0.9.7`
3. Monitor the automated release workflow

This release will include the Windows installer in the release artifacts.

---

🤖 Generated with [Claude Code](https://claude.ai/code)