### PR TITLE
docs: add AI assistant automation instructions to release guide

### DIFF
--- a/docs/devel/release-guide.md
+++ b/docs/devel/release-guide.md
@@ -19,6 +19,42 @@ The release process is fully automated via GitHub Actions. Once you push a versi
 
 ## Release Process
 
+### Automated Execution (AI Assistant/Claude Code)
+
+When using Claude Code or another AI assistant to create a release, the assistant can automate most steps:
+
+**What the AI CAN do automatically:**
+1. ✅ Check current version and determine next version
+2. ✅ Verify main branch and clean working directory
+3. ✅ Run tests and linters
+4. ✅ Execute prepare-release.sh script
+5. ✅ Push release branch
+6. ✅ Create pull request
+7. ✅ Monitor CI checks status
+8. ✅ After PR merge: checkout main, pull, and run release.sh
+9. ✅ Monitor release workflow progress
+
+**What requires MANUAL action:**
+- ❌ **Merge the PR** - Must be done via GitHub web interface due to branch protection rules
+
+**AI Assistant Instructions:**
+```bash
+# The AI will execute these automatically:
+./scripts/prepare-release.sh v0.9.1
+git push -u origin release-v0.9.1
+gh pr create --title "Release v0.9.1" --body "Preparing release v0.9.1"
+
+# AI will monitor CI and notify when ready to merge
+# After you merge, AI continues automatically:
+git checkout main && git pull origin main
+./scripts/release.sh v0.9.1
+gh run watch  # AI monitors until complete
+```
+
+### Manual Execution (Human Developer)
+
+If executing manually, follow these steps:
+
 ### Step 1: Prepare the Release
 
 Run the release preparation script with your desired version:


### PR DESCRIPTION
## Summary
This PR updates the release guide to include clear instructions for AI assistants (like Claude Code) to automate the release process.

## Changes
- Added new 'Automated Execution' section specifically for AI assistants
- Clearly documented what steps can be automated vs what requires manual action
- Specified that PR merging must be done manually via GitHub web interface
- Preserved original instructions under 'Manual Execution' section

## Purpose
This documentation ensures that AI assistants have clear, explicit instructions for automating releases, reducing manual work while respecting GitHub's branch protection requirements.

The key insight is that AI can automate everything except the PR merge step, which requires web interface access due to branch protection rules.