### PR TITLE
Fix: Disable incompatible visualizations for Kernel PCA

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -159,6 +159,16 @@ function AppContent() {
         };
     }, []);
 
+    // Auto-switch visualization when Kernel PCA is selected and incompatible plot is active
+    useEffect(() => {
+        if (pcaResponse && pcaResponse.result && pcaResponse.result.method === 'kernel') {
+            if (selectedPlot === 'loadings' || selectedPlot === 'diagnostics' || selectedPlot === 'eigencorrelation') {
+                // Switch to scores plot as a safe default
+                setSelectedPlot('scores');
+            }
+        }
+    }, [pcaResponse, selectedPlot]);
+
     // Helper function to get column data and type
     const getColumnData = (columnName: string | null): { values?: string[] | number[], type?: 'categorical' | 'continuous' } => {
         if (!columnName || !fileData) {
@@ -1065,7 +1075,9 @@ return;
                                                 <option value="scores">Scores Plot</option>
                                                 <option value="scores3d">3D Scores Plot</option>
                                                 <option value="scree">Scree Plot</option>
-                                                <option value="loadings">Loadings Plot</option>
+                                                {pcaResponse.result.method !== 'kernel' && (
+                                                    <option value="loadings">Loadings Plot</option>
+                                                )}
                                                 {pcaResponse.result.preprocessing_applied && (
                                                     <option value="biplot">Biplot</option>
                                                 )}
@@ -1075,8 +1087,10 @@ return;
                                                 {pcaResponse.result.preprocessing_applied && (
                                                     <option value="correlations">Circle of Correlations</option>
                                                 )}
-                                                <option value="diagnostics">Diagnostic Plot</option>
-                                                {pcaResponse.result.eigencorrelations && (
+                                                {pcaResponse.result.method !== 'kernel' && (
+                                                    <option value="diagnostics">Diagnostic Plot</option>
+                                                )}
+                                                {pcaResponse.result.eigencorrelations && pcaResponse.result.method !== 'kernel' && (
                                                     <option value="eigencorrelation">Eigencorrelation Plot</option>
                                                 )}
                                             </select>
@@ -1275,7 +1289,7 @@ return;
                                         )}
 
                                         {/* Loadings Plot Component Selector */}
-                                        {selectedPlot === 'loadings' && (
+                                        {selectedPlot === 'loadings' && pcaResponse.result?.method !== 'kernel' && (
                                             <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
                                                 <label className="text-sm text-gray-600 dark:text-gray-400">Component:</label>
                                                 <select
@@ -1356,7 +1370,7 @@ return;
                                                 showCumulative={true}
                                                 elbowThreshold={80}
                                             />
-                                        ) : selectedPlot === 'loadings' ? (
+                                        ) : selectedPlot === 'loadings' && pcaResponse.result.method !== 'kernel' ? (
                                             <LoadingsPlot
                                                 pcaResult={pcaResponse.result}
                                                 selectedComponent={selectedLoadingComponent}
@@ -1412,7 +1426,7 @@ return;
                                                 xComponent={selectedXComponent}
                                                 yComponent={selectedYComponent}
                                             />
-                                        ) : selectedPlot === 'diagnostics' ? (
+                                        ) : selectedPlot === 'diagnostics' && pcaResponse.result.method !== 'kernel' ? (
                                             <DiagnosticScatterPlot
                                                 pcaResult={pcaResponse.result}
                                                 rowNames={fileData?.rowNames || []}


### PR DESCRIPTION
## Summary
This PR comprehensively fixes the application crashes and incorrect visualization options that occur when using Kernel PCA method.

## Problem
Multiple visualizations were incorrectly available for Kernel PCA, causing crashes or showing meaningless data:
1. **Loadings Plot** - Always visible, caused crash
2. **Diagnostic Plot** - Always visible, would crash or show invalid metrics
3. **Eigencorrelation Plot** - Could be visible with invalid data

These visualizations are not mathematically meaningful for Kernel PCA since it operates in a transformed feature space.

## Solution
Implemented a comprehensive fix that hides incompatible visualizations and adds safety checks:

### For Loadings Plot:
- Hides the option from dropdown when `method === 'kernel'`
- Added safety check to component selector
- Added safety check to component rendering

### For Diagnostic Plot:
- Hides the option from dropdown when `method === 'kernel'`
- Added safety check to component rendering
- (RSS/SPE calculation requires loadings which don't exist for Kernel PCA)

### For Eigencorrelation Plot:
- Added explicit check to hide when `method === 'kernel'`
- Already protected by data availability check

### General Improvements:
- Updated `useEffect` to auto-switch from any incompatible plot to Scores Plot
- Handles all three incompatible visualizations

## Technical Details
Kernel PCA operates in a transformed (often infinite-dimensional) feature space where:
- Traditional loadings (variable contributions) don't exist
- RSS/SPE metrics can't be calculated without loadings
- Direct correlations with original variables are not meaningful

## Changes Made
- Modified visualization dropdown conditions (lines 1068-1093)
- Added safety check to loadings component selector (line 1280)
- Added safety checks to component rendering (lines 1361, 1429)
- Updated useEffect hook to handle all incompatible plots (lines 162-170)

## Testing
✅ Built successfully with no TypeScript errors
✅ Verified Loadings Plot is visible for SVD and NIPALS methods
✅ Verified Loadings Plot is hidden for Kernel PCA method
✅ Verified Diagnostic Plot is hidden for Kernel PCA method
✅ Verified Eigencorrelation Plot handling for Kernel PCA
✅ Verified auto-switch works when changing to Kernel PCA with incompatible plot selected

## Impact
- Prevents multiple application crash scenarios
- Improves user experience by only showing mathematically valid visualizations
- Maintains full compatibility with SVD and NIPALS methods

Closes #299