### PR TITLE
ci: add integration tests to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,20 @@ jobs:
           echo "ineffassign not found, skipping"
         fi
       shell: bash
+    
+    - name: Build CLI for integration tests
+      run: |
+        echo "Building CLI for integration tests..."
+        make build
+      shell: bash
+    
+    - name: Run integration tests
+      run: |
+        echo "Running integration tests..."
+        make test-e2e
+      shell: bash
+      env:
+        GOPCA_TEST_TIMEOUT: 60
 
   build-cli:
     name: Build CLI


### PR DESCRIPTION
## Summary
This PR adds integration tests to the CI workflow, implementing the solution for issue #266.

## Changes
- Added CLI build step before integration tests
- Added integration test execution using `make test-e2e`
- Tests use pre-built binary for optimal performance (~1 second execution time)

## Why This Matters
We have comprehensive integration tests written but they were never run in CI. This was a critical gap - tests that don't run automatically provide no regression protection. Now we get:
- ✅ Automatic regression detection
- ✅ Cross-platform validation (Linux/macOS/Windows)
- ✅ End-to-end workflow verification
- ✅ Fast execution (tests complete in ~1 second)

## Implementation Details
Following the guidance in issue #266 to "start simple":
- Minimal changes to existing workflow
- Uses existing make targets (no new scripts)
- Tests already proven to work locally
- Low risk, high value addition

## Testing
- Verified locally with `make build && make test-e2e`
- Tests pass in 1.057 seconds using pre-built binary
- Will be validated across all platforms in CI

Fixes #266