### PR TITLE
Release v0.9.17

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.16",
+    "productVersion": "0.9.17",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.16",
+    "productVersion": "0.9.17",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
## Release v0.9.17

This PR prepares the v0.9.17 release by updating the version numbers in the wails.json files.

### Changes since v0.9.16
- Fixed AppImage creation by moving to self-hosted runner (#360)
- Standardized application naming to "GoPCA Suite" (#361)

### Checklist
- [x] Version updated in cmd/gopca-desktop/wails.json
- [x] Version updated in cmd/gocsv/wails.json
- [x] All tests passing
- [x] Linter checks passed

After this PR is merged, the release will be created by pushing the v0.9.17 tag.