### PR TITLE
docs: make website text more engineering-focused

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GoPCA Suite - Liberating Your Data from Dimensional Oppression</title>
-    <meta name="description" content="Professional-grade PCA analysis tools. Data analysis for the people, by the people. No corporate clouds. No surveillance. No masters.">
+    <title>GoPCA Suite - Professional PCA Analysis Tools</title>
+    <meta name="description" content="Free, open-source Principal Component Analysis tools. Desktop application, CLI, and data preparation. 100% local processing.">
     <meta name="keywords" content="PCA, Principal Component Analysis, data analysis, open source, privacy, local processing">
     <meta property="og:title" content="GoPCA Suite">
-    <meta property="og:description" content="Liberating your data from dimensional oppression">
+    <meta property="og:description" content="Professional PCA analysis tools - free and open source">
     <meta property="og:image" content="https://bitjungle.github.io/gopca/images/GoPCA-icon-1024-black.png">
     <link rel="icon" type="image/png" href="images/GoPCA-icon-1024-black.png">
     <link rel="stylesheet" href="assets/style.css">
@@ -33,25 +33,25 @@
 ╚═══════════════════════════════════════════════════════════════╝
             </div>
             
-            <img src="images/GoPCA-icon-1024-black.png" alt="GoPCA Revolutionary Logo" class="hero-logo glitch-image">
+            <img src="images/GoPCA-icon-1024-black.png" alt="GoPCA Logo" class="hero-logo glitch-image">
             
-            <h1 class="glitch" data-text="LIBERATING YOUR DATA">
-                LIBERATING YOUR DATA<br>
-                <span class="subtitle">FROM DIMENSIONAL OPPRESSION</span>
+            <h1 class="glitch" data-text="PRINCIPAL COMPONENT ANALYSIS">
+                PRINCIPAL COMPONENT ANALYSIS<br>
+                <span class="subtitle">MADE SIMPLE</span>
             </h1>
             
             <p class="hero-description distressed-text">
-                Data analysis for the people, by the people.<br>
-                No corporate clouds. No surveillance. No masters.<br>
-                <span class="highlight">100% LOCAL • 100% FREE • 100% YOURS</span>
+                Fast, accurate Principal Component Analysis.<br>
+                Desktop app and command-line tool.<br>
+                <span class="highlight">LOCAL PROCESSING • MIT LICENSE • OPEN SOURCE</span>
             </p>
             
             <div class="cta-container">
                 <a href="https://github.com/bitjungle/gopca/releases/latest" class="cta-button rough-border">
-                    <span class="button-text">⬇ SEIZE THE MEANS OF COMPUTATION</span>
+                    <span class="button-text">⬇ DOWNLOAD</span>
                 </a>
                 <a href="#quickstart" class="cta-button-secondary">
-                    <span class="button-text">▶ START THE REVOLUTION</span>
+                    <span class="button-text">▶ GET STARTED</span>
                 </a>
             </div>
         </div>
@@ -61,7 +61,7 @@
     <section class="features" id="features">
         <div class="container">
             <h2 class="section-title">
-                <span class="distressed">━━━</span> TOOLS OF LIBERATION <span class="distressed">━━━</span>
+                <span class="distressed">━━━</span> THREE TOOLS <span class="distressed">━━━</span>
             </h2>
             
             <div class="feature-grid">
@@ -73,15 +73,15 @@
                     </div>
                     <img src="images/GoPCA_overview.png" alt="GoPCA Desktop" class="feature-image">
                     <p class="feature-description">
-                        <strong>COLLECTIVE INTELLIGENCE THROUGH VISUALIZATION</strong><br>
-                        Interactive analysis that breaks the chains of complexity. 
-                        See through the matrix of high-dimensional data.
+                        <strong>DESKTOP APPLICATION</strong><br>
+                        Interactive Plotly.js visualizations.
+                        Export publication-ready figures.
                     </p>
                     <ul class="feature-list">
-                        <li>◉ Real-time interactive plots</li>
-                        <li>◉ No cloud dependency</li>
-                        <li>◉ Your data stays yours</li>
-                        <li>◉ Dark mode for the resistance</li>
+                        <li>◉ Interactive Plotly visualizations</li>
+                        <li>◉ Multiple PCA algorithms (SVD, NIPALS, Kernel)</li>
+                        <li>◉ Confidence ellipses and diagnostics</li>
+                        <li>◉ Dark and light themes</li>
                     </ul>
                 </div>
 
