### PR TITLE
Fix: Palette selector positioning and mode synchronization

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -122,6 +122,7 @@ function AppContent() {
                 setExcludedRows([]);
                 setExcludedColumns([]);
                 setSelectedGroupColumn(null);
+                setMode('none'); // Reset palette mode
                 setDatasetId(prev => prev + 1); // Force DataTable re-render
                 updateGammaForData(result);
             } catch (err) {
@@ -169,18 +170,26 @@ function AppContent() {
             
             // Validate group column exists before setting
             if (defaultGroupColumn && result) {
-                const isValid = 
-                    (result.categoricalColumns && defaultGroupColumn in result.categoricalColumns) ||
-                    (result.numericTargetColumns && defaultGroupColumn in result.numericTargetColumns);
+                const isCategorical = result.categoricalColumns && defaultGroupColumn in result.categoricalColumns;
+                const isContinuous = result.numericTargetColumns && defaultGroupColumn in result.numericTargetColumns;
+                const isValid = isCategorical || isContinuous;
                 
                 if (isValid) {
                     setSelectedGroupColumn(defaultGroupColumn);
+                    // Set the appropriate palette mode based on column type
+                    if (isCategorical) {
+                        setMode('categorical');
+                    } else if (isContinuous) {
+                        setMode('continuous');
+                    }
                 } else {
                     console.warn(`Column "${defaultGroupColumn}" not found in ${filename}, setting group column to null`);
                     setSelectedGroupColumn(null);
+                    setMode('none');
                 }
             } else {
                 setSelectedGroupColumn(null);
+                setMode('none');
             }
             
             updateGammaForData(result);
@@ -209,6 +218,7 @@ function AppContent() {
             setExcludedRows([]);
             setExcludedColumns([]);
             setSelectedGroupColumn(null);
+            setMode('none'); // Reset palette mode
             setDatasetId(prev => prev + 1); // Force DataTable re-render
             
             // Calculate and set default gamma for kernel PCA
@@ -1027,7 +1037,9 @@ function AppContent() {
                                         </HelpWrapper>
                                     </div>
                                     {selectedGroupColumn && (
-                                        <PaletteSelector />
+                                        <div className="flex-shrink-0">
+                                            <PaletteSelector />
+                                        </div>
                                     )}
                                 </div>
                                 


### PR DESCRIPTION
## Summary
This PR fixes two related issues with the palette selector that prevented it from working correctly when datasets with single categorical variables were auto-selected.

## Issues Fixed

### 1. Positioning Issue
The palette selector was being pushed off-screen to the right due to the `justify-between` flexbox layout in the parent container.

**Solution**: Wrapped the PaletteSelector in a `flex-shrink-0` div to constrain its position while keeping it on the right side of the visualization controls.

### 2. Mode Synchronization Issue  
When datasets with auto-selected categorical columns (like Iris with 'species') were loaded, the palette mode remained 'none' instead of being set to 'categorical'. This caused the dropdown to not render, showing only the "Palette:" label.

**Solution**: Added proper mode synchronization in the `loadDataset` function and other file loading mechanisms to set the appropriate palette mode ('categorical' or 'continuous') when auto-selecting columns.

## Changes Made

- Added `flex-shrink-0` wrapper around PaletteSelector to prevent off-screen positioning
- Added `setMode()` calls in all file loading functions to synchronize with column selection:
  - `loadDataset()` - for sample datasets with auto-selection
  - `handleFileUpload()` - for user file uploads
  - `LoadCSVFile` handler - for file dialog selections
- Mode is now properly set to 'categorical' or 'continuous' when auto-selecting columns
- Mode is reset to 'none' when loading new files without auto-selection

## Testing
- ✅ Tested with Iris dataset (single categorical variable, auto-selected)
- ✅ Tested with Wine dataset (multiple categorical variables, manual selection)
- ✅ Palette selector now stays visible and properly positioned in both scenarios
- ✅ Dropdown renders correctly when mode is synchronized
- ✅ TypeScript compilation successful
- ✅ All pre-commit checks passed

## Before/After

**Before**: 
- Palette selector could float off-screen
- Dropdown wouldn't render when auto-selecting categorical columns

**After**:
- Palette selector stays within visible bounds
- Dropdown properly renders based on synchronized mode

Closes #227

🤖 Generated with [Claude Code](https://claude.ai/code)