### PR TITLE
Fix: Remove indentation from heredoc closing delimiters in AppImage build (#366)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,7 @@ jobs:
           Categories=Science;Math;Education;DataVisualization;
           MimeType=text/csv;text/plain;
           StartupNotify=true
-          EOF
+EOF
           
           # Download icon from repository
           curl -L -o appdir-gopca/gopca.png https://raw.githubusercontent.com/${{ github.repository }}/main/cmd/gopca-desktop/build/linux/icon-256.png
@@ -420,7 +420,7 @@ jobs:
           Categories=Office;Spreadsheet;Science;DataVisualization;
           MimeType=text/csv;text/plain;text/tab-separated-values;
           StartupNotify=true
-          EOF
+EOF
           
           # Download icon from repository
           curl -L -o appdir-gocsv/gocsv.png https://raw.githubusercontent.com/${{ github.repository }}/main/cmd/gocsv/build/linux/icon-256.png


### PR DESCRIPTION
## Summary

This PR fixes a bash syntax error in the AppImage build workflow that was causing the build to fail with "unexpected end of file".

## Problem
In shell heredocs, the closing delimiter must be at the beginning of the line without any leading whitespace. The indented  delimiters were not being recognized as heredoc terminators, causing the shell to continue looking for the end of the heredoc until it reached the end of the file.

## Solution
Removed the leading whitespace (10 spaces) from both  closing delimiters:
- Line 381: GoPCA desktop file heredoc
- Line 423: GoCSV desktop file heredoc

## Changes
- Fixed heredoc syntax in  for both AppImage desktop file creation blocks
- The content of the desktop files remains indented for readability, only the closing delimiter is at column 0

## Testing
- The heredoc syntax is now correct according to shell standards
- This will allow AppImage builds to complete successfully in future releases

Fixes #366