### PR TITLE
docs: add GitHub community standards documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Report a bug in GoPCA Suite
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Before submitting a bug report:**
+- [ ] I've checked for existing issues that describe this bug
+- [ ] I've tested with the latest version
+- [ ] I can reproduce this issue consistently
+- [ ] I understand this is a spare-time project and responses may take time
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Enter '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+What actually happened instead.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - OS: [e.g., Windows 11, macOS 14, Ubuntu 22.04]
+ - GoPCA Version: [e.g., v0.9.19]
+ - Component: [pca CLI / GoPCA Desktop / GoCSV Desktop]
+
+**Sample Data**
+If the bug involves specific data, please provide:
+- A minimal CSV file that reproduces the issue (remove sensitive data)
+- The exact command or settings used
+
+**Additional context**
+Add any other context about the problem here.
+
+**Note:** This is a personal project maintained in spare time. Bug fixes will be addressed as time permits, which may take several weeks or months. If you need an immediate fix, consider forking the repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/bitjungle/gopca/discussions/categories/q-a
+    about: Please ask questions in Discussions, not Issues
+  - name: Show and Tell
+    url: https://github.com/bitjungle/gopca/discussions/categories/show-and-tell
+    about: Share how you're using GoPCA Suite
+  - name: Ideas and Feedback
+    url: https://github.com/bitjungle/gopca/discussions/categories/ideas
+    about: Share ideas and general feedback in Discussions
+  - name: Read Contributing Guidelines
+    url: https://github.com/bitjungle/gopca/blob/main/CONTRIBUTING.md
+    about: Please read the contributing guidelines before submitting code

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest a feature for GoPCA Suite
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+**Before submitting a feature request:**
+- [ ] I've checked that this feature hasn't been requested already
+- [ ] I've considered if this aligns with GoPCA's core mission (PCA analysis)
+- [ ] I understand this is a personal project with a specific roadmap
+- [ ] I've considered forking the project for my immediate needs
+
+**Is your feature request related to a problem?**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**How does this align with PCA analysis?**
+Explain how this feature enhances PCA analysis capabilities.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Would you need this urgently?**
+If yes, I encourage you to fork the repository and implement it for your needs. This is a personal project with limited bandwidth, and features are prioritized based on the maintainer's personal roadmap.
+
+**Additional context**
+Add any other context, mockups, or examples about the feature request here.
+
+**Note:** Feature requests are considered on a best-effort basis and must align with the project's vision. Implementation may take considerable time or may not happen. The maintainer prioritizes features needed for personal use cases. For immediate needs, forking is encouraged.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+As a personal project maintained in spare time, security updates are provided on a best-effort basis for the latest release only.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest release | ✅ Best effort |
+| Older releases | ❌ Not supported |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in GoPCA Suite, I appreciate your help in disclosing it responsibly.
+
+### How to Report
+
+1. **Do NOT create a public issue** for security vulnerabilities
+2. Send an email to: devel@bitjungle.com
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if you have one)
+
+### What to Expect
+
+- **Acknowledgment**: I'll try to acknowledge receipt within a week, but as this is a spare-time project, it may take longer
+- **Investigation**: I'll investigate as time permits (this could take several weeks)
+- **Resolution**: Critical vulnerabilities will be prioritized, but fix timeline depends on complexity and my available time
+- **Disclosure**: Once fixed, the vulnerability will be disclosed in the release notes
+
+### Scope
+
+This security policy applies to:
+- The `pca` CLI tool
+- GoPCA Desktop application
+- GoCSV Desktop application
+- Core PCA algorithms and data handling
+
+### Out of Scope
+
+The following are not considered security vulnerabilities:
+- Issues requiring physical access to the user's machine
+- Social engineering attacks
+- Issues in dependencies (report these to the dependency maintainer)
+- Missing security headers in the desktop applications (they run locally)
+
+## General Security Practices
+
+GoPCA Suite is designed with security in mind:
+- **100% local processing** - No data is sent to external servers
+- **No telemetry** - No usage data or metrics are collected
+- **No network dependencies** - Works completely offline
+- **Open source** - All code is publicly auditable
+
+However, users should:
+- Keep their installation updated to the latest version
+- Only load CSV files from trusted sources
+- Be aware that PCA models may contain information about the training data
+
+## Disclaimer
+
+This is a personal open-source project maintained in spare time. While I take security seriously and will do my best to address vulnerabilities, there are no guarantees or SLAs for security fixes. Organizations requiring guaranteed security response times should consider alternative solutions or maintain their own fork.
+
+Thank you for helping keep GoPCA Suite secure!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## Pull Request Checklist
+
+**Before submitting this PR:**
+- [ ] I've read and understood the [Contributing Guidelines](../CONTRIBUTING.md)
+- [ ] I've opened a discussion first and got agreement that this change makes sense
+- [ ] I understand this is a personal project and PRs may take weeks/months to review
+- [ ] I've considered if forking might better serve my immediate needs
+
+## Description
+Brief description of what this PR does.
+
+## Related Discussion
+Link to the GitHub Discussion where this was agreed upon: #
+
+## Type of Change
+- [ ] Bug fix (non-breaking change fixing an issue)
+- [ ] New feature (non-breaking change adding functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Testing
+- [ ] I've added tests that prove my fix is effective or my feature works
+- [ ] All new and existing tests pass locally (`make test`)
+- [ ] Test coverage remains above 80% for core modules
+
+## Code Quality
+- [ ] My code follows the existing code style and patterns
+- [ ] I've run `make lint` and fixed all issues
+- [ ] I've added necessary documentation and code comments
+- [ ] For PCA algorithms: I've included mathematical references
+
+## Documentation
+- [ ] I've updated the README.md if needed
+- [ ] I've updated other documentation as necessary
+- [ ] My commits use the conventional format (`feat:`, `fix:`, etc.)
+
+## Cross-platform
+- [ ] Changes work on Windows
+- [ ] Changes work on macOS
+- [ ] Changes work on Linux
+
+## Screenshots (if applicable)
+Add screenshots for UI changes.
+
+## Additional Notes
+Any additional information that might be helpful for review.
+
+---
+
+**Reviewer Notice:** This PR may not be reviewed immediately due to limited maintainer bandwidth. The maintainer reserves the right to:
+- Request changes that align with the project vision
+- Implement the idea differently
+- Decline the PR if it doesn't fit the roadmap
+- Take several weeks or months to review
+
+Thank you for your patience and understanding.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the GoPCA community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* **Respecting the maintainer's vision and roadmap for this personal project**
+* Understanding that this is a spare-time project with limited bandwidth
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery
+* Trolling, insulting or derogatory comments, and personal attacks
+* Public or private harassment
+* Publishing others' private information without permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+As this is a personal project maintained in spare time, enforcement will be on a best-effort basis. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at devel@bitjungle.com. 
+
+The project maintainer will review and investigate all complaints as time permits, and will respond in a way deemed necessary and appropriate to the circumstances. The project maintainer is obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to GoPCA Suite
+
+First off, thank you for your interest in GoPCA Suite! This document provides guidelines for contributing to the project.
+
+## About This Project
+
+GoPCA Suite is a **personal exploration project** that I maintain in my spare time. It represents my learning journey in creating professional-grade PCA analysis tools. While the code is open source under the MIT license, please understand that this is primarily a personal project with a specific vision and roadmap.
+
+## Before You Contribute
+
+### Consider Forking
+
+If you need specific features or modifications for your use case, I encourage you to **fork the repository**. This gives you complete freedom to adapt the code to your needs without waiting for reviews or approvals.
+
+### Limited Maintenance Bandwidth
+
+As this is a spare-time project, I have very limited bandwidth for reviewing contributions. Response times for issues and pull requests may range from several weeks to months. Please plan accordingly.
+
+## How to Contribute
+
+### 1. Start with a Discussion
+
+**Before writing any code**, please open a discussion in the [GitHub Discussions](https://github.com/bitjungle/gopca/discussions) area to:
+- Explain what you'd like to contribute
+- Understand if it aligns with the project's roadmap
+- Get feedback on your approach
+
+This saves everyone time and ensures we're aligned before you invest effort in code.
+
+### 2. Reporting Bugs
+
+Before reporting a bug:
+- Check if it's already reported in [existing issues](https://github.com/bitjungle/gopca/issues)
+- Ensure you can reproduce it with the latest version
+- Collect all relevant information (OS, version, steps to reproduce)
+
+Use the bug report template when creating an issue.
+
+### 3. Suggesting Features
+
+Feature suggestions are welcome through GitHub Discussions. Please understand that:
+- Features must align with the project's core mission of PCA analysis
+- I prioritize features that I personally need for my use cases
+- Implementation may take considerable time or may not happen
+
+### 4. Code Contributions
+
+If we've agreed through discussion that a contribution makes sense:
+
+#### Prerequisites
+- Go 1.24+ and Node.js 24+
+- Familiarity with the codebase structure
+- Understanding of PCA mathematics (for algorithm contributions)
+
+#### Quality Standards
+All contributions must meet these standards:
+- **Tests Required**: New features need comprehensive tests (target 80%+ coverage)
+- **Documentation**: Update relevant documentation and add inline comments
+- **Code Style**: Follow existing patterns in the codebase
+- **Commit Messages**: Use conventional commits format (`feat:`, `fix:`, etc.)
+- **Mathematical Correctness**: PCA-related code must be mathematically sound with references
+- **Cross-platform**: Code must work on Windows, macOS, and Linux
+- **No Breaking Changes**: Unless previously discussed and approved
+
+#### Pull Request Process
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes following the standards above
+4. Ensure all tests pass: `make test`
+5. Run linters: `make lint`
+6. Submit a PR with:
+   - Clear description of changes
+   - Reference to the discussion thread
+   - Test results
+   - Screenshots (for UI changes)
+
+#### Review Timeline
+- PRs may take **several weeks** for review
+- Complex changes require more time
+- I may request changes or decide not to merge
+- No response doesn't mean rejection - it means I haven't had time yet
+
+## What Happens to Contributions
+
+Please understand that:
+- Not all PRs will be merged, even if they meet quality standards
+- I may implement your idea differently to match my vision
+- Merged code becomes part of the project under the MIT license
+- I may modify or revert changes in future versions
+
+## Alternative Ways to Contribute
+
+If code contributions don't work out:
+- **Report bugs**: Well-documented bug reports are incredibly helpful
+- **Improve documentation**: Spot a typo or unclear explanation? Let me know
+- **Share your use cases**: Understanding how you use GoPCA helps guide development
+- **Star the repository**: If you find it useful, a star is appreciated
+
+## Questions?
+
+For questions about contributing, please use [GitHub Discussions](https://github.com/bitjungle/gopca/discussions) rather than issues.
+
+## Final Note
+
+I deeply appreciate your interest in contributing to GoPCA Suite. While I maintain tight control over the project's direction due to limited time and specific vision, I value the open source community and encourage you to fork and adapt the code for your needs. The MIT license ensures you have complete freedom to do so.
+
+Thank you for understanding and respecting these contribution guidelines.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Teach multivariate statistics with interactive visualizations, explore research 
 - **Report Issues**: [GitHub Issues](https://github.com/bitjungle/gopca/issues)
 - **Ask Questions**: [GitHub Discussions](https://github.com/bitjungle/gopca/discussions)
 - **Documentation**: See the docs folder for detailed guides
+- **Contributing**: Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting code
 
 ## License
 


### PR DESCRIPTION
## Summary
Adding standard GitHub community health files to improve project documentation and meet GitHub's recommended community standards.

## Files Added
- `CODE_OF_CONDUCT.md` - Contributor Covenant v2.1
- `CONTRIBUTING.md` - Contribution guidelines  
- `SECURITY.md` - Security vulnerability reporting
- `.github/ISSUE_TEMPLATE/` - Issue templates
- `.github/pull_request_template.md` - PR template

## Benefits
- Completes GitHub community standards checklist
- Provides clear guidelines for community interaction
- Establishes contribution expectations
- Improves project professionalism

Based on [GitHub's community standards recommendations](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions).