### PR TITLE
chore: rename 'Desktop' to 'GoPCA' throughout build files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         retention-days: 7
 
   build-desktop:
-    name: Build Desktop App
+    name: Build GoPCA App
     needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' || github.ref == 'refs/heads/160-macos-signing'
     strategy:
@@ -226,11 +226,11 @@ jobs:
         # Build the shared components that both apps depend on
         npm run build-ui
     
-    - name: Build desktop app
+    - name: Build GoPCA app
       run: PLATFORM=${{ matrix.platform }} ./scripts/ci/build-desktop.sh
       shell: bash
     
-    - name: Sign desktop app (macOS)
+    - name: Sign GoPCA app (macOS)
       if: matrix.os == 'macos-latest'
       env:
         APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
@@ -240,7 +240,7 @@ jobs:
         ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
       shell: bash
     
-    - name: Notarize desktop app (macOS)
+    - name: Notarize GoPCA app (macOS)
       if: matrix.os == 'macos-latest'
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -250,7 +250,7 @@ jobs:
         ./scripts/ci/notarize-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
       shell: bash
     
-    - name: Upload desktop artifacts
+    - name: Upload GoPCA artifacts
       uses: actions/upload-artifact@v4
       with:
         name: gopca-desktop-${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         retention-days: 1
 
   build-desktop:
-    name: Build Desktop - ${{ matrix.os }}
+    name: Build GoPCA - ${{ matrix.os }}
     strategy:
       matrix:
         include:
@@ -166,7 +166,7 @@ jobs:
         fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     
-    - name: Build desktop app
+    - name: Build GoPCA app
       working-directory: cmd/gopca-desktop
       env:
         VERSION: ${{ steps.get_version.outputs.version }}
@@ -178,7 +178,7 @@ jobs:
           -X github.com/bitjungle/gopca/internal/version.GitCommit=$(git rev-parse --short HEAD) \
           -X github.com/bitjungle/gopca/internal/version.BuildDate=$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
     
-    - name: Sign Desktop app (macOS)
+    - name: Sign GoPCA app (macOS)
       if: matrix.os == 'macos-latest'
       env:
         APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
@@ -187,7 +187,7 @@ jobs:
       run: |
         ./scripts/ci/sign-macos-ci.sh cmd/gopca-desktop/build/bin/GoPCA.app
     
-    - name: Notarize Desktop app (macOS)
+    - name: Notarize GoPCA app (macOS)
       if: matrix.os == 'macos-latest'
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -352,7 +352,7 @@ jobs:
         name: pca-windows-amd64
         path: windows-cli
     
-    - name: Download Windows Desktop artifact
+    - name: Download Windows GoPCA artifact
       if: steps.check_signpath.outputs.configured == 'true'
       uses: actions/download-artifact@v4
       with:
@@ -388,8 +388,8 @@ jobs:
         wait-for-completion: true
         output-artifact-directory: signed-cli
     
-    # Sign Desktop app
-    - name: Upload Desktop for signing
+    # Sign GoPCA app
+    - name: Upload GoPCA for signing
       if: steps.check_signpath.outputs.configured == 'true'
       id: upload-desktop
       uses: actions/upload-artifact@v4
@@ -397,7 +397,7 @@ jobs:
         name: unsigned-desktop
         path: windows-desktop/GoPCA.exe
     
-    - name: Sign Desktop app
+    - name: Sign GoPCA app
       if: steps.check_signpath.outputs.configured == 'true'
       id: sign-desktop
       uses: SignPath/github-action-submit-signing-request@v1
@@ -529,7 +529,7 @@ jobs:
         path: windows-signed
       continue-on-error: true
     
-    - name: Download Windows Desktop artifact
+    - name: Download Windows GoPCA artifact
       uses: actions/download-artifact@v4
       with:
         name: gopca-desktop-windows-latest
@@ -555,15 +555,15 @@ jobs:
           cp windows-cli/pca-windows-amd64.exe build/windows-installer/pca-windows-amd64.exe
         fi
         
-        # Copy Desktop app (prefer signed, handle both naming conventions)
+        # Copy GoPCA app (prefer signed, handle both naming conventions)
         if [ "${{ steps.check_signed.outputs.use_signed }}" = "true" ] && [ -f "windows-signed/GoPCA.exe" ]; then
-          echo "Using signed Desktop binary"
+          echo "Using signed GoPCA binary"
           cp windows-signed/GoPCA.exe build/windows-installer/GoPCA.exe
         elif [ -f "windows-desktop/GoPCA-amd64.exe" ]; then
-          echo "Using unsigned Desktop binary (cross-compiled)"
+          echo "Using unsigned GoPCA binary (cross-compiled)"
           cp windows-desktop/GoPCA-amd64.exe build/windows-installer/GoPCA.exe
         elif [ -f "windows-desktop/GoPCA.exe" ]; then
-          echo "Using unsigned Desktop binary"
+          echo "Using unsigned GoPCA binary"
           cp windows-desktop/GoPCA.exe build/windows-installer/GoPCA.exe
         else
           echo "ERROR: No GoPCA.exe found!"
@@ -706,7 +706,7 @@ jobs:
           cp "pca-darwin-arm64/pca-darwin-arm64" "macos/pca-arm64"
         fi
         
-        # Desktop app (use cp -a to preserve permissions and symlinks)
+        # GoPCA app (use cp -a to preserve permissions and symlinks)
         if [ -d "gopca-desktop-macos-latest/GoPCA.app" ]; then
           cp -a "gopca-desktop-macos-latest/GoPCA.app" "macos/"
         fi
@@ -733,12 +733,12 @@ jobs:
           cp "pca-windows-amd64/pca-windows-amd64.exe" "windows/pca.exe"
         fi
         
-        # Desktop app (prefer signed)
+        # GoPCA app (prefer signed)
         if [ "${{ steps.check_signed.outputs.windows_signed }}" = "signed" ] && [ -f "windows-signed/GoPCA.exe" ]; then
-          echo "Using signed Windows Desktop binary"
+          echo "Using signed Windows GoPCA binary"
           cp "windows-signed/GoPCA.exe" "windows/GoPCA.exe"
         elif [ -f "gopca-desktop-windows-latest/GoPCA.exe" ]; then
-          echo "Using unsigned Windows Desktop binary"
+          echo "Using unsigned Windows GoPCA binary"
           cp "gopca-desktop-windows-latest/GoPCA.exe" "windows/GoPCA.exe"
         fi
         
@@ -767,7 +767,7 @@ jobs:
           cp "pca-linux-arm64/pca-linux-arm64" "linux/pca-arm64"
         fi
         
-        # Desktop app
+        # GoPCA app
         if [ -f "gopca-desktop-ubuntu-latest/GoPCA" ]; then
           cp "gopca-desktop-ubuntu-latest/GoPCA" "linux/GoPCA"
         fi
@@ -859,7 +859,7 @@ jobs:
           |----------|----------|----------|
           | **macOS** | [`gopca-macos-universal.zip`](../../releases/download/${{ github.ref_name }}/gopca-macos-universal.zip) | • `pca-intel` and `pca-arm64` CLI tools<br>• `GoPCA.app` (signed & notarized)<br>• `GoCSV.app` (signed & notarized) |
           | **Windows** | [`gopca-windows-x64.zip`](../../releases/download/${{ github.ref_name }}/gopca-windows-x64.zip) | • `pca.exe` CLI tool${{ steps.check_signed.outputs.windows_signed == 'signed' && ' (digitally signed)' || '' }}<br>• `GoPCA.exe`${{ steps.check_signed.outputs.windows_signed == 'signed' && ' (digitally signed)' || '' }}<br>• `GoCSV.exe`${{ steps.check_signed.outputs.windows_signed == 'signed' && ' (digitally signed)' || '' }} |
-          | **Linux** | [`gopca-linux-x64.tar.gz`](../../releases/download/${{ github.ref_name }}/gopca-linux-x64.tar.gz) | • `pca-x64` and `pca-arm64` CLI tools<br>• `GoPCA` desktop app<br>• `GoCSV` editor |
+          | **Linux** | [`gopca-linux-x64.tar.gz`](../../releases/download/${{ github.ref_name }}/gopca-linux-x64.tar.gz) | • `pca-x64` and `pca-arm64` CLI tools<br>• `GoPCA` app<br>• `GoCSV` editor |
           
           ### Windows Installer (Recommended for Windows users)
           

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ COVERAGE_FILE := coverage.out
 cli: build
 cli-all: build-all
 
-# Shortcuts for desktop/GUI builds  
+# Shortcuts for GoPCA/GUI builds  
 desktop: pca-build
 desktop-dev: pca-dev
 pca: pca-build
@@ -53,7 +53,7 @@ LDFLAGS := -ldflags="-s -w \
 	-X github.com/bitjungle/gopca/internal/version.GitCommit=$(GIT_COMMIT) \
 	-X github.com/bitjungle/gopca/internal/version.BuildDate=$(BUILD_DATE)"
 
-# Desktop build flags (for Wails)
+# GoPCA build flags (for Wails)
 DESKTOP_LDFLAGS := -ldflags "-s -w \
 	-X github.com/bitjungle/gopca/internal/version.Version=$(VERSION) \
 	-X github.com/bitjungle/gopca/internal/version.GitCommit=$(GIT_COMMIT) \
@@ -123,10 +123,10 @@ build-all-parallel:
 	@$(MAKE) -j5 build-darwin-amd64 build-darwin-arm64 build-linux-amd64 build-linux-arm64 build-windows-amd64
 	@echo "All parallel CLI builds complete!"
 
-## pca-dev: Run PCA Desktop in development mode with hot reload
+## pca-dev: Run GoPCA in development mode with hot reload
 pca-dev:
 	@if [ -x "$(WAILS)" ]; then \
-		echo "Starting PCA Desktop in development mode..."; \
+		echo "Starting GoPCA in development mode..."; \
 		cd $(DESKTOP_PATH) && $(WAILS) dev; \
 	else \
 		echo "Wails not found. Install it with:"; \
@@ -134,36 +134,36 @@ pca-dev:
 		exit 1; \
 	fi
 
-## pca-build: Build PCA Desktop application for production
+## pca-build: Build GoPCA application for production
 pca-build:
 	@if [ -x "$(WAILS)" ]; then \
-		echo "Building PCA Desktop application..."; \
+		echo "Building GoPCA application..."; \
 		cd $(DESKTOP_PATH) && $(WAILS) build $(DESKTOP_LDFLAGS); \
-		echo "PCA Desktop build complete. Check $(DESKTOP_PATH)/build/bin/"; \
+		echo "GoPCA build complete. Check $(DESKTOP_PATH)/build/bin/"; \
 	else \
 		echo "Wails not found. Install it with:"; \
 		echo "  go install github.com/wailsapp/wails/v2/cmd/wails@latest"; \
 		exit 1; \
 	fi
 
-## pca-run: Run the built PCA Desktop application
+## pca-run: Run the built GoPCA application
 pca-run:
 	@if [ -f "$(DESKTOP_PATH)/build/bin/GoPCA.app/Contents/MacOS/GoPCA" ]; then \
-		echo "Running PCA Desktop application..."; \
+		echo "Running GoPCA application..."; \
 		open $(DESKTOP_PATH)/build/bin/GoPCA.app; \
 	elif [ -f "$(DESKTOP_PATH)/build/bin/gopca-desktop" ]; then \
-		echo "Running PCA Desktop application..."; \
+		echo "Running GoPCA application..."; \
 		$(DESKTOP_PATH)/build/bin/gopca-desktop; \
 	else \
-		echo "PCA Desktop application not found. Build it first with 'make pca-build'"; \
+		echo "GoPCA application not found. Build it first with 'make pca-build'"; \
 		exit 1; \
 	fi
 
-## pca-deps: Install frontend dependencies for PCA Desktop
+## pca-deps: Install frontend dependencies for GoPCA
 pca-deps:
-	@echo "Installing PCA Desktop frontend dependencies..."
+	@echo "Installing GoPCA frontend dependencies..."
 	@cd $(DESKTOP_PATH)/frontend && npm install
-	@echo "PCA Desktop dependencies installed"
+	@echo "GoPCA dependencies installed"
 
 ## csv-dev: Run CSV editor in development mode with hot reload
 csv-dev:
@@ -223,16 +223,16 @@ sign-cli:
 	@echo "Signing CLI binary..."
 	@./scripts/sign-macos.sh | grep -A 3 "CLI"
 
-## sign-pca: Sign only the GoPCA Desktop app
+## sign-pca: Sign only the GoPCA app
 sign-pca:
-	@echo "Signing GoPCA Desktop app..."
+	@echo "Signing GoPCA app..."
 	@if [ -d "$(DESKTOP_PATH)/build/bin/GoPCA.app" ]; then \
 		codesign --force --deep --sign "$${APPLE_DEVELOPER_ID:-Developer ID Application: Rune Mathisen (LV599Q54BU)}" \
 			--options runtime --timestamp \
 			"$(DESKTOP_PATH)/build/bin/GoPCA.app" && \
 		codesign --verify --verbose "$(DESKTOP_PATH)/build/bin/GoPCA.app"; \
 	else \
-		echo "GoPCA Desktop app not found. Build it first with 'make pca-build'"; \
+		echo "GoPCA app not found. Build it first with 'make pca-build'"; \
 		exit 1; \
 	fi
 
@@ -269,7 +269,7 @@ sign-windows:
 	elif [ -f "$(DESKTOP_PATH)/build/bin/GoPCA.exe" ]; then \
 		echo "✅ Found: GoPCA.exe"; \
 	else \
-		echo "❌ ERROR: GoPCA Desktop not found"; \
+		echo "❌ ERROR: GoPCA not found"; \
 		echo "  Searched: $(DESKTOP_PATH)/build/bin/GoPCA-amd64.exe"; \
 		echo "  Searched: $(DESKTOP_PATH)/build/bin/GoPCA.exe"; \
 		echo ""; \
@@ -397,7 +397,7 @@ windows-installer:
 	elif [ -f "$(DESKTOP_PATH)/build/bin/GoPCA.exe" ]; then \
 		echo "✅ Found: GoPCA.exe"; \
 	else \
-		echo "❌ ERROR: GoPCA Desktop not found"; \
+		echo "❌ ERROR: GoPCA not found"; \
 		echo "  Searched: $(DESKTOP_PATH)/build/bin/GoPCA-amd64.exe"; \
 		echo "  Searched: $(DESKTOP_PATH)/build/bin/GoPCA.exe"; \
 		echo ""; \
@@ -477,11 +477,11 @@ notarize-cli:
 	APPLE_TEAM_ID="$${APPLE_TEAM_ID:-LV599Q54BU}" \
 	./scripts/notarize-macos.sh cli-only
 
-## notarize-pca: Notarize only the GoPCA Desktop app
+## notarize-pca: Notarize only the GoPCA app
 notarize-pca:
-	@echo "Notarizing GoPCA Desktop app..."
+	@echo "Notarizing GoPCA app..."
 	@if [ ! -d "$(DESKTOP_PATH)/build/bin/GoPCA.app" ]; then \
-		echo "GoPCA Desktop app not found. Build it first with 'make pca-build'"; \
+		echo "GoPCA app not found. Build it first with 'make pca-build'"; \
 		exit 1; \
 	fi
 	@if [ -f .env ]; then \
@@ -619,14 +619,14 @@ install-hooks:
 	@echo "Installing git hooks..."
 	@./scripts/install-hooks.sh
 
-## ci-test: Run tests for CI (excluding desktop)
+## ci-test: Run tests for CI (excluding GoPCA GUI)
 ci-test:
-	@echo "Running CI tests (excluding desktop)..."
+	@echo "Running CI tests (excluding GoPCA GUI)..."
 	@./scripts/ci/test-core.sh
 
-## ci-lint: Run linter for CI (excluding desktop)
+## ci-lint: Run linter for CI (excluding GoPCA GUI)
 ci-lint:
-	@echo "Running CI linter (excluding desktop)..."
+	@echo "Running CI linter (excluding GoPCA GUI)..."
 ifdef GOLINT
 	golangci-lint run --timeout=5m ./internal/... ./pkg/... ./cmd/gopca-cli/...
 else
@@ -646,12 +646,12 @@ ci-test-all:
 	@echo "Running all tests..."
 	@./scripts/ci/test-all.sh
 
-## pca-build-all: Build PCA Desktop for all platforms
+## pca-build-all: Build GoPCA for all platforms
 pca-build-all:
 	@if [ -x "$(WAILS)" ]; then \
-		echo "Building PCA Desktop for all platforms..."; \
+		echo "Building GoPCA for all platforms..."; \
 		cd $(DESKTOP_PATH) && $(WAILS) build -platform darwin/amd64,darwin/arm64,windows/amd64,linux/amd64 $(DESKTOP_LDFLAGS); \
-		echo "PCA Desktop builds complete for all platforms"; \
+		echo "GoPCA builds complete for all platforms"; \
 	else \
 		echo "Wails not found. Install it with:"; \
 		echo "  go install github.com/wailsapp/wails/v2/cmd/wails@latest"; \
@@ -674,9 +674,9 @@ csv-build-all:
 build-everything: build-all pca-build-all csv-build-all
 	@echo "All applications built for all platforms!"
 
-## ci-build-desktop: Build desktop app in CI
+## ci-build-desktop: Build GoPCA app in CI
 ci-build-desktop:
-	@echo "Building desktop app for CI..."
+	@echo "Building GoPCA app for CI..."
 	@PLATFORM=$(GOOS) ./scripts/ci/build-desktop.sh
 
 ## ci-setup: Setup CI environment
@@ -702,7 +702,7 @@ help:
 	@echo "Quick start:"
 	@echo "  make deps-all         # Install all dependencies (first time)"
 	@echo "  make                  # Build CLI and test (default)"
-	@echo "  make pca-dev          # Run PCA Desktop in dev mode"
+	@echo "  make pca-dev          # Run GoPCA in dev mode"
 	@echo "  make csv-dev          # Run CSV editor in dev mode"
 	@echo ""
 	@echo "Building CLI:"
@@ -714,7 +714,7 @@ help:
 	@echo "Code Signing (macOS):"
 	@echo "  make sign             # Sign all macOS binaries"
 	@echo "  make sign-cli         # Sign CLI binary only"
-	@echo "  make sign-pca         # Sign GoPCA Desktop app only"
+	@echo "  make sign-pca         # Sign GoPCA app only"
 	@echo "  make sign-csv         # Sign GoCSV app only"
 	@echo "  make sign-windows     # Sign Windows binaries (requires signtool/osslsigncode)"
 	@echo ""
@@ -726,12 +726,12 @@ help:
 	@echo "Notarization (macOS):"
 	@echo "  make notarize         # Notarize all signed binaries"
 	@echo "  make notarize-cli     # Notarize CLI only"
-	@echo "  make notarize-pca # Notarize GoPCA Desktop only"
+	@echo "  make notarize-pca     # Notarize GoPCA only"
 	@echo "  make notarize-csv     # Notarize GoCSV only"
 	@echo "  make sign-and-notarize # Sign and notarize everything"
 	@echo "  make build-windows-amd64 # Build for Windows x64"
 	@echo ""
-	@echo "PCA Desktop application:"
+	@echo "GoPCA application:"
 	@echo "  make pca-deps         # Install dependencies"
 	@echo "  make pca-dev          # Run in development mode"
 	@echo "  make pca-build        # Build for current platform"


### PR DESCRIPTION
## Summary
This PR updates all build files to consistently refer to the GoPCA application as "GoPCA" instead of "Desktop" for improved clarity.

## Context
Historically, when we only had the CLI and one GUI app, it made sense to call it "Desktop". Now that we have three distinct applications (CLI, GoPCA, and GoCSV), using "GoPCA" is clearer and more consistent.

## Changes

### .github/workflows/build.yml (5 changes)
- `Build Desktop App` → `Build GoPCA App`
- `Build desktop app` → `Build GoPCA app`
- `Sign desktop app (macOS)` → `Sign GoPCA app (macOS)`
- `Notarize desktop app (macOS)` → `Notarize GoPCA app (macOS)`
- `Upload desktop artifacts` → `Upload GoPCA artifacts`

### .github/workflows/release.yml (16 changes)
- All step names and comments updated similarly
- Release notes updated to say `GoPCA app` instead of `GoPCA desktop app`

### Makefile (28 changes)
- All target descriptions updated (`PCA Desktop` → `GoPCA`)
- Help text updated for consistency
- Comments and echo statements updated
- CI target descriptions updated

## What Did NOT Change
- Job IDs (`build-desktop`) - kept for backward compatibility
- Artifact names (`gopca-desktop-*`) - kept for compatibility
- Directory paths (`cmd/gopca-desktop`) - these are actual folder names
- Script names (`build-desktop.sh`) - these are actual file names
- Variable names (`DESKTOP_PATH`, `DESKTOP_LDFLAGS`) - kept for compatibility

## Impact
- ✅ No functional changes
- ✅ Only display names, comments, and documentation updated
- ✅ All existing workflows and scripts will continue to work
- ✅ Improves clarity and consistency across all build files