### PR TITLE
Fix: Remove references to deleted internal/io package in CI scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           # Run tests for all packages with test files
           # Note: Use explicit list to avoid Windows issues with packages without tests
           # Skip TestValidateOutputPath on Windows as it uses Unix-specific paths
-          go test -v -race -timeout 10m ./internal/cli ./internal/core ./internal/io ./pkg/types ./cmd/gopca-desktop
+          go test -v -race -timeout 10m ./internal/cli ./internal/core ./pkg/types ./cmd/gopca-desktop
           go test -v -race -timeout 10m -skip "TestValidateOutputPath" ./internal/utils
           # Test GoCSV commands separately (skip app tests that require Wails context)
           cd cmd/gocsv && go test -v -race -timeout 10m -run "TestMultiStepUndoRedo|TestUndoRedoState" . && cd ../..

--- a/scripts/ci/test-all.sh
+++ b/scripts/ci/test-all.sh
@@ -22,7 +22,7 @@ go mod download
 # Run tests for core packages
 echo ""
 echo "=== Testing Core Packages ==="
-CORE_PACKAGES="./internal/cli ./internal/core ./internal/io ./internal/utils ./pkg/types"
+CORE_PACKAGES="./internal/cli ./internal/core ./internal/utils ./pkg/types"
 
 echo "Testing: $CORE_PACKAGES"
 if go test -v -race -cover $CORE_PACKAGES; then

--- a/scripts/ci/test-core.sh
+++ b/scripts/ci/test-core.sh
@@ -29,7 +29,7 @@ mkdir -p cmd/gopca-desktop/frontend/dist
 echo '<!DOCTYPE html><html><body>Test</body></html>' > cmd/gopca-desktop/frontend/dist/index.html
 
 # First run core packages and GoPCA Desktop tests
-if ! go test -v -cover ./internal/cli ./internal/core ./internal/io ./internal/utils ./pkg/types ./cmd/gopca-desktop; then
+if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./cmd/gopca-desktop; then
     echo "✗ Core tests failed"
     exit 1
 fi
@@ -53,7 +53,7 @@ echo "✓ All core tests passed"
 # Show coverage summary
 echo ""
 echo "=== Coverage Summary ==="
-go test -cover ./internal/cli ./internal/core ./internal/io ./internal/utils ./pkg/types ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
+go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
 
 echo ""
 echo "=== Core tests completed successfully ===" 


### PR DESCRIPTION
## Problem
All GitHub Actions workflows have been failing since run #400 due to references to the removed `internal/io` package in CI test scripts.

## Root Cause
During Phase 2 refactoring (PR #247), the `internal/io` package was removed and its functionality was consolidated into `pkg/csv`, but the CI test scripts were not updated to reflect this change.

## Solution
This PR removes all references to the non-existent `internal/io` package from:
- `scripts/ci/test-all.sh` (line 25)
- `scripts/ci/test-core.sh` (lines 32, 56)
- `.github/workflows/build.yml` (line 73)

## Testing
- ✅ Ran `make ci-test` locally - all tests pass
- ✅ No compilation errors
- ✅ CI should now pass on this PR

Fixes #251