### PR TITLE
Fix: preserve symlinks in macOS release bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -693,9 +693,9 @@ jobs:
           cp -a "gocsv-macos-latest/GoCSV.app" "macos/"
         fi
         
-        # Create macOS bundle zip
+        # Create macOS bundle zip (preserve symlinks with -y flag)
         cd macos
-        zip -r ../gopca-macos-universal.zip .
+        zip -r -y ../gopca-macos-universal.zip .
         cd ..
         
         # === Windows Bundle ===


### PR DESCRIPTION
## Summary
This PR fixes the macOS app detection issue where GoPCA and GoCSV fail to detect each other when downloaded from release artifacts.

## Problem
The release workflow was using `zip -r` which follows symlinks, corrupting the internal structure of macOS app bundles. This caused the companion app detection to fail.

## Solution
Added the `-y` flag to the zip command to preserve symlinks as links rather than following them:
```bash
# Before
zip -r ../gopca-macos-universal.zip .

# After  
zip -r -y ../gopca-macos-universal.zip .
```

## Testing
Tested locally to verify:
- Without `-y`: Creates 1.1K zip (follows symlinks, duplicates content)
- With `-y`: Creates 903B zip (preserves symlinks, no duplication)
- Symlinks are properly preserved in the zip archive

## Impact
- macOS apps will correctly detect each other when extracted from release artifacts
- Smaller zip file size (no duplicate files from followed symlinks)
- App bundle structure preserved exactly as built

Closes #218