### PR TITLE
feat: add GitHub Pages site with grungy aesthetic

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+# GitHub Pages Configuration
+title: GoPCA Suite - Liberating Your Data from Dimensional Oppression
+description: Professional-grade PCA analysis tools. Data analysis for the people, by the people. No corporate clouds. No surveillance. No masters.
+baseurl: "/gopca"
+url: "https://bitjungle.github.io"
+
+# Build settings
+markdown: kramdown
+theme: null  # We're using custom HTML/CSS
+
+# Exclude files from build
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,568 @@
+/* ===============================================
+   GOPCA SUITE - REVOLUTIONARY AESTHETIC CSS
+   No corporate design. Just raw truth.
+   =============================================== */
+
+/* Base Reset - Start from nothing */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+/* Root Variables - The color of revolution */
+:root {
+    --blood-red: #c41e3a;
+    --dark-red: #8b0000;
+    --black: #0a0a0a;
+    --off-black: #1a1a1a;
+    --gray: #2a2a2a;
+    --off-white: #f5f5f0;
+    --dirty-white: #e8e8e3;
+    --font-mono: 'Courier New', Courier, monospace;
+    --font-system: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Body - Dark as the void */
+body {
+    font-family: var(--font-mono);
+    background-color: var(--black);
+    color: var(--off-white);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+}
+
+/* Noise Overlay - Grungy texture */
+.noise-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    opacity: 0.03;
+    z-index: 1;
+    background-image: 
+        repeating-linear-gradient(
+            45deg,
+            transparent,
+            transparent 2px,
+            rgba(255,255,255,.03) 2px,
+            rgba(255,255,255,.03) 4px
+        ),
+        repeating-linear-gradient(
+            -45deg,
+            transparent,
+            transparent 2px,
+            rgba(196,30,58,.02) 2px,
+            rgba(196,30,58,.02) 4px
+        );
+}
+
+/* Container - Constrained chaos */
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    position: relative;
+    z-index: 2;
+}
+
+/* ASCII Border */
+.ascii-border {
+    font-family: var(--font-mono);
+    color: var(--blood-red);
+    white-space: pre;
+    font-size: clamp(8px, 1.5vw, 14px);
+    line-height: 1.2;
+    margin: 2rem 0;
+    text-align: center;
+    text-shadow: 0 0 10px rgba(196, 30, 58, 0.5);
+}
+
+/* Hero Section */
+.hero {
+    padding: 4rem 0;
+    text-align: center;
+    position: relative;
+    background: linear-gradient(180deg, var(--black) 0%, var(--off-black) 100%);
+    border-bottom: 3px solid var(--blood-red);
+}
+
+.hero-logo {
+    width: 150px;
+    height: 150px;
+    margin: 2rem auto;
+    filter: drop-shadow(0 0 20px rgba(196, 30, 58, 0.6));
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+
+/* Glitch Effect */
+.glitch {
+    font-size: clamp(2rem, 5vw, 4rem);
+    font-weight: bold;
+    text-transform: uppercase;
+    position: relative;
+    color: var(--off-white);
+    letter-spacing: 0.05em;
+    text-shadow: 
+        0.05em 0 0 rgba(196, 30, 58, .75),
+        -0.025em -0.05em 0 rgba(196, 30, 58, .75),
+        0.025em 0.05em 0 rgba(139, 0, 0, .75);
+    animation: glitch 2s infinite;
+}
+
+@keyframes glitch {
+    0%, 100% {
+        text-shadow: 
+            0.05em 0 0 rgba(196, 30, 58, .75),
+            -0.025em -0.05em 0 rgba(196, 30, 58, .75),
+            0.025em 0.05em 0 rgba(139, 0, 0, .75);
+    }
+    25% {
+        text-shadow: 
+            -0.05em -0.025em 0 rgba(196, 30, 58, .75),
+            0.025em 0.025em 0 rgba(139, 0, 0, .75),
+            -0.05em -0.05em 0 rgba(196, 30, 58, .75);
+    }
+    50% {
+        text-shadow: 
+            0.025em 0.05em 0 rgba(196, 30, 58, .75),
+            0.05em 0 0 rgba(139, 0, 0, .75),
+            0 -0.05em 0 rgba(196, 30, 58, .75);
+    }
+}
+
+.subtitle {
+    font-size: 0.6em;
+    color: var(--blood-red);
+    display: block;
+    margin-top: 0.5rem;
+}
+
+/* Hero Description */
+.hero-description {
+    font-size: 1.1rem;
+    margin: 2rem auto;
+    max-width: 600px;
+    line-height: 1.8;
+}
+
+.highlight {
+    color: var(--blood-red);
+    font-weight: bold;
+    letter-spacing: 0.1em;
+}
+
+/* Distressed Text */
+.distressed-text {
+    position: relative;
+    filter: contrast(1.1);
+}
+
+.distressed-text::after {
+    content: attr(data-text);
+    position: absolute;
+    left: 2px;
+    top: 2px;
+    color: var(--blood-red);
+    opacity: 0.1;
+}
+
+/* CTA Buttons */
+.cta-container {
+    margin-top: 3rem;
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.cta-button, .cta-button-secondary {
+    display: inline-block;
+    padding: 1rem 2rem;
+    text-decoration: none;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    transition: all 0.3s;
+    position: relative;
+    overflow: hidden;
+}
+
+.cta-button {
+    background: var(--blood-red);
+    color: var(--off-white);
+    border: 3px solid var(--blood-red);
+}
+
+.cta-button-secondary {
+    background: transparent;
+    color: var(--blood-red);
+    border: 3px solid var(--blood-red);
+}
+
+.cta-button:hover {
+    background: var(--dark-red);
+    transform: scale(1.05) rotate(-1deg);
+}
+
+.cta-button-secondary:hover {
+    background: var(--blood-red);
+    color: var(--off-white);
+    transform: scale(1.05) rotate(1deg);
+}
+
+/* Rough Border */
+.rough-border {
+    border-radius: 255px 15px 225px 15px/15px 225px 15px 255px;
+    position: relative;
+}
+
+.rough-border::before {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border: 2px solid var(--blood-red);
+    border-radius: 225px 25px 255px 5px/25px 205px 25px 235px;
+    opacity: 0.5;
+}
+
+/* Sections */
+section {
+    padding: 4rem 0;
+    position: relative;
+    z-index: 2;
+}
+
+.section-title {
+    text-align: center;
+    font-size: clamp(1.5rem, 4vw, 2.5rem);
+    margin-bottom: 3rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--off-white);
+}
+
+.distressed {
+    color: var(--blood-red);
+    opacity: 0.8;
+}
+
+/* Features Grid */
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.feature-card {
+    background: var(--off-black);
+    padding: 2rem;
+    border: 2px solid var(--gray);
+    transition: all 0.3s;
+    position: relative;
+}
+
+.feature-card:hover {
+    transform: translateY(-5px) rotate(0.5deg);
+    border-color: var(--blood-red);
+    box-shadow: 0 10px 30px rgba(196, 30, 58, 0.3);
+}
+
+.feature-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.feature-icon {
+    font-size: 2rem;
+    color: var(--blood-red);
+}
+
+.feature-card h3 {
+    font-size: 1.5rem;
+    color: var(--off-white);
+    letter-spacing: 0.05em;
+}
+
+.feature-image {
+    width: 100%;
+    height: auto;
+    margin: 1rem 0;
+    filter: contrast(1.1) grayscale(0.2);
+    border: 1px solid var(--gray);
+}
+
+.feature-description {
+    margin: 1rem 0;
+    line-height: 1.6;
+}
+
+.feature-description strong {
+    color: var(--blood-red);
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.feature-list {
+    list-style: none;
+    margin-top: 1rem;
+}
+
+.feature-list li {
+    padding: 0.3rem 0;
+    color: var(--dirty-white);
+}
+
+/* Code Block */
+.code-block {
+    background: var(--black);
+    border: 1px solid var(--gray);
+    padding: 1rem;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--off-white);
+}
+
+.comment {
+    color: var(--blood-red);
+    opacity: 0.8;
+}
+
+/* Quick Start Steps */
+.steps-container {
+    display: grid;
+    gap: 2rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.step {
+    background: var(--off-black);
+    padding: 2rem;
+    border: 2px solid var(--gray);
+    position: relative;
+    transition: all 0.3s;
+}
+
+.step:hover {
+    border-color: var(--blood-red);
+    transform: translateX(5px);
+}
+
+.step-number {
+    position: absolute;
+    top: -15px;
+    left: 20px;
+    background: var(--blood-red);
+    color: var(--off-white);
+    padding: 0.3rem 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
+}
+
+.step h3 {
+    margin-bottom: 1rem;
+    color: var(--off-white);
+    letter-spacing: 0.05em;
+}
+
+.inline-link {
+    color: var(--blood-red);
+    text-decoration: none;
+    font-weight: bold;
+    transition: all 0.3s;
+}
+
+.inline-link:hover {
+    text-decoration: underline;
+    text-shadow: 0 0 10px rgba(196, 30, 58, 0.5);
+}
+
+.inline-code {
+    background: var(--black);
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--gray);
+    font-family: var(--font-mono);
+    display: inline-block;
+    margin-top: 0.5rem;
+}
+
+.revolution-text {
+    color: var(--blood-red);
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+/* Philosophy Section */
+.philosophy {
+    background: linear-gradient(180deg, var(--off-black) 0%, var(--black) 100%);
+    border-top: 2px solid var(--blood-red);
+    border-bottom: 2px solid var(--blood-red);
+}
+
+.manifesto-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+}
+
+.manifesto-item {
+    padding: 1.5rem;
+    background: var(--black);
+    border-left: 4px solid var(--blood-red);
+    transition: all 0.3s;
+}
+
+.manifesto-item:hover {
+    transform: translateX(10px);
+    background: var(--off-black);
+}
+
+.manifesto-item h3 {
+    color: var(--off-white);
+    margin-bottom: 1rem;
+    font-size: 1.2rem;
+}
+
+.manifesto-item p {
+    color: var(--dirty-white);
+    line-height: 1.6;
+}
+
+/* Documentation Section */
+.documentation {
+    background: var(--black);
+}
+
+.doc-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.doc-link {
+    display: block;
+    padding: 1.5rem;
+    background: var(--off-black);
+    border: 2px solid var(--gray);
+    color: var(--off-white);
+    text-decoration: none;
+    text-align: center;
+    transition: all 0.3s;
+    font-weight: bold;
+}
+
+.doc-link:hover {
+    background: var(--gray);
+    border-color: var(--blood-red);
+    transform: rotate(-2deg) scale(1.05);
+}
+
+/* Footer */
+.footer {
+    background: var(--black);
+    padding: 3rem 0;
+    border-top: 3px solid var(--blood-red);
+    text-align: center;
+}
+
+.ascii-divider {
+    color: var(--blood-red);
+    font-family: var(--font-mono);
+    white-space: pre;
+    overflow: hidden;
+    opacity: 0.5;
+    font-size: clamp(8px, 2vw, 12px);
+    line-height: 1;
+}
+
+.footer-text {
+    margin: 2rem 0;
+    line-height: 1.8;
+}
+
+.small-text {
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.footer-links {
+    margin-top: 1rem;
+}
+
+.footer-links a {
+    color: var(--blood-red);
+    text-decoration: none;
+    font-weight: bold;
+    transition: all 0.3s;
+}
+
+.footer-links a:hover {
+    text-decoration: underline;
+    text-shadow: 0 0 10px rgba(196, 30, 58, 0.5);
+}
+
+.separator {
+    color: var(--gray);
+    margin: 0 1rem;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .hero-logo {
+        width: 100px;
+        height: 100px;
+    }
+    
+    .ascii-border {
+        font-size: 8px;
+        overflow-x: auto;
+    }
+    
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .cta-container {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .cta-button, .cta-button-secondary {
+        width: 100%;
+        max-width: 300px;
+    }
+}
+
+/* Print Styles - For the manifestos */
+@media print {
+    body {
+        background: white;
+        color: black;
+    }
+    
+    .noise-overlay {
+        display: none;
+    }
+    
+    .glitch {
+        animation: none;
+        text-shadow: none;
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GoPCA Suite - Liberating Your Data from Dimensional Oppression</title>
+    <meta name="description" content="Professional-grade PCA analysis tools. Data analysis for the people, by the people. No corporate clouds. No surveillance. No masters.">
+    <meta name="keywords" content="PCA, Principal Component Analysis, data analysis, open source, privacy, local processing">
+    <meta property="og:title" content="GoPCA Suite">
+    <meta property="og:description" content="Liberating your data from dimensional oppression">
+    <meta property="og:image" content="https://bitjungle.github.io/gopca/images/GoPCA-icon-1024-black.png">
+    <link rel="icon" type="image/png" href="images/GoPCA-icon-1024-black.png">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <div class="noise-overlay"></div>
+    
+    <!-- Hero Section -->
+    <header class="hero">
+        <div class="container">
+            <div class="ascii-border">
+╔═══════════════════════════════════════════════════════════════╗
+║                                                               ║
+║  ░██████╗░░█████╗░██████╗░░█████╗░░█████╗░                  ║
+║  ██╔════╝░██╔══██╗██╔══██╗██╔══██╗██╔══██╗                  ║
+║  ██║░░██╗░██║░░██║██████╔╝██║░░╚═╝███████║                  ║
+║  ██║░░╚██╗██║░░██║██╔═══╝░██║░░██╗██╔══██║                  ║
+║  ╚██████╔╝╚█████╔╝██║░░░░░╚█████╔╝██║░░██║                  ║
+║  ░╚═════╝░░╚════╝░╚═╝░░░░░░╚════╝░╚═╝░░╚═╝                  ║
+║                                                               ║
+║              S U I T E                                        ║
+║                                                               ║
+╚═══════════════════════════════════════════════════════════════╝
+            </div>
+            
+            <img src="images/GoPCA-icon-1024-black.png" alt="GoPCA Revolutionary Logo" class="hero-logo glitch-image">
+            
+            <h1 class="glitch" data-text="LIBERATING YOUR DATA">
+                LIBERATING YOUR DATA<br>
+                <span class="subtitle">FROM DIMENSIONAL OPPRESSION</span>
+            </h1>
+            
+            <p class="hero-description distressed-text">
+                Data analysis for the people, by the people.<br>
+                No corporate clouds. No surveillance. No masters.<br>
+                <span class="highlight">100% LOCAL • 100% FREE • 100% YOURS</span>
+            </p>
+            
+            <div class="cta-container">
+                <a href="https://github.com/bitjungle/gopca/releases/latest" class="cta-button rough-border">
+                    <span class="button-text">⬇ SEIZE THE MEANS OF COMPUTATION</span>
+                </a>
+                <a href="#quickstart" class="cta-button-secondary">
+                    <span class="button-text">▶ START THE REVOLUTION</span>
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <!-- Features Section -->
+    <section class="features" id="features">
+        <div class="container">
+            <h2 class="section-title">
+                <span class="distressed">━━━</span> TOOLS OF LIBERATION <span class="distressed">━━━</span>
+            </h2>
+            
+            <div class="feature-grid">
+                <!-- GoPCA Desktop -->
+                <div class="feature-card rough-border">
+                    <div class="feature-header">
+                        <span class="feature-icon">⚡</span>
+                        <h3>GoPCA DESKTOP</h3>
+                    </div>
+                    <img src="images/GoPCA_overview.png" alt="GoPCA Desktop" class="feature-image">
+                    <p class="feature-description">
+                        <strong>COLLECTIVE INTELLIGENCE THROUGH VISUALIZATION</strong><br>
+                        Interactive analysis that breaks the chains of complexity. 
+                        See through the matrix of high-dimensional data.
+                    </p>
+                    <ul class="feature-list">
+                        <li>◉ Real-time interactive plots</li>
+                        <li>◉ No cloud dependency</li>
+                        <li>◉ Your data stays yours</li>
+                        <li>◉ Dark mode for the resistance</li>
+                    </ul>
+                </div>
+
+                <!-- pca CLI -->
+                <div class="feature-card rough-border">
+                    <div class="feature-header">
+                        <span class="feature-icon">⚙</span>
+                        <h3>pca CLI</h3>
+                    </div>
+                    <pre class="code-block">
+<span class="comment"># Automate the struggle</span>
+$ pca analyze data.csv
+$ pca validate spectra.csv
+$ pca transform model.json
+
+<span class="comment"># No corporate APIs</span>
+<span class="comment"># No tracking</span>
+<span class="comment"># Just results</span>
+                    </pre>
+                    <p class="feature-description">
+                        <strong>TOOLS FOR THE DATA WORKERS</strong><br>
+                        Command-line power for those who refuse the GUI overlords.
+                        Script your way to analytical freedom.
+                    </p>
+                    <ul class="feature-list">
+                        <li>◉ Batch processing</li>
+                        <li>◉ Pipeline integration</li>
+                        <li>◉ Scriptable automation</li>
+                        <li>◉ No telemetry, ever</li>
+                    </ul>
+                </div>
+
+                <!-- GoCSV Desktop -->
+                <div class="feature-card rough-border">
+                    <div class="feature-header">
+                        <span class="feature-icon">✂</span>
+                        <h3>GoCSV DESKTOP</h3>
+                    </div>
+                    <img src="images/GoCSV_overview.png" alt="GoCSV Desktop" class="feature-image">
+                    <p class="feature-description">
+                        <strong>BREAK THE CHAINS OF MESSY DATA</strong><br>
+                        Data preparation without submission to cloud services.
+                        Edit, clean, transform - all on your machine.
+                    </p>
+                    <ul class="feature-list">
+                        <li>◉ Excel-like editing</li>
+                        <li>◉ Quality validation</li>
+                        <li>◉ Privacy-first design</li>
+                        <li>◉ Zero external connections</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Quick Start Section -->
+    <section class="quickstart" id="quickstart">
+        <div class="container">
+            <h2 class="section-title">
+                <span class="distressed">━━━</span> JOIN THE RESISTANCE <span class="distressed">━━━</span>
+            </h2>
+            
+            <div class="steps-container">
+                <div class="step rough-border">
+                    <div class="step-number">01</div>
+                    <h3>ACQUIRE THE TOOLS</h3>
+                    <p>Download for your platform. No registration. No tracking. No corporate overlords watching.</p>
+                    <a href="https://github.com/bitjungle/gopca/releases/latest" class="inline-link">→ Get the latest weapons</a>
+                </div>
+                
+                <div class="step rough-border">
+                    <div class="step-number">02</div>
+                    <h3>LIBERATE YOUR DATA</h3>
+                    <p>Load your CSV. Process locally. Keep your secrets safe from the surveillance capitalism machine.</p>
+                    <code class="inline-code">pca analyze --components 3 your-data.csv</code>
+                </div>
+                
+                <div class="step rough-border">
+                    <div class="step-number">03</div>
+                    <h3>VISUALIZE THE TRUTH</h3>
+                    <p>See patterns they don't want you to see. Understand complexity without algorithmic gatekeepers.</p>
+                    <span class="revolution-text">✊ Click "Go PCA!" and break free</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Philosophy Section -->
+    <section class="philosophy">
+        <div class="container">
+            <h2 class="section-title">
+                <span class="distressed">━━━</span> THE COMMONS MANIFESTO <span class="distressed">━━━</span>
+            </h2>
+            
+            <div class="manifesto-grid">
+                <div class="manifesto-item">
+                    <h3>⚫ PRIVACY IS RESISTANCE</h3>
+                    <p>Every byte stays on your machine. No clouds. No servers. No masters tracking your analysis.</p>
+                </div>
+                
+                <div class="manifesto-item">
+                    <h3>🔴 TRANSPARENCY IS POWER</h3>
+                    <p>Open source from the ground up. Read every line. Fork it. Share it. Make it yours.</p>
+                </div>
+                
+                <div class="manifesto-item">
+                    <h3>⚫ ALGORITHMS FOR ALL</h3>
+                    <p>Professional-grade PCA without the enterprise price tag. Knowledge should be free.</p>
+                </div>
+                
+                <div class="manifesto-item">
+                    <h3>🔴 NO CORPORATE CHAINS</h3>
+                    <p>Zero telemetry. Zero analytics. Zero surveillance. Your data, your hardware, your freedom.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Documentation Section -->
+    <section class="documentation">
+        <div class="container">
+            <h2 class="section-title">
+                <span class="distressed">━━━</span> EDUCATE • AGITATE • ORGANIZE <span class="distressed">━━━</span>
+            </h2>
+            
+            <div class="doc-links">
+                <a href="https://github.com/bitjungle/gopca/blob/main/docs/intro_to_pca.md" class="doc-link rough-border">
+                    📚 THEORY: Understanding PCA
+                </a>
+                <a href="https://github.com/bitjungle/gopca/blob/main/docs/cli_reference.md" class="doc-link rough-border">
+                    ⚙ PRAXIS: CLI Reference
+                </a>
+                <a href="https://github.com/bitjungle/gopca/blob/main/docs/intro_to_data_prep.md" class="doc-link rough-border">
+                    ✂ ACTION: Data Preparation
+                </a>
+                <a href="https://github.com/bitjungle/gopca" class="doc-link rough-border">
+                    🏴 SOURCE: GitHub Repository
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="ascii-divider">
+═══════════════════════════════════════════════════════════════════════
+                </div>
+                
+                <p class="footer-text">
+                    <span class="revolution-text">NO GODS • NO MASTERS • JUST PCA</span><br>
+                    MIT License - Fork it, share it, improve it<br>
+                    <span class="small-text">Copyright © 2025 - Built for the commons</span>
+                </p>
+                
+                <div class="footer-links">
+                    <a href="https://github.com/bitjungle/gopca">GitHub</a>
+                    <span class="separator">•</span>
+                    <a href="https://github.com/bitjungle/gopca/issues">Report Issues</a>
+                    <span class="separator">•</span>
+                    <a href="https://github.com/bitjungle/gopca/discussions">Discussions</a>
+                </div>
+                
+                <div class="ascii-divider">
+═══════════════════════════════════════════════════════════════════════
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implementation of GitHub Pages site for GoPCA Suite as specified in issue #394.

## Design Philosophy
Created a distinctive, grungy aesthetic that:
- Reflects the DIY/independent nature of the project
- Emphasizes local processing and privacy
- Uses a bold red/black color scheme matching the logo
- Implements distressed/brutalist design elements

## Technical Implementation

### Files Created
- `docs/index.html` - Single-page landing site
- `docs/assets/style.css` - Brutalist/grungy styling
- `docs/_config.yml` - Minimal Jekyll configuration

### Features
- ✅ Pure HTML/CSS (no build process needed)
- ✅ Mobile responsive design
- ✅ Fast loading (<2 seconds)
- ✅ Links to GitHub releases (auto-updated)
- ✅ Glitch text effects and animations
- ✅ ASCII art elements
- ✅ Noise texture overlays

### Content Sections
1. **Hero** - Project logo with tagline
2. **Features** - Three tools (GoPCA Desktop, pca CLI, GoCSV)
3. **Quick Start** - Three-step getting started guide
4. **Philosophy** - Project principles and values
5. **Documentation** - Links to existing docs
6. **Footer** - License and links

## Testing
- [x] Tested locally with Python HTTP server
- [x] All images and CSS load correctly
- [x] Mobile responsive verified
- [x] Links to GitHub releases work

## Maintenance
The site requires minimal maintenance:
- Only version updates needed for releases
- All download links point to GitHub (auto-updated)
- No dependencies or build process

## GitHub Pages Setup
After merging, enable GitHub Pages:
1. Settings → Pages
2. Source: Deploy from branch
3. Branch: main / docs folder
4. Save

The site will be available at: https://bitjungle.github.io/gopca/

Closes #394