### PR TITLE
fix: Add memory safety limit for Kernel PCA to prevent system crashes

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1113,7 +1113,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 	recommendedComponents := 0
 	varianceCaptured := 0.0
 	targetVariance := 80.0 // 80% threshold
-	
+
 	cumulative := 0.0
 	for i, variance := range request.ExplainedVariance {
 		cumulative += variance
@@ -1122,7 +1122,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 			varianceCaptured = cumulative
 		}
 	}
-	
+
 	// If we haven't reached 80%, use all components
 	if recommendedComponents == 0 {
 		recommendedComponents = len(request.ExplainedVariance)
@@ -1134,7 +1134,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 	if request.StandardScale {
 		kaiserComponents = 0
 		numVariables := len(request.Loadings)
-		
+
 		for _, variance := range request.ExplainedVariance {
 			// Convert percentage to eigenvalue approximation
 			// For standardized data, total variance = number of variables
@@ -1145,7 +1145,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 				break // Eigenvalues are ordered, so we can stop here
 			}
 		}
-		
+
 		if kaiserComponents == 0 {
 			kaiserComponents = 1
 		}
@@ -1154,16 +1154,16 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 	// Calculate scale heterogeneity if original data is provided
 	scaleRatio := 1.0
 	scaleWarning := ""
-	
+
 	if len(request.OriginalData) > 0 && len(request.OriginalData[0]) > 0 {
 		// Calculate variance for each column (variable)
 		numRows := len(request.OriginalData)
 		numCols := len(request.OriginalData[0])
-		
+
 		if numRows > 1 && numCols > 0 {
 			minVar := math.MaxFloat64
 			maxVar := 0.0
-			
+
 			for j := 0; j < numCols; j++ {
 				// Calculate mean
 				mean := 0.0
@@ -1176,7 +1176,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 				}
 				if validCount > 0 {
 					mean /= float64(validCount)
-					
+
 					// Calculate variance
 					variance := 0.0
 					for i := 0; i < numRows; i++ {
@@ -1187,7 +1187,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 					}
 					if validCount > 1 {
 						variance /= float64(validCount - 1)
-						
+
 						if variance > 0 {
 							if variance < minVar {
 								minVar = variance
@@ -1199,11 +1199,11 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 					}
 				}
 			}
-			
+
 			// Calculate scale ratio
 			if minVar > 0 && minVar < math.MaxFloat64 {
 				scaleRatio = maxVar / minVar
-				
+
 				// Generate warning if scales are heterogeneous and not standardized
 				if scaleRatio > 100 && !request.StandardScale {
 					if scaleRatio > 10000 {

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -831,6 +831,22 @@ return;
                                     {config.method === 'kernel' && (
                                         <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-4">
                                             <h4 className="font-medium text-sm">Kernel PCA Options</h4>
+                                            
+                                            {/* Memory warning for large datasets */}
+                                            {fileData && fileData.data && fileData.data.length > 5000 && (
+                                                <div className="p-3 bg-yellow-100 dark:bg-yellow-900/50 border border-yellow-300 dark:border-yellow-700 rounded-lg">
+                                                    <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                                                        <strong>⚠️ Warning:</strong> Kernel PCA with {fileData.data.length.toLocaleString()} samples 
+                                                        may require significant memory (~{Math.round(fileData.data.length * fileData.data.length * 24 / 1024 / 1024 / 1024 * 10) / 10} GB).
+                                                        {fileData.data.length > 10000 && (
+                                                            <span className="block mt-1 font-semibold">
+                                                                Maximum supported: 10,000 samples. Consider using SVD or NIPALS instead.
+                                                            </span>
+                                                        )}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            
                                             <div className="space-y-4">
                                                 <HelpWrapper helpKey="kernel-type">
                                                     <label className="block text-sm font-medium mb-1">

--- a/internal/core/kernel_pca.go
+++ b/internal/core/kernel_pca.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/bitjungle/gopca/pkg/security"
 	"github.com/bitjungle/gopca/pkg/types"
 	"gonum.org/v1/gonum/mat"
 )
@@ -220,6 +221,15 @@ func (kpca *KernelPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*type
 
 	nSamples := len(data)
 	nFeatures := len(data[0])
+
+	// Check sample size limit for memory safety
+	if nSamples > security.MaxKernelPCASamples {
+		return nil, fmt.Errorf("kernel PCA limited to %d samples for memory safety (got %d samples). "+
+			"Consider: 1) Using SVD or NIPALS methods for large datasets, "+
+			"2) Subsampling your data, or "+
+			"3) Applying dimension reduction first",
+			security.MaxKernelPCASamples, nSamples)
+	}
 
 	if config.Components > nSamples {
 		return nil, fmt.Errorf("number of components (%d) cannot exceed number of samples (%d)",

--- a/internal/core/kernel_pca_memory_test.go
+++ b/internal/core/kernel_pca_memory_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bitjungle/gopca/pkg/security"
+	"github.com/bitjungle/gopca/pkg/types"
+)
+
+// TestKernelPCAMemoryLimit tests that kernel PCA properly enforces memory limits
+func TestKernelPCAMemoryLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		nSamples    int
+		shouldFail  bool
+		errContains string
+	}{
+		{
+			name:        "Small dataset - should work",
+			nSamples:    100,
+			shouldFail:  false,
+			errContains: "",
+		},
+		{
+			name:        "Medium dataset - should work",
+			nSamples:    500,
+			shouldFail:  false,
+			errContains: "",
+		},
+		{
+			name:        "Over limit - should fail",
+			nSamples:    security.MaxKernelPCASamples + 1,
+			shouldFail:  true,
+			errContains: "kernel PCA limited to",
+		},
+		{
+			name:        "Large dataset - should fail",
+			nSamples:    50000,
+			shouldFail:  true,
+			errContains: "memory safety",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate dummy data with specified number of samples
+			data := make(types.Matrix, tt.nSamples)
+			for i := 0; i < tt.nSamples; i++ {
+				data[i] = []float64{float64(i), float64(i) * 2, float64(i) * 3}
+			}
+
+			// Create kernel PCA engine
+			kpca := NewKernelPCAEngine()
+
+			// Configure for RBF kernel PCA
+			config := types.PCAConfig{
+				Components:  2,
+				KernelType:  "rbf",
+				KernelGamma: 0.1,
+			}
+
+			// Try to fit the model
+			_, err := kpca.Fit(data, config)
+
+			// Check if error matches expectation
+			if tt.shouldFail {
+				if err == nil {
+					t.Errorf("Expected error for %d samples, but got none", tt.nSamples)
+				} else if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Expected error containing '%s', got: %v", tt.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %d samples: %v", tt.nSamples, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/security/input_validation.go
+++ b/pkg/security/input_validation.go
@@ -19,18 +19,19 @@ import (
 
 // Limits for various input types to prevent resource exhaustion
 const (
-	MaxFileSize      = 500 * 1024 * 1024 // 500MB max file size
-	MaxCSVRows       = 1000000           // 1M rows max
-	MaxCSVColumns    = 10000             // 10K columns max
-	MaxFieldLength   = 100000            // 100K chars per field
-	MaxStringLength  = 10000             // 10K chars for general strings
-	MaxPathLength    = 4096              // Standard PATH_MAX
-	MaxComponents    = 1000              // Max PCA components
-	MinComponents    = 1                 // Min PCA components
-	MaxKernelGamma   = 1e6               // Max kernel gamma value
-	MinKernelGamma   = 1e-6              // Min kernel gamma value
-	MaxIterations    = 10000             // Max iterations for algorithms
-	MaxMemoryUsageMB = 2048              // 2GB max memory for operations
+	MaxFileSize         = 500 * 1024 * 1024 // 500MB max file size
+	MaxCSVRows          = 1000000           // 1M rows max
+	MaxCSVColumns       = 10000             // 10K columns max
+	MaxFieldLength      = 100000            // 100K chars per field
+	MaxStringLength     = 10000             // 10K chars for general strings
+	MaxPathLength       = 4096              // Standard PATH_MAX
+	MaxComponents       = 1000              // Max PCA components
+	MinComponents       = 1                 // Min PCA components
+	MaxKernelPCASamples = 10000             // Max samples for Kernel PCA (memory safety)
+	MaxKernelGamma      = 1e6               // Max kernel gamma value
+	MinKernelGamma      = 1e-6              // Min kernel gamma value
+	MaxIterations       = 10000             // Max iterations for algorithms
+	MaxMemoryUsageMB    = 2048              // 2GB max memory for operations
 )
 
 // ValidateNumericInput validates and sanitizes numeric input within bounds


### PR DESCRIPTION
## Summary
Implements memory safety limits for Kernel PCA to prevent system crashes when processing large datasets.

## Problem
Kernel PCA requires O(n²) memory for the kernel matrix, causing memory exhaustion with datasets like MET (~50-67k samples) which would require 60-108 GB of RAM.

## Solution
- Added configurable sample size limit (10,000 samples) to prevent memory exhaustion
- Provides clear error messages with alternative suggestions
- Maintains mathematical correctness - no approximations introduced

## Changes
### Backend
- Added `MaxKernelPCASamples` constant (10,000) in `pkg/security/input_validation.go`
- Implemented sample size check in `internal/core/kernel_pca.go` before matrix computation
- Added comprehensive tests in `internal/core/kernel_pca_memory_test.go`

### Frontend (GoPCA Desktop)
- Added memory usage warning for datasets >5,000 samples
- Shows estimated memory requirements based on dataset size
- Displays maximum supported sample count when limit is exceeded

## Testing
- ✅ Unit tests for various dataset sizes (100, 500, 10001, 50000 samples)
- ✅ Verified error message appears correctly in CLI
- ✅ Swiss Roll dataset (1,000 samples) still works correctly
- ✅ All existing tests pass

## Memory Requirements Table
| Samples | Memory Required | Status |
|---------|----------------|---------|
| 1,000 | ~24 MB | ✅ Works |
| 5,000 | ~600 MB | ✅ Works |
| 10,000 | ~2.4 GB | ✅ At limit |
| 15,000 | ~5.4 GB | ❌ Blocked |
| 50,000 | ~60 GB | ❌ Blocked |

## User Impact
- Prevents system crashes and unresponsive applications
- Clear guidance to use SVD/NIPALS for large datasets
- Transparent about limitations while maintaining trust

Closes #385