### PR TITLE
feat: add CLI command preview in desktop app

### DIFF
--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -200,6 +200,11 @@
       "text": "Choose between Categorical (distinct colors for groups/categories) or Sequential (gradient for continuous values).",
       "category": "interface"
     },
+    "cli-command-preview": {
+      "title": "CLI Command Preview",
+      "text": "How to run the same analysis using the pca command-line tool. Copy command to use it in your terminal or scripts.",
+      "category": "interface"
+    },
     "preprocessing-order": {
       "title": "Preprocessing Order",
       "text": "Row-wise (SNV/L2) applied first, then column-wise (centering/scaling). Order matters!",


### PR DESCRIPTION
## Summary
Adds a live CLI command preview in the GoPCA desktop application that shows users how to invoke the `pca` CLI with their current GUI selections. This helps bridge the gap between GUI and CLI usage, making the command-line tool more accessible to users.

## Changes
- Added dynamic CLI command generation based on current GUI configuration
- Implemented clipboard copy functionality with visual feedback (check icon)
- Created terminal-like UI component with dark background and monospace font
- Added help documentation entry for the CLI preview feature

## Features
✅ Real-time command updates as settings change
✅ One-click copy to clipboard with visual feedback
✅ Proper handling of file paths with spaces (automatic quoting)
✅ Support for all PCA methods (SVD, NIPALS, Kernel)
✅ Support for all preprocessing options (SNV, vector norm, mean center, standard scale, robust scale)
✅ Support for missing data strategies
✅ Support for excluded rows/columns
✅ Terminal-like appearance for familiarity
✅ Help tooltip integration

## Testing
- ✅ Tested with Iris sample dataset
- ✅ Verified command updates when changing components
- ✅ Verified command updates when changing preprocessing options
- ✅ Tested copy to clipboard functionality
- ✅ TypeScript compilation successful
- ✅ All Go tests pass

## Screenshots
The CLI command preview appears below the "Go PCA\!" button with a dark terminal-like background and green monospace text. The copy button changes to a checkmark when clicked.

Closes #221