### PR TITLE
Fix: Explained variance display shows percentages correctly

### DIFF
--- a/internal/cobra/output.go
+++ b/internal/cobra/output.go
@@ -177,7 +177,7 @@ func outputTableFormat(result *types.PCAResult, data *pkgcsv.Data,
 		for i := 0; i < len(result.ComponentLabels); i++ {
 			fmt.Printf("%-15s%14.1f%%%14.1f%%\n",
 				result.ComponentLabels[i],
-				result.ExplainedVar[i],
+				result.ExplainedVarRatio[i],
 				result.CumulativeVar[i])
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes incorrect display of explained variance in CLI output where raw eigenvalues were shown instead of percentages.

## Issue
During the v1.0 audit (#324), discovered that the CLI table output was displaying raw eigenvalues (e.g., "2.0%") instead of the correct percentage values (e.g., "100.0%") for explained variance.

## Root Cause
The output formatter was using `result.ExplainedVar[i]` which contains raw eigenvalues, instead of `result.ExplainedVarRatio[i]` which contains the percentage values.

## Fix
Changed line 180 in `internal/cobra/output.go` to use the correct field:
- Before: `result.ExplainedVar[i]`
- After: `result.ExplainedVarRatio[i]`

## Testing
- Tested with edge case data (zero column) - now correctly shows 100.0% for PC1
- Tested with normal data (iris dataset) - shows expected percentages
- All existing tests pass

## Example Output
Before fix:
```
PC1                       2.0%         100.0%
PC2                       0.0%         100.0%
```

After fix:
```
PC1                     100.0%         100.0%
PC2                       0.0%         100.0%
```

Closes #324