### PR TITLE
fix: use printf instead of heredoc for AppImage desktop files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,21 +364,21 @@ jobs:
           printf '#!/bin/bash\nHERE="$(dirname "$(readlink -f "${0}")")"\nexec "${HERE}/usr/bin/GoPCA" "$@"\n' > appdir-gopca/AppRun
           chmod +x appdir-gopca/AppRun
           
-          # Create desktop file
-          cat > appdir-gopca/gopca.desktop << 'EOF'
-[Desktop Entry]
-Version=1.0
-Type=Application
-Name=GoPCA
-GenericName=PCA Analysis Tool
-Comment=Professional Principal Component Analysis Tool
-Exec=GoPCA %f
-Icon=gopca
-Terminal=false
-Categories=Science;Math;Education;DataVisualization;
-MimeType=text/csv;text/plain;
-StartupNotify=true
-EOF
+          # Create desktop file using printf
+          printf '%s\n' \
+            '[Desktop Entry]' \
+            'Version=1.0' \
+            'Type=Application' \
+            'Name=GoPCA' \
+            'GenericName=PCA Analysis Tool' \
+            'Comment=Professional Principal Component Analysis Tool' \
+            'Exec=GoPCA %f' \
+            'Icon=gopca' \
+            'Terminal=false' \
+            'Categories=Science;Math;Education;DataVisualization;' \
+            'MimeType=text/csv;text/plain;' \
+            'StartupNotify=true' \
+            > appdir-gopca/gopca.desktop
           
           # Download icon from repository
           curl -L -o appdir-gopca/gopca.png https://raw.githubusercontent.com/${{ github.repository }}/main/cmd/gopca-desktop/build/linux/icon-256.png
@@ -406,21 +406,21 @@ EOF
           printf '#!/bin/bash\nHERE="$(dirname "$(readlink -f "${0}")")"\nexec "${HERE}/usr/bin/GoCSV" "$@"\n' > appdir-gocsv/AppRun
           chmod +x appdir-gocsv/AppRun
           
-          # Create desktop file
-          cat > appdir-gocsv/gocsv.desktop << 'EOF'
-[Desktop Entry]
-Version=1.0
-Type=Application
-Name=GoCSV
-GenericName=CSV Editor
-Comment=Fast and Efficient CSV Data Editor
-Exec=GoCSV %f
-Icon=gocsv
-Terminal=false
-Categories=Office;Spreadsheet;Science;DataVisualization;
-MimeType=text/csv;text/plain;text/tab-separated-values;
-StartupNotify=true
-EOF
+          # Create desktop file using printf
+          printf '%s\n' \
+            '[Desktop Entry]' \
+            'Version=1.0' \
+            'Type=Application' \
+            'Name=GoCSV' \
+            'GenericName=CSV Editor' \
+            'Comment=Fast and Efficient CSV Data Editor' \
+            'Exec=GoCSV %f' \
+            'Icon=gocsv' \
+            'Terminal=false' \
+            'Categories=Office;Spreadsheet;Science;DataVisualization;' \
+            'MimeType=text/csv;text/plain;text/tab-separated-values;' \
+            'StartupNotify=true' \
+            > appdir-gocsv/gocsv.desktop
           
           # Download icon from repository
           curl -L -o appdir-gocsv/gocsv.png https://raw.githubusercontent.com/${{ github.repository }}/main/cmd/gocsv/build/linux/icon-256.png


### PR DESCRIPTION
## Summary

This PR fixes the AppImage build workflow to use `printf` instead of heredocs for creating desktop files.

## The Problem

The current solution (merged in #374) has desktop file content at column 0, which:
- ✅ Creates correct desktop files without leading spaces
- ❌ **Breaks YAML syntax** - lines at column 0 are interpreted as YAML keys

## The Solution

Use `printf` with line continuations:
```bash
printf '%s\n' \
  '[Desktop Entry]' \
  'Version=1.0' \
  'Type=Application' \
  ...
  > appdir-gopca/gopca.desktop
```

## Why This Works

1. **YAML Valid**: All lines stay properly indented
2. **Desktop Files Correct**: No leading spaces in output
3. **Tested & Verified**: Actually tested the exact commands

## Why Heredocs Can't Work

After extensive testing:
- **EOF at column 0**: Breaks YAML literal block
- **EOF indented**: Gets included as content in the file
- **sed solutions**: Still have the EOF positioning problem

## Testing

Created comprehensive test script that:
1. Validates YAML syntax remains correct
2. Verifies desktop files have no leading spaces
3. Tests the exact `printf` commands

All tests pass ✅

## Previous Failed Attempts

- PR #368 (b179137): Only fixed EOF delimiters, left content indented
- PR #374 (751d760): Removed all indentation, broke YAML syntax
- This PR: Uses `printf` which is proven to work

Fixes #366 (properly this time)