### PR TITLE
fix: remove all indentation from desktop file content in AppImage build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,18 +366,18 @@ jobs:
           
           # Create desktop file
           cat > appdir-gopca/gopca.desktop << 'EOF'
-          [Desktop Entry]
-          Version=1.0
-          Type=Application
-          Name=GoPCA
-          GenericName=PCA Analysis Tool
-          Comment=Professional Principal Component Analysis Tool
-          Exec=GoPCA %f
-          Icon=gopca
-          Terminal=false
-          Categories=Science;Math;Education;DataVisualization;
-          MimeType=text/csv;text/plain;
-          StartupNotify=true
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=GoPCA
+GenericName=PCA Analysis Tool
+Comment=Professional Principal Component Analysis Tool
+Exec=GoPCA %f
+Icon=gopca
+Terminal=false
+Categories=Science;Math;Education;DataVisualization;
+MimeType=text/csv;text/plain;
+StartupNotify=true
 EOF
           
           # Download icon from repository
@@ -408,18 +408,18 @@ EOF
           
           # Create desktop file
           cat > appdir-gocsv/gocsv.desktop << 'EOF'
-          [Desktop Entry]
-          Version=1.0
-          Type=Application
-          Name=GoCSV
-          GenericName=CSV Editor
-          Comment=Fast and Efficient CSV Data Editor
-          Exec=GoCSV %f
-          Icon=gocsv
-          Terminal=false
-          Categories=Office;Spreadsheet;Science;DataVisualization;
-          MimeType=text/csv;text/plain;text/tab-separated-values;
-          StartupNotify=true
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=GoCSV
+GenericName=CSV Editor
+Comment=Fast and Efficient CSV Data Editor
+Exec=GoCSV %f
+Icon=gocsv
+Terminal=false
+Categories=Office;Spreadsheet;Science;DataVisualization;
+MimeType=text/csv;text/plain;text/tab-separated-values;
+StartupNotify=true
 EOF
           
           # Download icon from repository


### PR DESCRIPTION
## Summary

This PR fixes the AppImage build failure by removing ALL indentation from the desktop file content in the heredocs.

## Problem

The previous fix (commit b179137) only removed indentation from the heredoc EOF delimiters but left the desktop file content indented with 10 spaces on every line. This caused `appimagetool` to fail because:

- Desktop files must not have leading spaces
- Each line must start at column 0
- The desktop file specification requires strict formatting

## Solution

Removed ALL indentation from:
- Lines 369-380: GoPCA desktop file content
- Lines 411-422: GoCSV desktop file content

The heredoc structure remains intact, but the content now starts at column 0 as required by the desktop file specification.

## Testing

Created and ran a test script locally that:
1. Simulates the desktop file creation from the workflow
2. Checks for leading spaces
3. Validates the file format
4. Confirms files start with `[Desktop Entry]` at column 0

Test output:
```
✅ All tests passed! Desktop files will be created correctly.
```

## Desktop File Requirements

According to the desktop file specification:
- No leading spaces on any line
- Group headers like `[Desktop Entry]` must be at the start of the line
- Keys and values must follow strict formatting rules

The AppImage build will now create properly formatted desktop files that pass validation with `desktop-file-validate` and `appimagetool`.

Fixes #366