### PR TITLE
feat: replace logo click scroll-to-top with About modal

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import './App.css';
-import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer } from './components';
+import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, AboutDialog } from './components';
 import { ConfirmDialog } from '@gopca/ui-components';
 import { ThemeProvider, ThemeToggle } from '@gopca/ui-components';
 import logo from './assets/images/GoCSV-logo-1024-transp.png';
@@ -34,6 +34,7 @@ function AppContent() {
     const [showImportWizard, setShowImportWizard] = useState(false);
     const [showTransformDialog, setShowTransformDialog] = useState(false);
     const [showDocumentation, setShowDocumentation] = useState(false);
+    const [showAboutDialog, setShowAboutDialog] = useState(false);
     const [showDownloadConfirm, setShowDownloadConfirm] = useState(false);
     const [version, setVersion] = useState<string>('');
 
@@ -90,9 +91,9 @@ function AppContent() {
         }
     }, [fileLoaded, fileData]);
 
-    // Scroll to top function
-    const scrollToTop = () => {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+    // Handle logo click - show About dialog
+    const handleLogoClick = () => {
+        setShowAboutDialog(true);
     };
 
     // Check GoPCA installation status
@@ -297,7 +298,7 @@ return;
                             src={logo}
                             alt="GoCSV - GoPCA CSV Editor"
                             className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
-                            onClick={scrollToTop}
+                            onClick={handleLogoClick}
                         />
                         {version && (
                             <span className="text-xs text-gray-500 dark:text-gray-400">
@@ -671,6 +672,13 @@ return;
             <DocumentationViewer
                 isOpen={showDocumentation}
                 onClose={() => setShowDocumentation(false)}
+            />
+
+            {/* About Dialog */}
+            <AboutDialog
+                isOpen={showAboutDialog}
+                onClose={() => setShowAboutDialog(false)}
+                version={version}
             />
 
             {/* Download GoPCA Confirmation */}

--- a/cmd/gocsv/frontend/src/components/AboutDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/AboutDialog.tsx
@@ -1,0 +1,105 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { Dialog, DialogBody, DialogFooter } from '@gopca/ui-components';
+import { BrowserOpenURL } from '../../wailsjs/runtime/runtime';
+import logo from '../assets/images/GoCSV-logo-1024-transp.png';
+
+interface AboutDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    version: string;
+}
+
+export const AboutDialog: React.FC<AboutDialogProps> = ({ isOpen, onClose, version }) => {
+    const handleHomepageClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        BrowserOpenURL('https://bitjungle.github.io/gopca/');
+    };
+
+    const handleLicenseClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        BrowserOpenURL('https://github.com/bitjungle/gopca/blob/main/LICENSE');
+    };
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            onClose={onClose}
+            title="About GoCSV Desktop"
+            width="w-[500px]"
+            showCloseButton={true}
+        >
+            <DialogBody>
+                <div className="flex flex-col items-center text-center space-y-4">
+                    <img
+                        src={logo}
+                        alt="GoCSV Logo"
+                        className="h-24 w-24"
+                    />
+                    
+                    <div className="space-y-2">
+                        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                            GoCSV Desktop
+                        </h2>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                            Version {version}
+                        </p>
+                        <p className="text-sm text-gray-700 dark:text-gray-300 italic">
+                            Data preparation and CSV manipulation tool for GoPCA
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            © 2025 bitjungle - Rune Mathisen
+                        </p>
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            All rights reserved.
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full space-y-2">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            Licensed under the{' '}
+                            <a
+                                href="#"
+                                onClick={handleLicenseClick}
+                                className="text-blue-600 dark:text-blue-400 hover:underline"
+                            >
+                                MIT License
+                            </a>
+                        </p>
+                        <p className="text-xs text-gray-600 dark:text-gray-400 italic">
+                            The author respectfully requests that it not be used for
+                            military, warfare, or surveillance applications.
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full">
+                        <a
+                            href="#"
+                            onClick={handleHomepageClick}
+                            className="text-blue-600 dark:text-blue-400 hover:underline text-sm"
+                        >
+                            https://bitjungle.github.io/gopca/
+                        </a>
+                    </div>
+                </div>
+            </DialogBody>
+            
+            <DialogFooter>
+                <button
+                    onClick={onClose}
+                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
+                >
+                    Close
+                </button>
+            </DialogFooter>
+        </Dialog>
+    );
+};

