### PR TITLE
feat: add chart abstraction layer for future library migration

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { EventsOn } from '../wailsjs/runtime/runtime';
 import { DataTable, SelectionTable, MatrixIllustration, HelpWrapper, DocumentationViewer } from './components';
 import { ScoresPlot, ScreePlot, LoadingsPlot, Biplot, CircleOfCorrelations, DiagnosticScatterPlot, EigencorrelationPlot } from './components/visualizations';
 import { FileData, PCARequest, PCAResponse } from './types';
-import { ThemeProvider, ThemeToggle, ConfirmDialog } from '@gopca/ui-components';
+import { ThemeProvider, ThemeToggle, ConfirmDialog, ChartProvider } from '@gopca/ui-components';
 import { HelpProvider, useHelp } from './contexts/HelpContext';
 import { PaletteProvider, usePalette } from './contexts/PaletteContext';
 import { HelpDisplay } from './components/HelpDisplay';
@@ -1359,11 +1359,13 @@ function AppContent() {
 function App() {
     return (
         <ThemeProvider>
-            <PaletteProvider>
-                <HelpProvider>
-                    <AppContent />
-                </HelpProvider>
-            </PaletteProvider>
+            <ChartProvider>
+                <PaletteProvider>
+                    <HelpProvider>
+                        <AppContent />
+                    </HelpProvider>
+                </PaletteProvider>
+            </ChartProvider>
         </ThemeProvider>
     );
 }

--- a/packages/ui-components/src/charts/ChartProvider.tsx
+++ b/packages/ui-components/src/charts/ChartProvider.tsx
@@ -1,0 +1,67 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type ChartLibrary = 'recharts' | 'plotly' | 'd3';
+
+interface ChartConfig {
+  provider: ChartLibrary;
+  zoomEnabled: boolean;
+  panEnabled: boolean;
+}
+
+interface ChartContextType {
+  config: ChartConfig;
+  setProvider: (provider: ChartLibrary) => void;
+  setZoomEnabled: (enabled: boolean) => void;
+  setPanEnabled: (enabled: boolean) => void;
+}
+
+const ChartContext = createContext<ChartContextType | undefined>(undefined);
+
+const DEFAULT_CONFIG: ChartConfig = {
+  provider: 'recharts',
+  zoomEnabled: true,
+  panEnabled: true,
+};
+
+export const ChartProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [config, setConfig] = useState<ChartConfig>(DEFAULT_CONFIG);
+
+  const setProvider = (provider: ChartLibrary) => {
+    setConfig(prev => ({ ...prev, provider }));
+  };
+
+  const setZoomEnabled = (enabled: boolean) => {
+    setConfig(prev => ({ ...prev, zoomEnabled: enabled }));
+  };
+
+  const setPanEnabled = (enabled: boolean) => {
+    setConfig(prev => ({ ...prev, panEnabled: enabled }));
+  };
+
+  return (
+    <ChartContext.Provider 
+      value={{
+        config,
+        setProvider,
+        setZoomEnabled,
+        setPanEnabled,
+      }}
+    >
+      {children}
+    </ChartContext.Provider>
+  );
+};
+
+export const useChartConfig = () => {
+  const context = useContext(ChartContext);
+  if (!context) {
+    throw new Error('useChartConfig must be used within a ChartProvider');
+  }
+  return context;
+};

