### PR TITLE
Fix: Add validation for minimum components in 3D plots

### DIFF
--- a/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
@@ -594,6 +594,42 @@ export const PCA3DBiplot: React.FC<{
   data: Biplot3DData;
   config?: Biplot3DConfig;
 }> = ({ data, config }) => {
+  // Check if we have enough components for 3D visualization
+  const pc3 = data.pc3 ?? 2;
+  const numComponents = data.scores[0]?.length || 0;
+  const numLoadingComponents = data.loadings?.length || 0;
+  
+  // Validate that we have at least 3 components in both scores and loadings
+  if (numComponents < 3 || pc3 >= numComponents || numLoadingComponents < 3 || pc3 >= numLoadingComponents) {
+    const theme = config?.theme || 'light';
+    return (
+      <div style={{ 
+        width: '100%', 
+        height: '100%', 
+        display: 'flex', 
+        alignItems: 'center', 
+        justifyContent: 'center',
+        flexDirection: 'column'
+      }}>
+        <p style={{ 
+          color: theme === 'dark' ? '#9ca3af' : '#6b7280', 
+          textAlign: 'center',
+          marginBottom: '10px'
+        }}>
+          3D Biplot requires at least 3 principal components.
+        </p>
+        <p style={{ 
+          color: theme === 'dark' ? '#9ca3af' : '#6b7280', 
+          textAlign: 'center',
+          fontSize: '14px'
+        }}>
+          Current PCA has only {numComponents} component{numComponents === 1 ? '' : 's'}.
+          Please use the 2D Biplot visualization instead.
+        </p>
+      </div>
+    );
+  }
+  
   const plot = useMemo(() => new Plotly3DBiplot(data, config), [data, config]);
 
   return (

--- a/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
@@ -289,6 +289,42 @@ export const PCA3DScoresPlot: React.FC<{
   data: Scores3DPlotData;
   config?: Scores3DPlotConfig;
 }> = ({ data, config }) => {
+  // Check if we have enough components for 3D visualization
+  const pc3 = data.pc3 ?? 2;
+  const numComponents = data.scores[0]?.length || 0;
+  const numExplainedVariance = data.explainedVariance?.length || 0;
+  
+  // Validate that we have at least 3 components
+  if (numComponents < 3 || pc3 >= numComponents || numExplainedVariance < 3 || pc3 >= numExplainedVariance) {
+    const theme = config?.theme || 'light';
+    return (
+      <div style={{ 
+        width: '100%', 
+        height: '100%', 
+        display: 'flex', 
+        alignItems: 'center', 
+        justifyContent: 'center',
+        flexDirection: 'column'
+      }}>
+        <p style={{ 
+          color: theme === 'dark' ? '#9ca3af' : '#6b7280', 
+          textAlign: 'center',
+          marginBottom: '10px'
+        }}>
+          3D Scores Plot requires at least 3 principal components.
+        </p>
+        <p style={{ 
+          color: theme === 'dark' ? '#9ca3af' : '#6b7280', 
+          textAlign: 'center',
+          fontSize: '14px'
+        }}>
+          Current PCA has only {numComponents} component{numComponents === 1 ? '' : 's'}.
+          Please use the 2D Scores Plot visualization instead.
+        </p>
+      </div>
+    );
+  }
+  
   const plot = useMemo(() => new Plotly3DScoresPlot(data, config), [data, config]);
 
   return (


### PR DESCRIPTION
## Summary
- Added validation to prevent crashes when 3D plots are rendered with less than 3 principal components
- Both 3D Biplot and 3D Scores Plot now display a helpful error message instead of crashing
- Fixes #298

## Changes
1. **3D Biplot (`Plotly3DBiplot.tsx`)**:
   - Added validation to check if PCA has at least 3 components
   - Added validation for loadings array to ensure it has at least 3 components
   - Display informative message when insufficient components are available

2. **3D Scores Plot (`Plotly3DScoresPlot.tsx`)**:
   - Added validation to check if PCA has at least 3 components
   - Added validation for explainedVariance array
   - Display informative message when insufficient components are available

## Test Plan
- [x] Build UI components successfully
- [x] TypeScript compilation passes
- [x] Pre-commit hooks pass
- [ ] Test with PCA having 1 component - should show error message
- [ ] Test with PCA having 2 components - should show error message
- [ ] Test with PCA having 3+ components - should render normally

## Screenshots
When PCA has less than 3 components, users will see:
> "3D [Plot Type] requires at least 3 principal components.
> Current PCA has only [N] component(s).
> Please use the 2D [Plot Type] visualization instead."

This is consistent with how we handle incompatible visualizations for Kernel PCA.