--- a/cmd/gocsv/frontend/src/components/index.ts
+++ b/cmd/gocsv/frontend/src/components/index.ts
@@ -19,6 +19,7 @@ export { DataPreview } from './DataPreview';
 export { DataTransformDialog } from './DataTransformDialog';
 export { DocumentationViewer } from './DocumentationViewer';
 export { RenameDialog } from './RenameDialog';
+export { AboutDialog } from './AboutDialog';
 export {
     TargetColumnIcon,
     CategoryColumnIcon,

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import './App.css';
 import { ParseCSV, RunPCA, LoadIrisDataset, LoadDatasetFile, GetVersion, CalculateEllipses, GetGUIConfig, LoadCSVFile, CheckGoCSVStatus, OpenInGoCSV, LaunchGoCSV, DownloadGoCSV, SaveFile } from '../wailsjs/go/main/App';
 import { Copy, Check } from 'lucide-react';
 import { EventsOn } from '../wailsjs/runtime/runtime';
-import { DataTable, SelectionTable, MatrixIllustration, HelpWrapper, DocumentationViewer, ModelOverview } from './components';
+import { DataTable, SelectionTable, MatrixIllustration, HelpWrapper, DocumentationViewer, ModelOverview, AboutDialog } from './components';
 import { setupPlotlyWailsIntegration } from '@gopca/ui-components';
 
 // Lazy load visualization components for better performance
@@ -58,6 +58,7 @@ function AppContent() {
     const [showRowLabels, setShowRowLabels] = useState(false);
     const [maxLabelsToShow, setMaxLabelsToShow] = useState(10);
     const [showDocumentation, setShowDocumentation] = useState(false);
+    const [showAboutDialog, setShowAboutDialog] = useState(false);
     const [datasetId, setDatasetId] = useState(0); // Force DataTable re-render on dataset change
     const [showCopied, setShowCopied] = useState(false);
     const [loadingsPlotType, setLoadingsPlotType] = useState<'bar' | 'line' | null>(null); // null means auto
@@ -325,13 +326,8 @@ return;
         }
     }, [fileData]);
 