--- a/packages/ui-components/src/charts/adapters/recharts/RechartsAdapter.tsx
+++ b/packages/ui-components/src/charts/adapters/recharts/RechartsAdapter.tsx
@@ -1,0 +1,277 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import {
+  ComposedChart as RechartComposedChart,
+  Scatter as RechartsScatter,
+  Bar as RechartsBar,
+  Line as RechartsLine,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+import {
+  ScatterChartProps,
+  BarChartProps,
+  LineChartProps,
+  ComposedChartProps,
+  ChartAdapter,
+} from '../../types';
+import { useChartTheme } from '../../../hooks/useChartTheme';
+
+export const RechartsScatterChart: React.FC<ScatterChartProps> = ({
+  data,
+  domain,
+  margin = { top: 20, right: 20, bottom: 60, left: 80 },
+  width = '100%',
+  height = '100%',
+  xDataKey = 'x',
+  yDataKey = 'y',
+  xLabel,
+  yLabel,
+  showGrid = true,
+  showReferenceLines = true,
+  tooltip,
+  dot,
+  fill = '#3B82F6',
+  stroke = '#1E40AF',
+  children,
+  onMouseMove,
+  onMouseDown,
+  onMouseUp,
+  onMouseLeave,
+  className,
+}) => {
+  const chartTheme = useChartTheme();
+
+  return (
+    <div 
+      className={className}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseLeave}
+    >
+      <ResponsiveContainer width={width} height={height}>
+        <RechartComposedChart data={data} margin={margin}>
+          {showGrid && (
+            <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.gridColor} />
+          )}
+          <XAxis
+            type="number"
+            dataKey={xDataKey}
+            name={xLabel}
+            label={xLabel ? { value: xLabel, position: 'insideBottom', offset: -10 } : undefined}
+            stroke={chartTheme.axisColor}
+            domain={domain?.x || ['dataMin', 'dataMax']}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+            tickFormatter={(value) => typeof value === 'number' ? value.toFixed(1) : value}
+          />
+          <YAxis
+            type="number"
+            dataKey={yDataKey}
+            name={yLabel}
+            label={yLabel ? { value: yLabel, angle: -90, position: 'insideLeft' } : undefined}
+            stroke={chartTheme.axisColor}
+            domain={domain?.y || ['dataMin', 'dataMax']}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+            tickFormatter={(value) => typeof value === 'number' ? value.toFixed(1) : value}
+          />
+          {showReferenceLines && (
+            <>
+              <ReferenceLine x={0} stroke={chartTheme.referenceLineColor} strokeWidth={2} />
+              <ReferenceLine y={0} stroke={chartTheme.referenceLineColor} strokeWidth={2} />
+            </>
+          )}
+          {tooltip && (
+            <Tooltip content={typeof tooltip === 'function' ? tooltip : undefined} />
+          )}
+          <RechartsScatter
+            name="Data"
+            fill={fill}
+            fillOpacity={0.8}
+            strokeWidth={1}
+            stroke={stroke}
+            shape={typeof dot === 'function' ? dot : undefined}
+          />
+          {children}
+        </RechartComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const RechartsBarChart: React.FC<BarChartProps> = ({
+  data,
+  dataKey,
+  xDataKey = 'x',
+  margin = { top: 20, right: 20, bottom: 60, left: 80 },
+  width = '100%',
+  height = '100%',
+  xLabel,
+  yLabel,
+  showGrid = true,
+  fill = '#3B82F6',
+  children,
+  className,
+}) => {
+  const chartTheme = useChartTheme();
+
+  return (
+    <div className={className}>
+      <ResponsiveContainer width={width} height={height}>
+        <RechartComposedChart data={data} margin={margin}>
+          {showGrid && (
+            <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.gridColor} />
+          )}
+          <XAxis
+            dataKey={xDataKey}
+            stroke={chartTheme.axisColor}
+            label={xLabel ? { value: xLabel, position: 'insideBottom', offset: -10 } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+          />
+          <YAxis
+            stroke={chartTheme.axisColor}
+            label={yLabel ? { value: yLabel, angle: -90, position: 'insideLeft' } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+          />
+          <Tooltip />
+          <RechartsBar dataKey={dataKey} fill={fill} />
+          {children}
+        </RechartComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const RechartsLineChart: React.FC<LineChartProps> = ({
+  data,
+  dataKey,
+  xDataKey = 'x',
+  margin = { top: 20, right: 20, bottom: 60, left: 80 },
+  width = '100%',
+  height = '100%',
+  xLabel,
+  yLabel,
+  showGrid = true,
+  stroke = '#3B82F6',
+  strokeWidth = 2,
+  dot = false,
+  children,
+  className,
+}) => {
+  const chartTheme = useChartTheme();
+
+  return (
+    <div className={className}>
+      <ResponsiveContainer width={width} height={height}>
+        <RechartComposedChart data={data} margin={margin}>
+          {showGrid && (
+            <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.gridColor} />
+          )}
+          <XAxis
+            dataKey={xDataKey}
+            stroke={chartTheme.axisColor}
+            label={xLabel ? { value: xLabel, position: 'insideBottom', offset: -10 } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+          />
+          <YAxis
+            stroke={chartTheme.axisColor}
+            label={yLabel ? { value: yLabel, angle: -90, position: 'insideLeft' } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+          />
+          <Tooltip />
+          <RechartsLine
+            type="monotone"
+            dataKey={dataKey}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            dot={typeof dot === 'boolean' ? dot : (typeof dot === 'function' ? dot : false)}
+          />
+          {children}
+        </RechartComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const RechartsComposedChart: React.FC<ComposedChartProps> = ({
+  data,
+  domain,
+  margin = { top: 20, right: 20, bottom: 60, left: 80 },
+  width = '100%',
+  height = '100%',
+  xDataKey = 'x',
+  xLabel,
+  yLabel,
+  showGrid = true,
+  children,
+  onMouseMove,
+  onMouseDown,
+  onMouseUp,
+  onMouseLeave,
+  className,
+}) => {
+  const chartTheme = useChartTheme();
+
+  return (
+    <div 
+      className={className}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseLeave}
+    >
+      <ResponsiveContainer width={width} height={height}>
+        <RechartComposedChart data={data} margin={margin}>
+          {showGrid && (
+            <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.gridColor} />
+          )}
+          <XAxis
+            type="number"
+            dataKey={xDataKey}
+            stroke={chartTheme.axisColor}
+            domain={domain?.x || ['dataMin', 'dataMax']}
+            label={xLabel ? { value: xLabel, position: 'insideBottom', offset: -10 } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+            tickFormatter={(value) => typeof value === 'number' ? value.toFixed(1) : value}
+          />
+          <YAxis
+            type="number"
+            stroke={chartTheme.axisColor}
+            domain={domain?.y || ['dataMin', 'dataMax']}
+            label={yLabel ? { value: yLabel, angle: -90, position: 'insideLeft' } : undefined}
+            axisLine={{ stroke: chartTheme.axisColor }}
+            tickLine={{ stroke: chartTheme.axisColor }}
+            tickFormatter={(value) => typeof value === 'number' ? value.toFixed(1) : value}
+          />
+          <Tooltip />
+          {children}
+        </RechartComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+const RechartsAdapter: ChartAdapter = {
+  ScatterChart: RechartsScatterChart,
+  BarChart: RechartsBarChart,
+  LineChart: RechartsLineChart,
+  ComposedChart: RechartsComposedChart,
+};
+
+export default RechartsAdapter;

--- a/packages/ui-components/src/charts/components/BarChart.tsx
+++ b/packages/ui-components/src/charts/components/BarChart.tsx
@@ -1,0 +1,29 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { useChartConfig } from '../ChartProvider';
+import { BarChartProps } from '../types';
+import RechartsAdapter from '../adapters/recharts/RechartsAdapter';
+
+export const BarChart: React.FC<BarChartProps> = (props) => {
+  const { config } = useChartConfig();
+  
+  switch (config.provider) {
+    case 'recharts':
+      return <RechartsAdapter.BarChart {...props} />;
+    case 'plotly':
+      // Future: return <PlotlyAdapter.BarChart {...props} />;
+      console.warn('Plotly adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.BarChart {...props} />;
+    case 'd3':
+      // Future: return <D3Adapter.BarChart {...props} />;
+      console.warn('D3 adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.BarChart {...props} />;
+    default:
+      return <RechartsAdapter.BarChart {...props} />;
+  }
+};

--- a/packages/ui-components/src/charts/components/ComposedChart.tsx
+++ b/packages/ui-components/src/charts/components/ComposedChart.tsx
@@ -1,0 +1,29 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { useChartConfig } from '../ChartProvider';
+import { ComposedChartProps } from '../types';
+import RechartsAdapter from '../adapters/recharts/RechartsAdapter';
+
+export const ComposedChart: React.FC<ComposedChartProps> = (props) => {
+  const { config } = useChartConfig();
+  
+  switch (config.provider) {
+    case 'recharts':
+      return <RechartsAdapter.ComposedChart {...props} />;
+    case 'plotly':
+      // Future: return <PlotlyAdapter.ComposedChart {...props} />;
+      console.warn('Plotly adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.ComposedChart {...props} />;
+    case 'd3':
+      // Future: return <D3Adapter.ComposedChart {...props} />;
+      console.warn('D3 adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.ComposedChart {...props} />;
+    default:
+      return <RechartsAdapter.ComposedChart {...props} />;
+  }
+};

--- a/packages/ui-components/src/charts/components/LineChart.tsx
+++ b/packages/ui-components/src/charts/components/LineChart.tsx
@@ -1,0 +1,29 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { useChartConfig } from '../ChartProvider';
+import { LineChartProps } from '../types';
+import RechartsAdapter from '../adapters/recharts/RechartsAdapter';
+
+export const LineChart: React.FC<LineChartProps> = (props) => {
+  const { config } = useChartConfig();
+  
+  switch (config.provider) {
+    case 'recharts':
+      return <RechartsAdapter.LineChart {...props} />;
+    case 'plotly':
+      // Future: return <PlotlyAdapter.LineChart {...props} />;
+      console.warn('Plotly adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.LineChart {...props} />;
+    case 'd3':
+      // Future: return <D3Adapter.LineChart {...props} />;
+      console.warn('D3 adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.LineChart {...props} />;
+    default:
+      return <RechartsAdapter.LineChart {...props} />;
+  }
+};

--- a/packages/ui-components/src/charts/components/ScatterChart.tsx
+++ b/packages/ui-components/src/charts/components/ScatterChart.tsx
@@ -1,0 +1,29 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { useChartConfig } from '../ChartProvider';
+import { ScatterChartProps } from '../types';
+import RechartsAdapter from '../adapters/recharts/RechartsAdapter';
+
+export const ScatterChart: React.FC<ScatterChartProps> = (props) => {
+  const { config } = useChartConfig();
+  
+  switch (config.provider) {
+    case 'recharts':
+      return <RechartsAdapter.ScatterChart {...props} />;
+    case 'plotly':
+      // Future: return <PlotlyAdapter.ScatterChart {...props} />;
+      console.warn('Plotly adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.ScatterChart {...props} />;
+    case 'd3':
+      // Future: return <D3Adapter.ScatterChart {...props} />;
+      console.warn('D3 adapter not yet implemented, falling back to Recharts');
+      return <RechartsAdapter.ScatterChart {...props} />;
+    default:
+      return <RechartsAdapter.ScatterChart {...props} />;
+  }
+};

--- a/packages/ui-components/src/charts/examples/ScatterPlotExample.tsx
+++ b/packages/ui-components/src/charts/examples/ScatterPlotExample.tsx
@@ -1,0 +1,131 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+/**
+ * Example component demonstrating how to use the chart abstraction layer.
+ * This shows how visualization components can be migrated to use the abstraction
+ * instead of directly importing from Recharts.
+ */
+
+import React from 'react';
+import { ScatterChart, Cell } from '../index';
+import { useChartTheme } from '../../hooks/useChartTheme';
+
+interface ExampleData {
+  x: number;
+  y: number;
+  name: string;
+  group: string;
+  color: string;
+}
+
+interface ScatterPlotExampleProps {
+  data: ExampleData[];
+  xLabel?: string;
+  yLabel?: string;
+  showReferenceLines?: boolean;
+}
+
+export const ScatterPlotExample: React.FC<ScatterPlotExampleProps> = ({
+  data,
+  xLabel = 'X Axis',
+  yLabel = 'Y Axis',
+  showReferenceLines = true,
+}) => {
+  const chartTheme = useChartTheme();
+
+  // Custom tooltip renderer
+  const renderTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div 
+          className="p-2 rounded shadow-lg border"
+          style={{ 
+            backgroundColor: chartTheme.tooltipBackgroundColor,
+            borderColor: chartTheme.tooltipBorderColor
+          }}
+        >
+          <p className="font-semibold" style={{ color: chartTheme.tooltipTextColor }}>
+            {data.name}
+          </p>
+          <p style={{ color: chartTheme.tooltipTextColor }}>
+            Group: {data.group}
+          </p>
+          <p style={{ color: chartTheme.tooltipTextColor }}>
+            X: {data.x.toFixed(3)}
+          </p>
+          <p style={{ color: chartTheme.tooltipTextColor }}>
+            Y: {data.y.toFixed(3)}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  // Custom dot renderer
+  const renderDot = (props: any) => {
+    const { cx, cy, payload } = props;
+    return (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={4}
+        fill={payload.color}
+        stroke={payload.color}
+        strokeWidth={1}
+        fillOpacity={0.8}
+      />
+    );
+  };
+
+  return (
+    <div className="w-full h-full">
+      <ScatterChart
+        data={data}
+        xLabel={xLabel}
+        yLabel={yLabel}
+        showReferenceLines={showReferenceLines}
+        tooltip={renderTooltip}
+        dot={renderDot}
+        className="w-full h-full"
+      >
+        {/* Additional Recharts components can be added as children */}
+        {data.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={entry.color} />
+        ))}
+      </ScatterChart>
+    </div>
+  );
+};
+
+/**
+ * Migration Guide:
+ * 
+ * 1. Replace Recharts imports:
+ *    Before: import { ComposedChart, Scatter, ... } from 'recharts';
+ *    After:  import { ComposedChart, ScatterChart, ... } from '@gopca/ui-components';
+ * 
+ * 2. Use abstracted chart components where possible:
+ *    - ScatterChart for scatter plots
+ *    - BarChart for bar charts
+ *    - LineChart for line charts
+ *    - ComposedChart for complex compositions
+ * 
+ * 3. Native Recharts components (Cell, Legend, etc.) are re-exported from
+ *    the abstraction layer for compatibility.
+ * 
+ * 4. The abstraction automatically handles:
+ *    - Theme integration
+ *    - Provider selection (Recharts, Plotly, D3)
+ *    - Common chart configurations
+ * 
+ * 5. Complex visualizations may need gradual migration:
+ *    - Start with simple charts
+ *    - Keep complex interactions with Recharts for now
+ *    - Migrate fully when alternative providers are ready
+ */

--- a/packages/ui-components/src/charts/index.ts
+++ b/packages/ui-components/src/charts/index.ts
@@ -1,0 +1,38 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+// Provider
+export { ChartProvider, useChartConfig } from './ChartProvider';
+export type { ChartLibrary } from './ChartProvider';
+
+// Chart Components
+export { ScatterChart } from './components/ScatterChart';
+export { BarChart } from './components/BarChart';
+export { LineChart } from './components/LineChart';
+export { ComposedChart } from './components/ComposedChart';
+
+// Types
+export type {
+  ChartDataPoint,
+  ChartDomain,
+  ChartMargin,
+  BaseChartProps,
+  ScatterChartProps,
+  BarChartProps,
+  LineChartProps,
+  ComposedChartProps,
+} from './types';
+
+// Native components for use within ComposedChart
+export { 
+  Scatter,
+  Bar,
+  Line,
+  Cell,
+  Legend,
+  ReferenceLine,
+  Tooltip as RechartsTooltip,
+} from 'recharts';

--- a/packages/ui-components/src/charts/types.ts
+++ b/packages/ui-components/src/charts/types.ts
@@ -1,0 +1,89 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import { ReactNode } from 'react';
+
+export interface ChartDataPoint {
+  x: number;
+  y: number;
+  [key: string]: any;
+}
+
+export interface ChartDomain {
+  x?: [number, number];
+  y?: [number, number];
+}
+
+export interface ChartMargin {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+}
+
+export interface BaseChartProps {
+  data: ChartDataPoint[];
+  domain?: ChartDomain;
+  margin?: ChartMargin;
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  onMouseMove?: (event: any) => void;
+  onMouseDown?: (event: any) => void;
+  onMouseUp?: (event: any) => void;
+  onMouseLeave?: (event: any) => void;
+}
+
+export interface ScatterChartProps extends BaseChartProps {
+  xDataKey?: string;
+  yDataKey?: string;
+  xLabel?: string;
+  yLabel?: string;
+  showGrid?: boolean;
+  showReferenceLines?: boolean;
+  tooltip?: ReactNode | ((props: any) => ReactNode);
+  dot?: ReactNode | ((props: any) => React.ReactElement);
+  fill?: string;
+  stroke?: string;
+  children?: ReactNode;
+}
+
+export interface BarChartProps extends BaseChartProps {
+  dataKey: string;
+  xDataKey?: string;
+  xLabel?: string;
+  yLabel?: string;
+  showGrid?: boolean;
+  fill?: string;
+  children?: ReactNode;
+}
+
+export interface LineChartProps extends BaseChartProps {
+  dataKey: string;
+  xDataKey?: string;
+  xLabel?: string;
+  yLabel?: string;
+  showGrid?: boolean;
+  stroke?: string;
+  strokeWidth?: number;
+  dot?: boolean | ReactNode;
+  children?: ReactNode;
+}
+
+export interface ComposedChartProps extends BaseChartProps {
+  xDataKey?: string;
+  xLabel?: string;
+  yLabel?: string;
+  showGrid?: boolean;
+  children?: ReactNode;
+}
+
+export interface ChartAdapter {
+  ScatterChart: React.FC<ScatterChartProps>;
+  BarChart: React.FC<BarChartProps>;
+  LineChart: React.FC<LineChartProps>;
+  ComposedChart: React.FC<ComposedChartProps>;
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -69,3 +69,31 @@ export {
   type FormattedError,
   type ErrorSeverity
 } from './utils/errorMessages';
+
+// Charts
+export {
+  ChartProvider,
+  useChartConfig,
+  ScatterChart,
+  BarChart,
+  LineChart,
+  ComposedChart,
+  // Native Recharts components for composition
+  Scatter,
+  Bar,
+  Line,
+  Cell,
+  Legend,
+  ReferenceLine,
+  RechartsTooltip,
+  // Types
+  type ChartLibrary,
+  type ChartDataPoint,
+  type ChartDomain,
+  type ChartMargin,
+  type BaseChartProps,
+  type ScatterChartProps,
+  type BarChartProps,
+  type LineChartProps,
+  type ComposedChartProps,
+} from './charts';


### PR DESCRIPTION
## Summary

This PR implements a minimal chart abstraction layer that enables gradual migration from Recharts to more capable charting libraries (Plotly, D3) without breaking existing functionality.

## Problem

Recharts has fundamental limitations with zoom/pan functionality that make it unsuitable for scientific data visualization needs (see #268). The zoom feature cannot be properly implemented due to how Recharts handles axis domains.

## Solution

Created a thin abstraction layer following the KISS principle that:
- Wraps current Recharts components with a provider-based interface
- Enables future library swapping without rewriting visualization components
- Maintains 100% backward compatibility with existing code

## Implementation Details

### New Components
- **ChartProvider**: Context for chart library selection
- **Chart wrappers**: ScatterChart, BarChart, LineChart, ComposedChart
- **Recharts adapter**: Preserves all current functionality
- **Example component**: Demonstrates migration pattern

### Architecture
```
packages/ui-components/src/charts/
├── ChartProvider.tsx      # Library selection context
├── types.ts               # Abstract interfaces
├── components/            # Wrapper components
├── adapters/              # Library-specific adapters
│   └── recharts/         # Current implementation
└── examples/             # Migration examples
```

## Benefits
- ✅ No breaking changes to existing code
- ✅ Enables side-by-side testing of different libraries
- ✅ Provides clear migration path for zoom/pan improvements
- ✅ Maintains single source of truth for chart logic
- ✅ Follows existing codebase patterns (Context providers, shared components)

## Testing
- Built ui-components package successfully
- Built GoPCA Desktop frontend successfully
- All pre-commit checks passed
- Core tests continue to pass

## Future Work
1. Implement Plotly adapter for better zoom/pan
2. Gradually migrate visualization components to use abstraction
3. A/B test different libraries for performance
4. Remove Recharts once migration complete (optional)

## Migration Guide

Current visualizations continue using Recharts directly. When ready to migrate:

```typescript
// Before
import { ComposedChart, Scatter } from 'recharts';

// After
import { ComposedChart, ScatterChart } from '@gopca/ui-components';
```

The abstraction automatically handles theme integration, provider selection, and common configurations.

Closes #270