### PR TITLE
fix: left-align CustomSelect dropdown options

### DIFF
--- a/packages/ui-components/src/components/CustomSelect.tsx
+++ b/packages/ui-components/src/components/CustomSelect.tsx
@@ -215,7 +215,7 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
         onClick={() => handleOptionClick(option)}
         onMouseEnter={() => !option.disabled && setHighlightedIndex(index)}
         className={`
-          relative flex items-center px-3 py-2 cursor-pointer select-none
+          relative flex items-center justify-start px-3 py-2 cursor-pointer select-none text-left
           ${option.disabled 
             ? 'opacity-50 cursor-not-allowed bg-gray-50 dark:bg-gray-800 text-gray-400 dark:text-gray-500' 
             : isHighlighted
@@ -225,6 +225,7 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
                 : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
           }
         `}
+
       >
         {option.icon && (
           <span className="mr-2 flex-shrink-0">{option.icon}</span>


### PR DESCRIPTION
This PR updates the `CustomSelect` component so that dropdown options are left-aligned instead of centered, which improves readability and consistency.

I wasn’t able to run the UI locally, but based on the code this should be the correct fix. Please verify on your end that the alignment works as expected.