### PR TITLE
Fix: Remove redundant 'crest' color palette

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
@@ -44,7 +44,6 @@ export const PaletteSelector: React.FC = () => {
     viridis: 'Viridis',
     blues: 'Blues',
     reds: 'Reds',
-    crest: 'Crest',
     mako: 'Mako',
     flare: 'Flare'
   };
@@ -69,7 +68,6 @@ export const PaletteSelector: React.FC = () => {
                 { value: 'viridis', label: paletteDisplayNames.viridis },
                 { value: 'blues', label: paletteDisplayNames.blues },
                 { value: 'reds', label: paletteDisplayNames.reds },
-                { value: 'crest', label: paletteDisplayNames.crest },
                 { value: 'mako', label: paletteDisplayNames.mako },
                 { value: 'flare', label: paletteDisplayNames.flare }
               ]

--- a/cmd/gopca-desktop/frontend/src/contexts/PaletteContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/PaletteContext.tsx
@@ -46,6 +46,10 @@ export const PaletteProvider: React.FC<{ children: ReactNode }> = ({ children })
 
   const [sequentialPalette, setSequentialPalette] = useState<SequentialPaletteName>(() => {
     const stored = localStorage.getItem(SEQUENTIAL_STORAGE_KEY);
+    // Fallback from removed 'crest' palette to 'blues' (similar color scheme)
+    if (stored === 'crest') {
+      return 'blues';
+    }
     return (stored as SequentialPaletteName) || 'rocket';
   });
 

--- a/cmd/gopca-desktop/frontend/src/utils/colorPalettes.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/colorPalettes.ts
@@ -9,7 +9,7 @@
 
 // Palette names for user selection
 export type QualitativePaletteName = 'deep' | 'pastel' | 'dark' | 'colorblind' | 'husl';
-export type SequentialPaletteName = 'rocket' | 'viridis' | 'blues' | 'reds' | 'crest' | 'mako' | 'flare';
+export type SequentialPaletteName = 'rocket' | 'viridis' | 'blues' | 'reds' | 'mako' | 'flare';
 
 // Qualitative palettes for categorical data
 export const QUALITATIVE_PALETTES: Record<QualitativePaletteName, string[]> = {
@@ -223,20 +223,6 @@ export const SEQUENTIAL_PALETTES: Record<SequentialPaletteName, string[]> = {
     '#cb181d', //
     '#a50f15', //
     '#67000d' // dark red
-  ],
-
-  // Crest palette - blue to purple (seaborn's crest)
-  crest: [
-    '#f0f9ff', // very light blue
-    '#d0e7f7', // light blue
-    '#a8d5e2', //
-    '#7dc0d4', //
-    '#4fa8c5', //
-    '#2e8ab5', // medium blue
-    '#236ba3', //
-    '#22508c', // blue-purple
-    '#1e3670', // dark blue-purple
-    '#071e58' // very dark purple
   ],
 
   // Mako palette - blue to green (seaborn's mako)


### PR DESCRIPTION
## Summary
Removes the redundant 'crest' sequential color palette which was nearly identical to the existing 'blues' palette.

## Changes Made
- Removed 'crest' from `SequentialPaletteName` type definition
- Removed 'crest' palette data (10 color values) from `SEQUENTIAL_PALETTES`
- Removed 'crest' option from PaletteSelector component UI
- Added automatic migration in PaletteContext for users who had 'crest' stored in localStorage (falls back to 'blues')

## Why This Change?
The 'crest' and 'blues' palettes were visually almost indistinguishable:
- **Blues**: `#f7fbff` to `#08306b` 
- **Crest**: `#f0f9ff` to `#071e58`

Removing redundant options improves user experience by reducing decision fatigue and keeping only distinct, meaningful palette choices.

## Testing
- ✅ TypeScript compiles without errors
- ✅ Frontend builds successfully
- ✅ App launches and runs normally
- ✅ Palette selector shows correct options (no 'crest')
- ✅ Migration handles localStorage gracefully

## Screenshots
The palette selector now shows 6 sequential options instead of 7, with 'crest' removed.

Closes #350