### PR TITLE
Fix: Allow decimal values less than 1 in Kernel PCA gamma input

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -781,7 +781,10 @@ function AppContent() {
                                                         value={config.kernelGamma}
                                                         step="0.01"
                                                         min="0.001"
-                                                        onChange={(e) => setConfig({...config, kernelGamma: parseFloat(e.target.value) || 1.0})}
+                                                        onChange={(e) => {
+                                                            const value = parseFloat(e.target.value);
+                                                            setConfig({...config, kernelGamma: isNaN(value) ? 1.0 : value});
+                                                        }}
                                                         className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                                                     />
                                                 </HelpWrapper>
@@ -808,7 +811,10 @@ function AppContent() {
                                                                 type="number"
                                                                 value={config.kernelCoef0}
                                                                 step="0.1"
-                                                                onChange={(e) => setConfig({...config, kernelCoef0: parseFloat(e.target.value) || 0.0})}
+                                                                onChange={(e) => {
+                                                                    const value = parseFloat(e.target.value);
+                                                                    setConfig({...config, kernelCoef0: isNaN(value) ? 0.0 : value});
+                                                                }}
                                                                 className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                                                             />
                                                         </HelpWrapper>


### PR DESCRIPTION
## Description
Fixes the issue where users cannot type decimal values less than 1 (e.g., 0.01) in the Kernel PCA gamma parameter input field when selecting all text and typing.

## Problem
When a user selected all text in the gamma input field and typed "0", the `parseFloat("0")` returned `0`, which is falsy in JavaScript, causing the code to fallback to the default value of `1.0`. This prevented users from efficiently entering small gamma values.

## Solution
Replaced the falsy check (`|| 1.0`) with a proper `isNaN()` check to distinguish between valid zero values and invalid input:
- `kernelGamma`: Now correctly accepts any valid number including 0
- `kernelCoef0`: Fixed the same issue for consistency

## Changes
- Modified `onChange` handler for `kernelGamma` input to use `isNaN(value) ? 1.0 : value`
- Modified `onChange` handler for `kernelCoef0` input to use `isNaN(value) ? 0.0 : value`

## Testing
- ✅ Frontend builds successfully
- ✅ TypeScript compilation passes
- ✅ All Go tests pass
- ✅ Pre-commit hooks pass

## Impact
Users can now efficiently enter decimal values less than 1 by selecting all text and typing, improving the user experience when configuring Kernel PCA parameters.

Closes #243