### PR TITLE
Release v0.9.13

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.12",
+    "productVersion": "0.9.13",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.12",
+    "productVersion": "0.9.13",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
## Preparing release v0.9.13

This release includes:
- Fix: Resolved linter issues in validation package
- Fix: Linux dark mode dropdown visibility with custom select component (#312)
- Feature: JSON Schema validation for PCA models (#311)
- Enhancement: Linux dark mode dropdown visibility (#310)
- Chore: Renamed 'Desktop' to 'GoPCA' throughout build files (#308)

The version has been bumped to v0.9.13 in all wails.json files.