### PR TITLE
Fix: Update CLI author information to official project details

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,8 +26,8 @@ func NewApp() *cli.App {
 		Version: version.Get().Short(),
 		Authors: []*cli.Author{
 			{
-				Name:  "GoPCA Team",
-				Email: "support@gopca.example.com",
+				Name:  "bitjungle",
+				Email: "devel@bitjungle.com",
 			},
 		},
 		Description: `GoPCA is the definitive Principal Component Analysis (PCA) application.


### PR DESCRIPTION
## Summary
Updates the CLI author information from placeholder values to the official project author details.

## Changes
- Changed author name from "GoPCA Team" to "bitjungle"
- Changed email from "support@gopca.example.com" to "devel@bitjungle.com"

## Testing
✅ CLI builds successfully
✅ Author information displays correctly in `pca --help`
✅ All tests pass
✅ Linting passes

## Verification
```bash
$ ./build/pca --help | grep -A 2 "AUTHOR"
AUTHOR:
   bitjungle <devel@bitjungle.com>
```

Closes #212