### PR TITLE
Fix: Remove redundant Auto-size Columns button from GoCSV

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -487,23 +487,6 @@ return;
                                             Transform Data
                                         </span>
                                     </button>
-                                    <div className="w-px h-6 bg-gray-300 dark:bg-gray-600" />
-                                    <button
-                                        onClick={() => {
-                                            if (gridRef.current?.autoSizeColumns) {
-                                                gridRef.current.autoSizeColumns();
-                                            }
-                                        }}
-                                        className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
-                                        title="Auto-size all columns based on their content"
-                                    >
-                                        <span className="flex items-center gap-2">
-                                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16m-7 6h7" />
-                                            </svg>
-                                            Auto-size Columns
-                                        </span>
-                                    </button>
                                 </div>
                                 {missingValueStats && (
                                     <div className="text-sm text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary
Removed the redundant "Auto-size Columns" button from the GoCSV toolbar to simplify the UI without losing functionality.

## Changes
- Removed the Auto-size Columns button element from the toolbar
- Removed the associated divider before the button
- Retained the `autoSizeColumns` method in CSVGrid component for potential future use

## Rationale
- The button was redundant - users can already auto-size columns by double-clicking column borders (standard spreadsheet behavior)
- Simplifies the UI by removing unnecessary toolbar clutter
- Individual column sizing via double-click often provides better results than sizing all columns at once
- Follows the principle of keeping interfaces clean and focused

## Testing
- Built the GoCSV frontend successfully
- Ran the application to verify the button was removed
- Confirmed column auto-sizing via double-click still works
- All tests pass

Closes #317