### PR TITLE
Release v0.9.18

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "0.9.17",
+    "productVersion": "0.9.18",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "0.9.17",
+    "productVersion": "0.9.18",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
Preparing release v0.9.18

## Changes since v0.9.16

### Features
- Sort eigencorrelation variables by PC1 correlation and use Reds colorscale (#358)

### Bug Fixes
- Correct confidence ellipse dropdown display for 90% level (#357)
- Apply font size control consistently across all plot types (#355)
- Remove redundant 'crest' color palette (#353)

### Documentation
- Updated release guide to reflect Linux AppImages and signed macOS binaries

This release includes fully signed and notarized macOS binaries (no Gatekeeper warnings) and Linux AppImage artifacts for better cross-distribution compatibility.