### PR TITLE
fix: remove outdated Gatekeeper bypass instruction from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1031,7 +1031,6 @@ jobs:
           1. Download the bundle for your platform
           2. Extract the archive to your preferred location
           3. Add the directory to your PATH for CLI access (optional)
-          4. On macOS: Right-click and select "Open" on first launch to bypass Gatekeeper
           
           ### Verification
           


### PR DESCRIPTION
## Summary

Removes the outdated instruction telling macOS users to right-click and select "Open" to bypass Gatekeeper from the release notes template.

## Why This Change?

Our macOS binaries are now fully signed and notarized, which means:
- ✅ Users can double-click to open the apps normally
- ✅ No Gatekeeper warnings or security dialogs
- ✅ No need for right-click workarounds

The old instruction was confusing and contradicted the improvements we've made to our signing process.

## Changes Made

- Removed step 4 from the Installation instructions in the release workflow template
- The instruction "On macOS: Right-click and select 'Open' on first launch to bypass Gatekeeper" is no longer included

## Impact

- Future releases will have correct installation instructions
- Note: The v0.9.18 release notes cannot be updated (GitHub releases are immutable once published)
- No functional changes, only documentation improvement