### PR TITLE
ui: Remove interpretation guide text from Eigencorrelation plot

### DIFF
--- a/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
@@ -266,24 +266,12 @@ export class PlotlyEigencorrelationPlot {
       }
     }
 
-    // Add interpretation guide
-    layout.annotations!.push({
-      text: 'Strong correlations (|r| > 0.7) indicate metadata variables that are associated with PC variance',
-      xref: 'paper',
-      yref: 'paper',
-      x: 0.5,
-      y: -0.08,
-      xanchor: 'center',
-      showarrow: false,
-      font: { size: 10, color: 'gray' }
-    });
-
     // Adjust margins to accommodate labels
     layout.margin = {
       l: Math.max(...variableNames.map(n => n.length)) * 6 + 50,
       r: 100,
       t: 50,
-      b: 120
+      b: 80
     };
 
     return layout;


### PR DESCRIPTION
## Summary
Removes the hardcoded interpretation guide text from the Eigencorrelation plot to improve visual clarity and consistency with other plots in the suite.

## Changes
- Removed the interpretation guide annotation that displayed "Strong correlations (|r| > 0.7) indicate metadata variables that are associated with PC variance"
- Reduced bottom margin from 120 to 80 pixels since the extra space is no longer needed

## Rationale
- **Visual clarity**: Plots should prioritize data visualization over instructional text
- **Consistency**: Other plots in the suite don't have similar interpretation guides  
- **Screen space**: Better utilization of plot area for actual data

## Testing
- Built the ui-components package successfully
- TypeScript compilation passed
- Pre-commit checks passed

Closes #382