### PR TITLE
Fix: Left-align dropdown menu items in CustomSelect component

### DIFF
--- a/packages/ui-components/src/components/CustomSelect.tsx
+++ b/packages/ui-components/src/components/CustomSelect.tsx
@@ -215,7 +215,7 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
         onClick={() => handleOptionClick(option)}
         onMouseEnter={() => !option.disabled && setHighlightedIndex(index)}
         className={`
-          relative flex items-center px-3 py-2 cursor-pointer select-none
+          relative flex items-center px-3 py-2 cursor-pointer select-none text-left
           ${option.disabled 
             ? 'opacity-50 cursor-not-allowed bg-gray-50 dark:bg-gray-800 text-gray-400 dark:text-gray-500' 
             : isHighlighted


### PR DESCRIPTION
## Summary
Fixed dropdown menu item alignment in the CustomSelect component to be left-aligned instead of center-aligned for better readability and consistency with standard UI patterns.

## Changes
- Added `text-left` class to the option container div in the `renderOption` function of `CustomSelect.tsx`
- This ensures all dropdown items across both GoPCA Desktop and GoCSV applications are consistently left-aligned

## Testing
- Built the ui-components package successfully
- Tested in GoPCA Desktop application
- Tested in GoCSV application
- All dropdown menus now display with proper left alignment

Closes #316