### PR TITLE
Fix: Filter metadata when rows are excluded to prevent GUI crash (#365)

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -319,6 +319,32 @@ func (a *App) RunPCA(request PCARequest) (response PCAResponse) {
 			request.GroupLabels = newGroupLabels
 		}
 
+		// Filter metadata categorical columns if rows are excluded
+		if len(request.ExcludedRows) > 0 && len(request.MetadataCategorical) > 0 {
+			for colName, colData := range request.MetadataCategorical {
+				filteredCol := make([]string, 0)
+				for i := 0; i < len(colData); i++ {
+					if !contains(request.ExcludedRows, i) {
+						filteredCol = append(filteredCol, colData[i])
+					}
+				}
+				request.MetadataCategorical[colName] = filteredCol
+			}
+		}
+
+		// Filter metadata numeric columns if rows are excluded
+		if len(request.ExcludedRows) > 0 && len(request.MetadataNumeric) > 0 {
+			for colName, colData := range request.MetadataNumeric {
+				filteredCol := make([]float64, 0)
+				for i := 0; i < len(colData); i++ {
+					if !contains(request.ExcludedRows, i) {
+						filteredCol = append(filteredCol, colData[i])
+					}
+				}
+				request.MetadataNumeric[colName] = filteredCol
+			}
+		}
+
 		// Note: We don't need to filter headers and row names for PCA computation
 		// The frontend handles the display of selected data
 	}

--- a/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
@@ -72,6 +72,19 @@ export class PlotlyScoresPlot extends PlotlyVisualization<ScoresPlotData> {
     const { scores, groups, groupValues, groupType = 'categorical', sampleNames, pc1 = 0, pc2 = 1 } = this.data;
     const traces: Data[] = [];
 
+    // Validate scores data
+    if (!scores || scores.length === 0) {
+      console.error('PlotlyScoresPlot: No scores data available');
+      return [];
+    }
+
+    // Validate that each score has enough components
+    const invalidScores = scores.some(s => !s || !Array.isArray(s) || s.length <= Math.max(pc1, pc2));
+    if (invalidScores) {
+      console.error(`PlotlyScoresPlot: Invalid scores data - not enough components for PC${pc1 + 1} and PC${pc2 + 1}`);
+      return [];
+    }
+
     // Handle continuous vs categorical data
     if (groupType === 'continuous' && groupValues) {
       return this.getContinuousTraces();
@@ -195,6 +208,19 @@ export class PlotlyScoresPlot extends PlotlyVisualization<ScoresPlotData> {
   private getContinuousTraces(): Data[] {
     const { scores, groupValues, sampleNames, pc1 = 0, pc2 = 1 } = this.data;
     const traces: Data[] = [];
+
+    // Validate scores data
+    if (!scores || scores.length === 0) {
+      console.error('PlotlyScoresPlot: No scores data available for continuous plot');
+      return [];
+    }
+
+    // Validate that each score has enough components
+    const invalidScores = scores.some(s => !s || !Array.isArray(s) || s.length <= Math.max(pc1, pc2));
+    if (invalidScores) {
+      console.error(`PlotlyScoresPlot: Invalid scores data - not enough components for PC${pc1 + 1} and PC${pc2 + 1}`);
+      return [];
+    }
 
     if (!groupValues || groupValues.length === 0) {
       return this.getTraces(); // Fall back to categorical


### PR DESCRIPTION
## Summary
This PR fixes a GUI crash that occurs when running PCA on datasets with excluded rows. The issue was caused by a dimension mismatch between the filtered data matrix and unfiltered metadata arrays during eigencorrelation calculations.

## Problem
When rows are excluded from a dataset:
- The data matrix and group labels were correctly filtered to the reduced size (e.g., 149 rows)
- However, MetadataCategorical and MetadataNumeric were NOT filtered
- This caused eigencorrelation calculation to fail with dimension mismatch
- The frontend then crashed trying to access undefined scores data

## Solution

### Backend Fix (app.go)
Added filtering for metadata when rows are excluded:
- Filter MetadataCategorical columns to match excluded rows
- Filter MetadataNumeric columns to match excluded rows
- Ensures all data structures have consistent dimensions after exclusion

### Frontend Protection (PlotlyScoresPlot.tsx)
Added defensive validation to prevent crashes:
- Check if scores data exists before processing
- Validate that each score has sufficient components for selected PCs
- Return empty traces with error logging instead of crashing
- Applied to both categorical and continuous plot methods

## Testing
- ✅ All existing tests pass
- ✅ Code compiles without errors
- ✅ Linter checks pass
- ✅ UI components build successfully

## How to Test
1. Load the iris dataset
2. Exclude one or more rows
3. Click "Go PCA!" to run analysis
4. Verify that:
   - No GUI crash occurs
   - PCA completes successfully
   - Eigencorrelations are calculated correctly (if enabled)
   - Visualizations render properly

## Related Issue
Closes #365