@@ -92,25 +92,24 @@
                         <h3>pca CLI</h3>
                     </div>
                     <pre class="code-block">
-<span class="comment"># Automate the struggle</span>
+<span class="comment"># Quick analysis</span>
 $ pca analyze data.csv
 $ pca validate spectra.csv
 $ pca transform model.json
 
-<span class="comment"># No corporate APIs</span>
-<span class="comment"># No tracking</span>
-<span class="comment"># Just results</span>
+<span class="comment"># Flexible output formats</span>
+<span class="comment"># JSON, CSV, or text</span>
                     </pre>
                     <p class="feature-description">
-                        <strong>TOOLS FOR THE DATA WORKERS</strong><br>
-                        Command-line power for those who refuse the GUI overlords.
-                        Script your way to analytical freedom.
+                        <strong>COMMAND-LINE TOOL</strong><br>
+                        Automation-ready CLI.
+                        JSON/CSV output formats.
                     </p>
                     <ul class="feature-list">
-                        <li>◉ Batch processing</li>
+                        <li>◉ Batch processing capabilities</li>
+                        <li>◉ Multiple output formats</li>
                         <li>◉ Pipeline integration</li>
-                        <li>◉ Scriptable automation</li>
-                        <li>◉ No telemetry, ever</li>
+                        <li>◉ Cross-platform support</li>
                     </ul>
                 </div>
 
@@ -122,15 +121,15 @@ $ pca transform model.json
                     </div>
                     <img src="images/GoCSV_overview.png" alt="GoCSV Desktop" class="feature-image">
                     <p class="feature-description">
-                        <strong>BREAK THE CHAINS OF MESSY DATA</strong><br>
-                        Data preparation without submission to cloud services.
-                        Edit, clean, transform - all on your machine.
+                        <strong>CSV EDITOR</strong><br>
+                        Prepare data for PCA analysis.
+                        Handle missing values and outliers.
                     </p>
                     <ul class="feature-list">
-                        <li>◉ Excel-like editing</li>
-                        <li>◉ Quality validation</li>
-                        <li>◉ Privacy-first design</li>
-                        <li>◉ Zero external connections</li>
+                        <li>◉ Spreadsheet-like editing</li>
+                        <li>◉ Data quality validation</li>
+                        <li>◉ Missing value handling</li>
+                        <li>◉ Export PCA-ready CSV</li>
                     </ul>
                 </div>
             </div>
@@ -141,29 +140,29 @@ $ pca transform model.json
     <section class="quickstart" id="quickstart">
         <div class="container">
             <h2 class="section-title">
-                <span class="distressed">━━━</span> JOIN THE RESISTANCE <span class="distressed">━━━</span>
+                <span class="distressed">━━━</span> QUICK START <span class="distressed">━━━</span>
             </h2>
             
             <div class="steps-container">
                 <div class="step rough-border">
                     <div class="step-number">01</div>
-                    <h3>ACQUIRE THE TOOLS</h3>
-                    <p>Download for your platform. No registration. No tracking. No corporate overlords watching.</p>
-                    <a href="https://github.com/bitjungle/gopca/releases/latest" class="inline-link">→ Get the latest weapons</a>
+                    <h3>DOWNLOAD</h3>
+                    <p>macOS, Windows, and Linux binaries available.</p>
+                    <a href="https://github.com/bitjungle/gopca/releases/latest" class="inline-link">→ Download latest version</a>
                 </div>
                 
                 <div class="step rough-border">
                     <div class="step-number">02</div>
-                    <h3>LIBERATE YOUR DATA</h3>
-                    <p>Load your CSV. Process locally. Keep your secrets safe from the surveillance capitalism machine.</p>
+                    <h3>LOAD DATA</h3>
+                    <p>Import CSV files with numerical data.</p>
                     <code class="inline-code">pca analyze --components 3 your-data.csv</code>
                 </div>
                 
                 <div class="step rough-border">
                     <div class="step-number">03</div>
-                    <h3>VISUALIZE THE TRUTH</h3>
-                    <p>See patterns they don't want you to see. Understand complexity without algorithmic gatekeepers.</p>
-                    <span class="revolution-text">✊ Click "Go PCA!" and break free</span>
+                    <h3>RUN ANALYSIS</h3>
+                    <p>Configure components and algorithm. View results instantly.</p>
+                    <span class="revolution-text">Execute PCA computation</span>
                 </div>
             </div>
         </div>
