### PR TITLE
Fix: Scores Plot not displaying continuous data for Swiss Roll dataset

### DIFF
--- a/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
@@ -228,22 +228,25 @@ export class PlotlyScoresPlot extends PlotlyVisualization<ScoresPlotData> {
       return smartLabelIndices.includes(i) ? label : '';
     });
 
+    // Check if we have any actual labels to display
+    const hasLabels = smartLabelIndices.length > 0;
+
     // Create single trace with gradient colors
     // Use the actual numeric values for colors, not interpolated hex colors
     traces.push({
       type: 'scatter',
-      mode: 'markers+text' as any,
+      mode: hasLabels ? ('markers+text' as any) : 'markers',
       name: 'Samples',
       x: scores.map(s => s[pc1]),
       y: scores.map(s => s[pc2]),
-      text: text,
+      text: hasLabels ? text : undefined,
       hovertext: hovertext,
       hovertemplate: '%{hovertext}<extra></extra>',
-      textposition: 'top center',
-      textfont: {
+      textposition: hasLabels ? 'top center' : undefined,
+      textfont: hasLabels ? {
         size: 10,
         color: this.config.theme === 'dark' ? '#e5e7eb' : '#374151'
-      },
+      } : undefined,
       marker: {
         size: 8,
         color: groupValues, // Use raw numeric values


### PR DESCRIPTION
## Summary
Fixes the Scores Plot rendering empty when displaying the Swiss Roll dataset with continuous color values.

## Problem
When the Swiss Roll dataset was loaded with its continuous `color #target` column, the Scores Plot would render completely empty while the Biplot correctly displayed the same data with a color gradient.

## Root Cause
The issue was in the `getContinuousTraces()` method in `PlotlyScoresPlot.tsx`. The trace was always using `'markers+text'` mode even when no labels were being displayed. When all text values were empty strings (no smart labels), Plotly would not render the markers at all.

## Solution
Modified the `getContinuousTraces()` method to:
- Check if there are any smart labels to display
- Use `'markers'` mode when no labels are needed
- Only use `'markers+text'` mode when there are actual labels to display
- Conditionally set text-related properties only when labels are present

This matches the behavior of the Biplot component which handles continuous data correctly.

## Testing
- ✅ Tested with Swiss Roll dataset - Scores Plot now displays correctly with continuous color gradient
- ✅ Verified Biplot still works correctly with Swiss Roll dataset
- ✅ Ran PCA CLI tests to ensure core functionality is not affected
- ✅ All Go tests pass

## Screenshots
Before: Scores Plot was empty for Swiss Roll dataset
After: Scores Plot now correctly displays the scores with continuous color gradient, matching the Biplot

Closes #278