-    const scrollToTop = () => {
-        if (mainScrollRef.current) {
-            mainScrollRef.current.scrollTo({
-                top: 0,
-                behavior: 'smooth'
-            });
-        }
+    const handleLogoClick = () => {
+        setShowAboutDialog(true);
     };
 
     const generateCLICommand = (): string => {
@@ -526,7 +522,7 @@ return;
                             src={logo}
                             alt="GoPCA - Principal Component Analysis Tool"
                             className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
-                            onClick={scrollToTop}
+                            onClick={handleLogoClick}
                         />
                         {version && (
                             <span className="text-xs text-gray-500 dark:text-gray-400">
@@ -1521,6 +1517,13 @@ return;
             <DocumentationViewer
                 isOpen={showDocumentation}
                 onClose={() => setShowDocumentation(false)}
+            />
+
+            {/* About Dialog */}
+            <AboutDialog
+                isOpen={showAboutDialog}
+                onClose={() => setShowAboutDialog(false)}
+                version={version}
             />
 
             {/* GoCSV Download Confirmation Dialog */}

--- a/cmd/gopca-desktop/frontend/src/components/AboutDialog.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/AboutDialog.tsx
@@ -1,0 +1,105 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+import React from 'react';
+import { Dialog, DialogBody, DialogFooter } from '@gopca/ui-components';
+import { BrowserOpenURL } from '../../wailsjs/runtime/runtime';
+import logo from '../assets/images/GoPCA-logo-1024-transp.png';
+
+interface AboutDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    version: string;
+}
+
+export const AboutDialog: React.FC<AboutDialogProps> = ({ isOpen, onClose, version }) => {
+    const handleHomepageClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        BrowserOpenURL('https://bitjungle.github.io/gopca/');
+    };
+
+    const handleLicenseClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        BrowserOpenURL('https://github.com/bitjungle/gopca/blob/main/LICENSE');
+    };
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            onClose={onClose}
+            title="About GoPCA Desktop"
+            width="w-[500px]"
+            showCloseButton={true}
+        >
+            <DialogBody>
+                <div className="flex flex-col items-center text-center space-y-4">
+                    <img
+                        src={logo}
+                        alt="GoPCA Logo"
+                        className="h-24 w-24"
+                    />
+                    
+                    <div className="space-y-2">
+                        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                            GoPCA Desktop
+                        </h2>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                            Version {version}
+                        </p>
+                        <p className="text-sm text-gray-700 dark:text-gray-300 italic">
+                            The definitive Principal Component Analysis toolset
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            © 2025 bitjungle - Rune Mathisen
+                        </p>
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            All rights reserved.
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full space-y-2">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
+                            Licensed under the{' '}
+                            <a
+                                href="#"
+                                onClick={handleLicenseClick}
+                                className="text-blue-600 dark:text-blue-400 hover:underline"
+                            >
+                                MIT License
+                            </a>
+                        </p>
+                        <p className="text-xs text-gray-600 dark:text-gray-400 italic">
+                            The author respectfully requests that it not be used for
+                            military, warfare, or surveillance applications.
+                        </p>
+                    </div>
+
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full">
+                        <a
+                            href="#"
+                            onClick={handleHomepageClick}
+                            className="text-blue-600 dark:text-blue-400 hover:underline text-sm"
+                        >
+                            https://bitjungle.github.io/gopca/
+                        </a>
+                    </div>
+                </div>
+            </DialogBody>
+            
+            <DialogFooter>
+                <button
+                    onClick={onClose}
+                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
+                >
+                    Close
+                </button>
+            </DialogFooter>
+        </Dialog>
+    );
+};

--- a/cmd/gopca-desktop/frontend/src/components/index.ts
+++ b/cmd/gopca-desktop/frontend/src/components/index.ts
@@ -13,4 +13,5 @@ export { HelpWrapper } from './HelpWrapper';
 export { HelpDisplay } from './HelpDisplay';
 export { DocumentationViewer } from './DocumentationViewer';
 export { ModelOverview } from './ModelOverview';
+export { AboutDialog } from './AboutDialog';
 export * from './visualizations';


### PR DESCRIPTION
## Summary
Replaces the scroll-to-top behavior when clicking the application logo with an About modal that displays application information.

## Changes
- Created `AboutDialog` components for both GoPCA Desktop and GoCSV Desktop
- Replaced `scrollToTop` handler with About modal trigger on logo click
- Displays comprehensive application information:
  - Application name and logo
  - Version information
  - Copyright notice (© 2025 bitjungle - Rune Mathisen)
  - MIT License with military/surveillance use note
  - Homepage link (https://bitjungle.github.io/gopca/)

## Implementation Details
- Uses existing `Dialog` component from `@gopca/ui-components` for consistency
- Maintains theme support (light/dark mode)
- Homepage and license links open in external browser via `BrowserOpenURL`
- Accessible with keyboard navigation and screen reader support
- Version text remains visible next to logo for quick reference

## Testing
- ✅ Built both GoPCA and GoCSV frontends successfully
- ✅ All existing tests pass
- ✅ TypeScript compilation successful

## Screenshots
Both applications now show an About modal when clicking the logo instead of scrolling to top.

Closes #398