### PR TITLE
Fix: Scale plot margins with font size to prevent title cutoff

### DIFF
--- a/packages/ui-components/src/charts/utils/plotlyTheme.ts
+++ b/packages/ui-components/src/charts/utils/plotlyTheme.ts
@@ -61,10 +61,10 @@ export const getPlotlyTheme = (mode: ThemeMode, fontScale: number = 1.0): Plotly
         }
       },
       margin: {
-        l: 60,
-        r: 30,
-        t: 30,
-        b: 60
+        l: Math.round(60 * Math.max(fontScale, 1.0)),
+        r: Math.round(30 * Math.max(fontScale, 1.0)),
+        t: Math.round(30 * Math.max(fontScale, 1.0)),
+        b: Math.round(60 * Math.max(fontScale, 1.0))
       }
     },
     config: {


### PR DESCRIPTION
## Summary

This PR fixes issue #370 where plot titles get cut off when the font size is increased beyond 100% in GoPCA Desktop visualizations.

## Problem

When users increase the font size to 150% or higher, plot titles and potentially axis labels get cut off because the margins remain fixed while the text size increases. This affects all 14 Plotly-based visualizations in the application.

## Solution

Modified `/packages/ui-components/src/charts/utils/plotlyTheme.ts` to make margins scale proportionally with the `fontScale` parameter:

```typescript
margin: {
  l: Math.round(60 * Math.max(fontScale, 1.0)),
  r: Math.round(30 * Math.max(fontScale, 1.0)),
  t: Math.round(30 * Math.max(fontScale, 1.0)),
  b: Math.round(60 * Math.max(fontScale, 1.0))
}
```

### Key improvements:
- Margins now scale proportionally with font size
- `Math.max(fontScale, 1.0)` ensures margins never shrink below default values
- `Math.round()` provides integer pixel values
- All four margins scale consistently for visual balance

## Testing

### Manual testing performed:
- ✅ Built and ran GoPCA Desktop application
- ✅ Tested with iris dataset at various font scales
- ✅ Verified title visibility at 50%, 75%, 100%, 125%, 150%, 175%, 200%
- ✅ Confirmed no visual regressions at default (100%) scale
- ✅ All project tests pass (`make test`)

### Font scale behavior:
- **50-100%**: Margins remain at default (60, 30, 30, 60)
- **150%**: Margins scale to (90, 45, 45, 90)
- **200%**: Margins scale to (120, 60, 60, 120)

## Impact

- **Fixes**: Title cutoff at high font scales
- **Improves**: Accessibility for users needing larger text
- **Affects**: All Plotly visualizations (Scores, Loadings, Biplot, Scree, etc.)
- **Risk**: Minimal - backward compatible at default settings

Closes #370