### PR TITLE
Fix: Apply font size control consistently across all plot types

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
@@ -21,7 +21,8 @@ interface CircleOfCorrelationsProps {
 export const CircleOfCorrelations: React.FC<CircleOfCorrelationsProps> = ({
   pcaResult,
   xComponent = 0,
-  yComponent = 1
+  yComponent = 1,
+  fontScale
 }) => {
   const { theme } = useTheme();
   const { qualitativePalette } = usePalette();
@@ -37,7 +38,8 @@ export const CircleOfCorrelations: React.FC<CircleOfCorrelationsProps> = ({
     xComponent,
     yComponent,
     theme,
-    colorScheme
+    colorScheme,
+    fontScale
   );
 
   return (

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
@@ -31,7 +31,8 @@ export const DiagnosticScatterPlot: React.FC<DiagnosticScatterPlotProps> = ({
   showThresholds = true,
   confidenceLevel = 0.95,
   showRowLabels = false,
-  maxLabelsToShow = 10
+  maxLabelsToShow = 10,
+  fontScale
 }) => {
   const { theme } = useTheme();
   const { qualitativePalette } = usePalette();
@@ -62,7 +63,8 @@ export const DiagnosticScatterPlot: React.FC<DiagnosticScatterPlotProps> = ({
       theme,
       colorScheme,
       mahalanobisThreshold,
-      rssThreshold
+      rssThreshold,
+      fontScale
     ),
     showLabels: showRowLabels,
     labelThreshold: maxLabelsToShow

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/EigencorrelationPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/EigencorrelationPlot.tsx
@@ -19,7 +19,8 @@ interface EigencorrelationPlotProps {
 
 export const EigencorrelationPlot: React.FC<EigencorrelationPlotProps> = ({
   pcaResult,
-  maxComponents
+  maxComponents,
+  fontScale
 }) => {
   const { theme } = useTheme();
   const { sequentialPalette } = usePalette();
@@ -44,7 +45,7 @@ export const EigencorrelationPlot: React.FC<EigencorrelationPlotProps> = ({
   }
 
   // Create config for Plotly component
-  const plotlyConfig = createEigencorrelationPlotConfig(maxComponents, theme, colorScheme);
+  const plotlyConfig = createEigencorrelationPlotConfig(maxComponents, theme, colorScheme, fontScale);
 
   return (
     <div style={{ width: '100%', height: '100%' }}>

--- a/cmd/gopca-desktop/frontend/src/utils/plotlyDataTransform.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/plotlyDataTransform.ts
@@ -50,6 +50,22 @@ return [];
 }
 
 /**
+ * Shared config builder for all Plotly visualizations
+ * Provides common configuration properties to ensure consistency
+ */
+function createBaseVisualizationConfig(
+  theme?: 'light' | 'dark',
+  colorScheme?: string[],
+  fontScale?: number
+): { theme?: 'light' | 'dark'; colorScheme?: string[]; fontScale?: number } {
+  return {
+    theme,
+    colorScheme,
+    fontScale
+  };
+}
+
+/**
  * Transform PCAResult to Plotly ScoresPlot data format
  */
 export function transformToScoresPlotData(
@@ -307,7 +323,8 @@ export function createCircleOfCorrelationsConfig(
   xComponent: number = 0,
   yComponent: number = 1,
   theme?: 'light' | 'dark',
-  colorScheme?: string[]
+  colorScheme?: string[],
+  fontScale?: number
 ): CircleOfCorrelationsConfig {
   return {
     pcX: xComponent + 1,
@@ -317,8 +334,7 @@ export function createCircleOfCorrelationsConfig(
     showLabels: true,
     minVectorLength: 0.1,
     colorByMagnitude: true,
-    theme,
-    colorScheme
+    ...createBaseVisualizationConfig(theme, colorScheme, fontScale)
   };
 }
 
@@ -353,17 +369,17 @@ export function createDiagnosticPlotConfig(
   theme?: 'light' | 'dark',
   colorScheme?: string[],
   mahalanobisThreshold?: number,
-  rssThreshold?: number
+  rssThreshold?: number,
+  fontScale?: number
 ): DiagnosticPlotConfig {
   return {
     showThresholds,
     confidenceLevel,
     showLabels: false,  // Changed to false by default
     labelThreshold: 10,
-    theme,
-    colorScheme,
     mahalanobisThreshold,
-    rssThreshold
+    rssThreshold,
+    ...createBaseVisualizationConfig(theme, colorScheme, fontScale)
   };
 }
 
@@ -410,7 +426,8 @@ export function transformToEigencorrelationPlotData(
 export function createEigencorrelationPlotConfig(
   maxComponents?: number,
   theme?: 'light' | 'dark',
-  colorScheme?: string[]
+  colorScheme?: string[],
+  fontScale?: number
 ): EigencorrelationPlotConfig {
   return {
     maxComponents,
@@ -419,8 +436,7 @@ export function createEigencorrelationPlotConfig(
     valueFormat: '.2f',
     clusterVariables: false,
     annotationThreshold: 0.3,
-    theme,
-    colorScheme
+    ...createBaseVisualizationConfig(theme, colorScheme, fontScale)
   };
 }
 

--- a/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
@@ -8,11 +8,12 @@
 
 import React, { useMemo } from 'react';
 import { Data, Layout } from 'plotly.js';
-import { getPlotlyTheme, mergeLayouts, ThemeMode } from '../utils/plotlyTheme';
+import { getPlotlyTheme, mergeLayouts } from '../utils/plotlyTheme';
 import { getExportMenuItems } from '../utils/plotlyExport';
 import { PLOT_CONFIG, getScaledMarkerSize } from '../config/plotConfig';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
+import { PlotlyVisualizationConfig } from '../core/PlotlyVisualization';
 
 export interface CircleOfCorrelationsData {
   loadings: number[][];  // [n_components][n_variables]
@@ -20,7 +21,7 @@ export interface CircleOfCorrelationsData {
   explainedVariance: number[];
 }
 
-export interface CircleOfCorrelationsConfig {
+export interface CircleOfCorrelationsConfig extends PlotlyVisualizationConfig {
   pcX?: number;  // PC for X-axis (1-indexed)
   pcY?: number;  // PC for Y-axis (1-indexed)
   showCircle?: boolean;
@@ -30,9 +31,7 @@ export interface CircleOfCorrelationsConfig {
   colorByMagnitude?: boolean;
   arrowWidth?: number;
   labelSize?: number;
-  theme?: ThemeMode;
   colorScheme?: string[];  // Color palette for visualization
-  fontScale?: number;  // Scale factor for all font sizes (default: 1.0)
 }
 
 /**

--- a/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
@@ -8,11 +8,12 @@
 
 import React, { useMemo } from 'react';
 import { Data, Layout } from 'plotly.js';
-import { getPlotlyTheme, mergeLayouts, ThemeMode } from '../utils/plotlyTheme';
+import { getPlotlyTheme, mergeLayouts } from '../utils/plotlyTheme';
 import { getExportMenuItems } from '../utils/plotlyExport';
 import { PLOT_CONFIG, getScaledMarkerSize } from '../config/plotConfig';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
+import { PlotlyVisualizationConfig } from '../core/PlotlyVisualization';
 
 export interface DiagnosticPlotData {
   mahalanobisDistances: number[];
@@ -21,17 +22,15 @@ export interface DiagnosticPlotData {
   groups?: string[];
 }
 
-export interface DiagnosticPlotConfig {
+export interface DiagnosticPlotConfig extends PlotlyVisualizationConfig {
   showThresholds?: boolean;
   mahalanobisThreshold?: number;  // Chi-square based threshold
   rssThreshold?: number;
   confidenceLevel?: number;  // For Mahalanobis threshold calculation
   showLabels?: boolean;
   labelThreshold?: number;  // Number of outliers to label
-  colorScheme?: string[];
   pointSize?: number;
-  theme?: ThemeMode;
-  fontScale?: number;  // Scale factor for all font sizes (default: 1.0)
+  colorScheme?: string[];  // Color palette for visualization
 }
 
 /**

--- a/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
@@ -8,11 +8,12 @@
 
 import React, { useMemo } from 'react';
 import { Data, Layout } from 'plotly.js';
-import { getPlotlyTheme, mergeLayouts, ThemeMode } from '../utils/plotlyTheme';
+import { getPlotlyTheme, mergeLayouts } from '../utils/plotlyTheme';
 import { getExportMenuItems } from '../utils/plotlyExport';
 import { PLOT_CONFIG } from '../config/plotConfig';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
+import { PlotlyVisualizationConfig } from '../core/PlotlyVisualization';
 
 export interface EigencorrelationPlotData {
   correlations: number[][];  // [n_components][n_variables]
@@ -20,7 +21,7 @@ export interface EigencorrelationPlotData {
   explainedVariance: number[];
 }
 
-export interface EigencorrelationPlotConfig {
+export interface EigencorrelationPlotConfig extends PlotlyVisualizationConfig {
   maxComponents?: number;
   colorScale?: string | any[];
   showValues?: boolean;
@@ -28,7 +29,6 @@ export interface EigencorrelationPlotConfig {
   clusterVariables?: boolean;
   clusterComponents?: boolean;
   annotationThreshold?: number;  // Only show values above this threshold
-  theme?: ThemeMode;
   colorScheme?: string[];  // Color palette for visualization
 }
 
@@ -182,7 +182,7 @@ export class PlotlyEigencorrelationPlot {
 
   getEnhancedLayout(): Partial<Layout> {
     const baseLayout = this.getLayout();
-    const themeLayout = getPlotlyTheme(this.config.theme || 'light').layout;
+    const themeLayout = getPlotlyTheme(this.config.theme || 'light', this.config.fontScale).layout;
     
     // Add watermark if enabled
     let watermarkImages: any[] = [];


### PR DESCRIPTION
## Summary
Fixes the font size control slider to work consistently across all visualization types, including eigencorrelation plots, circle of correlations, and diagnostic scatter plots.

## Problem
The font size control slider (70%-150% range) only affected certain plot types while having no effect on others, creating an inconsistent user experience.

## Solution
Implemented a DRY (Don't Repeat Yourself) approach to ensure consistent font scaling across all plot types:

### Changes Made
1. **Standardized Config Interfaces**: Extended `PlotlyVisualizationConfig` for all plot config interfaces
2. **Shared Config Builder**: Created `createBaseVisualizationConfig()` to centralize common configuration
3. **Consistent Font Scaling**: Updated all plot classes to pass `fontScale` to `getPlotlyTheme()`
4. **Component Updates**: Modified components to properly extract and pass the `fontScale` prop

### Technical Implementation
- All plot config interfaces now extend a common base configuration
- Shared configuration logic reduces code duplication and ensures consistency
- Font scaling is now handled uniformly through the theme system

## Testing
- ✅ TypeScript compilation successful
- ✅ Frontend builds without errors
- ✅ All plot types now respond to font size control
- ✅ Pre-commit checks pass

## Affected Plot Types
Now working correctly:
- Eigencorrelation plot
- Circle of correlations
- Diagnostic scatter plot

Already working (maintained compatibility):
- Scores plots (2D and 3D)
- Scree plot
- Loadings plot
- Biplot (2D and 3D)

Closes #352