### PR TITLE
Fix: Confidence ellipse dropdown displays correctly for 90% level

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1217,7 +1217,7 @@ return;
                                                             </label>
                                                         </HelpWrapper>
                                                         <CustomSelect
-                                                            value={confidenceLevel.toString()}
+                                                            value={confidenceLevel.toFixed(2)}
                                                             onChange={(value) => setConfidenceLevel(parseFloat(value) as 0.90 | 0.95 | 0.99)}
                                                             options={[
                                                                 { value: '0.95', label: '95%' },
@@ -1247,7 +1247,7 @@ return;
                                                         </HelpWrapper>
                                                         {showEllipses && (
                                                             <CustomSelect
-                                                                value={confidenceLevel.toString()}
+                                                                value={confidenceLevel.toFixed(2)}
                                                                 onChange={(value) => setConfidenceLevel(parseFloat(value) as 0.90 | 0.95 | 0.99)}
                                                                 options={[
                                                                     { value: '0.90', label: '90%' },


### PR DESCRIPTION
## Summary
Fixes the confidence ellipse control dropdown to correctly display "90%" when 90% confidence level is selected, instead of showing "Select an option".

## Problem
The dropdown displayed placeholder text "Select an option" when 90% confidence level was selected because:
- JavaScript's `toString()` method drops trailing zeros: `(0.90).toString()` returns `"0.9"`
- The option value was defined as `"0.90"` 
- When matching, `"0.9"` ≠ `"0.90"`, causing no match to be found
- This only affected 90% (95% and 99% worked correctly)

## Solution
Changed `confidenceLevel.toString()` to `confidenceLevel.toFixed(2)` to ensure consistent decimal formatting:
- `(0.90).toFixed(2)` returns `"0.90"` ✅
- `(0.95).toFixed(2)` returns `"0.95"` ✅  
- `(0.99).toFixed(2)` returns `"0.99"` ✅

These now correctly match the option values in the dropdown.

## Testing
- ✅ TypeScript compilation successful
- ✅ Frontend builds without errors
- ✅ Tests pass
- ✅ All three confidence levels (90%, 95%, 99%) now display correctly
- ✅ Confidence ellipses continue to render correctly at all levels

## Affected Components
- Fixed in both confidence level dropdowns in App.tsx
- No changes needed to calculation logic (was already working correctly)

Closes #354