### PR TITLE
Fix kernel PCA CLI generation case mismatch

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -353,7 +353,7 @@ return;
         cmd += ` --method ${config.method.toLowerCase()}`;
 
         // Add kernel parameters if using kernel PCA
-        if (config.method === 'Kernel') {
+        if (config.method === 'kernel') {
             cmd += ` --kernel-type ${config.kernelType}`;
             if (config.kernelType === 'rbf' || config.kernelType === 'laplacian' || config.kernelType === 'sigmoid') {
                 cmd += ` --kernel-gamma ${config.kernelGamma}`;


### PR DESCRIPTION
## Summary
Fixed case-sensitive comparison bug in CLI command generation for Kernel PCA.

## Changes
- Changed case comparison from `'Kernel'` to `'kernel'` in App.tsx line 356
- This matches the lowercase value returned by the method dropdown component

## Problem
When selecting Kernel PCA in the GUI, the generated CLI command was missing kernel-specific parameters (--kernel-type, --kernel-gamma, --kernel-degree, --kernel-coef0) because of a case mismatch in the conditional check.

## Testing
- Built frontend successfully
- All tests pass
- Verified kernel parameters now appear in generated CLI commands

Fixes #384