@@ -173,28 +172,28 @@ $ pca transform model.json
     <section class="philosophy">
         <div class="container">
             <h2 class="section-title">
-                <span class="distressed">━━━</span> THE COMMONS MANIFESTO <span class="distressed">━━━</span>
+                <span class="distressed">━━━</span> WHY GOPCA? <span class="distressed">━━━</span>
             </h2>
             
             <div class="manifesto-grid">
                 <div class="manifesto-item">
-                    <h3>⚫ PRIVACY IS RESISTANCE</h3>
-                    <p>Every byte stays on your machine. No clouds. No servers. No masters tracking your analysis.</p>
+                    <h3>⚫ LOCAL PROCESSING</h3>
+                    <p>All computations run on your machine. No external dependencies.</p>
                 </div>
                 
                 <div class="manifesto-item">
-                    <h3>🔴 TRANSPARENCY IS POWER</h3>
-                    <p>Open source from the ground up. Read every line. Fork it. Share it. Make it yours.</p>
+                    <h3>🔴 MIT LICENSE</h3>
+                    <p>Full source code available. Modify and redistribute freely.</p>
                 </div>
                 
                 <div class="manifesto-item">
-                    <h3>⚫ ALGORITHMS FOR ALL</h3>
-                    <p>Professional-grade PCA without the enterprise price tag. Knowledge should be free.</p>
+                    <h3>⚫ ACCURATE ALGORITHMS</h3>
+                    <p>SVD, NIPALS, and Kernel PCA. Validated against R and MATLAB.</p>
                 </div>
                 
                 <div class="manifesto-item">
-                    <h3>🔴 NO CORPORATE CHAINS</h3>
-                    <p>Zero telemetry. Zero analytics. Zero surveillance. Your data, your hardware, your freedom.</p>
+                    <h3>🔴 PRIVACY FOCUSED</h3>
+                    <p>No telemetry. No analytics. No data collection.</p>
                 </div>
             </div>
         </div>
@@ -204,21 +203,21 @@ $ pca transform model.json
     <section class="documentation">
         <div class="container">
             <h2 class="section-title">
-                <span class="distressed">━━━</span> EDUCATE • AGITATE • ORGANIZE <span class="distressed">━━━</span>
+                <span class="distressed">━━━</span> DOCUMENTATION <span class="distressed">━━━</span>
             </h2>
             
             <div class="doc-links">
                 <a href="https://github.com/bitjungle/gopca/blob/main/docs/intro_to_pca.md" class="doc-link rough-border">
-                    📚 THEORY: Understanding PCA
+                    📚 Introduction to PCA
                 </a>
                 <a href="https://github.com/bitjungle/gopca/blob/main/docs/cli_reference.md" class="doc-link rough-border">
-                    ⚙ PRAXIS: CLI Reference
+                    ⚙ CLI Reference
                 </a>
                 <a href="https://github.com/bitjungle/gopca/blob/main/docs/intro_to_data_prep.md" class="doc-link rough-border">
-                    ✂ ACTION: Data Preparation
+                    ✂ Data Preparation Guide
                 </a>
                 <a href="https://github.com/bitjungle/gopca" class="doc-link rough-border">
-                    🏴 SOURCE: GitHub Repository
+                    💻 GitHub Repository
                 </a>
             </div>
         </div>
@@ -235,7 +234,7 @@ $ pca transform model.json
                 <p class="footer-text">
                     <span class="revolution-text">NO GODS • NO MASTERS • JUST PCA</span><br>
                     MIT License - Fork it, share it, improve it<br>
-                    <span class="small-text">Copyright © 2025 - Built for the commons</span>
+                    <span class="small-text">Copyright © 2025 Rune Mathisen</span>
                 </p>
                 
                 <div class="footer-links">


### PR DESCRIPTION
## Summary
- Updated website text to be more technical and direct
- Kept the grungy visual design unchanged
- Made political messaging more subtle (only in footer)

## Changes
- Simplified hero description to focus on technical capabilities
- Shortened feature descriptions with engineering terminology
- Updated "Why GoPCA?" section with technical focus
- Streamlined quick start instructions
- Maintained "NO GODS • NO MASTERS • JUST PCA" in footer as requested

Closes #326