### PR TITLE
Fix macOS app detection when apps are translocated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ Screenshot*.png
 .certs/
 *.p12
 *.pfx
+
+# Misc. temp files
+_tmp/

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ All visualizations feature:
 4. **Save** the cleaned file
 5. **Open in GoPCA** with one click
 
+### macOS Security Note
+
+When downloading GoPCA and GoCSV from GitHub releases, macOS may apply security measures that prevent the apps from detecting each other. This happens because macOS runs downloaded apps from a temporary, randomized location (App Translocation) for security.
+
+**Solutions:**
+1. **Move both apps to Applications**: Drag both GoPCA.app and GoCSV.app to your Applications folder before launching
+2. **Keep apps together**: Always keep both apps in the same folder (Applications, Downloads, or Desktop)
+3. **Alternative launch method**: Right-click the app and choose "Open" instead of double-clicking
+
 ### Command-Line Interface
 
 ```bash

--- a/docs/devel/macos-app-translocation.md
+++ b/docs/devel/macos-app-translocation.md
@@ -1,0 +1,56 @@
+# macOS App Translocation (Gatekeeper Path Randomization)
+
+## Overview
+
+macOS App Translocation is a security feature introduced in macOS Sierra (10.12) that protects users from malicious software. When an app is downloaded from the internet (has a quarantine flag) and launched by double-clicking, macOS may run it from a randomized, read-only location instead of its actual location.
+
+## How It Affects GoPCA/GoCSV
+
+When users download our release bundles from GitHub and double-click to launch:
+1. macOS moves the app to `/private/var/folders/.../AppTranslocation/[random-id]/`
+2. The app runs from this temporary location
+3. Relative path detection between GoPCA and GoCSV fails
+4. The apps cannot find each other even when in the same folder
+
+## Detection
+
+You can detect if an app is translocated by checking the executable path:
+
+```go
+if strings.Contains(execPath, "/AppTranslocation/") {
+    // App is translocated
+}
+```
+
+## Solutions Implemented
+
+### 1. Smart Detection (pkg/integration/app_integration.go)
+When we detect App Translocation:
+- Search common locations where both apps might be together
+- Check /Applications, ~/Applications, ~/Downloads, ~/Desktop
+- Look for both apps in the same location before using that path
+
+### 2. User Workarounds
+Users can avoid translocation by:
+- Moving apps to /Applications before first launch
+- Using command line: `open /path/to/GoPCA.app`
+- Right-clicking and choosing "Open" (sometimes helps)
+- Removing quarantine: `xattr -cr GoPCA.app GoCSV.app`
+
+## Testing
+
+To test translocation handling:
+1. Download apps from GitHub releases
+2. Unzip to ~/Downloads
+3. Double-click to launch (triggers translocation)
+4. Set `GOPCA_DEBUG=1` to see detection logic
+
+To verify translocation is active:
+```bash
+ps aux | grep GoPCA
+# Look for /AppTranslocation/ in the path
+```
+
+## References
+- [Apple Developer: App Translocation](https://developer.apple.com/library/archive/technotes/tn2206/_index.html)
+- [macOS Security Guide](https://support.apple.com/guide/security/app-security-overview-sec35dd877d0/web)


### PR DESCRIPTION
## Summary
Fixes app detection between GoPCA and GoCSV when downloaded from GitHub releases and launched via double-click on macOS.

## Problem
When macOS apps are downloaded from the internet and launched by double-clicking, macOS may run them from a randomized temporary location (`/private/var/folders/.../AppTranslocation/`) for security. This breaks the relative path detection between GoPCA and GoCSV, even when they're in the same folder.

## Solution
Added smart detection for translocated apps that:
1. Detects when an app is running from an AppTranslocation path
2. Searches common locations (Applications, Downloads, Desktop) for both apps
3. Only uses a location if both apps are found there together
4. Maintains backward compatibility for normal launches

## Changes
- **pkg/integration/app_integration.go**: Added translocation detection and fallback search logic
- **README.md**: Added user-facing documentation about the macOS security feature and workarounds
- **docs/devel/macos-app-translocation.md**: Added developer documentation explaining the issue and implementation
- **Makefile**: Fixed notarization targets to use correct app names (GoPCA.app and GoCSV.app)
- **scripts/notarize-macos.sh**: Added argument handling for selective notarization

## Testing
Tested by:
1. Downloading release bundles from GitHub
2. Extracting to ~/Downloads/gopca-macos-universal/
3. Double-clicking to launch (triggers translocation)
4. Verifying apps can now detect each other
5. Also tested normal launches from /Applications (still works)

## User Impact
Users can now:
- Download and run apps directly without special steps
- Or follow documented workarounds for a smoother experience:
  - Move both apps to /Applications before first launch
  - Keep both apps in the same folder
  - Right-click and choose "Open" instead of double-clicking

Fixes #218