### PR TITLE
Feat: Add missing help text entries for GUI elements

### DIFF
--- a/cmd/gocsv/frontend/src/help/help-content.json
+++ b/cmd/gocsv/frontend/src/help/help-content.json
@@ -1,0 +1,188 @@
+{
+  "help": {
+    "gocsv-logo-about": {
+      "title": "About GoCSV",
+      "text": "Click to view GoCSV version and information.",
+      "category": "interface"
+    },
+    "gocsv-documentation": {
+      "title": "Documentation",
+      "text": "Open GoCSV user manual for data editing and preparation guidance.",
+      "category": "interface"
+    },
+    "undo-redo-controls": {
+      "title": "Undo/Redo",
+      "text": "Undo or redo recent edits. Keyboard shortcuts: Ctrl+Z/Ctrl+Y.",
+      "category": "editing"
+    },
+    "data-quality-report": {
+      "title": "Data Quality Report",
+      "text": "Generate comprehensive report on data completeness, types, and potential issues.",
+      "category": "analysis"
+    },
+    "analyze-missing": {
+      "title": "Analyze Missing Values",
+      "text": "Identify missing data patterns and get column-wise statistics.",
+      "category": "analysis"
+    },
+    "fill-missing": {
+      "title": "Fill Missing Values",
+      "text": "Replace missing values using mean, median, or custom strategies.",
+      "category": "editing"
+    },
+    "transform-data": {
+      "title": "Transform Data",
+      "text": "Apply data transformations like scaling, normalization, or encoding.",
+      "category": "editing"
+    },
+    "browse-file": {
+      "title": "Browse for File",
+      "text": "Select CSV, TSV, or Excel file from your computer.",
+      "category": "data-input"
+    },
+    "import-wizard": {
+      "title": "Import with Wizard",
+      "text": "Advanced import with custom delimiters, encoding, and column selection.",
+      "category": "data-input"
+    },
+    "validate-gopca": {
+      "title": "Validate for GoPCA",
+      "text": "Check if data meets requirements for PCA analysis.",
+      "category": "validation"
+    },
+    "open-gopca": {
+      "title": "Open in GoPCA",
+      "text": "Launch GoPCA Desktop with current data for PCA analysis.",
+      "category": "integration"
+    },
+    "export-csv": {
+      "title": "Export as CSV",
+      "text": "Save edited data as CSV file with current formatting.",
+      "category": "export"
+    },
+    "export-excel": {
+      "title": "Export as Excel",
+      "text": "Save edited data as Excel file with formatting preserved.",
+      "category": "export"
+    },
+    "theme-toggle": {
+      "title": "Theme Toggle",
+      "text": "Switch between light and dark modes. Preference saved locally.",
+      "category": "interface"
+    },
+    "grid-editor": {
+      "title": "Data Grid Editor",
+      "text": "Edit cells directly. Click to select, double-click to edit. Use Tab/Enter to navigate.",
+      "category": "editing"
+    },
+    "column-stats": {
+      "title": "Column Statistics",
+      "text": "View min, max, mean, and missing count for each column.",
+      "category": "analysis"
+    },
+    "row-operations": {
+      "title": "Row Operations",
+      "text": "Add, delete, or duplicate rows. Right-click for context menu.",
+      "category": "editing"
+    },
+    "column-operations": {
+      "title": "Column Operations",
+      "text": "Add, delete, rename, or reorder columns. Right-click header for options.",
+      "category": "editing"
+    },
+    "search-replace": {
+      "title": "Search and Replace",
+      "text": "Find and replace values across the entire dataset or selected columns.",
+      "category": "editing"
+    },
+    "filter-data": {
+      "title": "Filter Data",
+      "text": "Apply filters to show only rows matching specific criteria.",
+      "category": "analysis"
+    },
+    "sort-data": {
+      "title": "Sort Data",
+      "text": "Sort by one or multiple columns in ascending or descending order.",
+      "category": "editing"
+    },
+    "data-types": {
+      "title": "Data Types",
+      "text": "Automatically detect or manually set column data types (numeric, text, date).",
+      "category": "analysis"
+    },
+    "correlation-matrix": {
+      "title": "Correlation Matrix",
+      "text": "View correlation coefficients between numeric columns.",
+      "category": "analysis"
+    },
+    "distribution-plots": {
+      "title": "Distribution Plots",
+      "text": "Visualize data distribution with histograms and box plots.",
+      "category": "visualization"
+    },
+    "missing-heatmap": {
+      "title": "Missing Data Heatmap",
+      "text": "Visual representation of missing data patterns across the dataset.",
+      "category": "visualization"
+    },
+    "keyboard-shortcuts": {
+      "title": "Keyboard Shortcuts",
+      "text": "Ctrl+O: Open, Ctrl+S: Save, Ctrl+Z: Undo, Ctrl+Y: Redo, Delete: Clear cell.",
+      "category": "interface"
+    },
+    "file-formats": {
+      "title": "Supported Formats",
+      "text": "CSV, TSV, and Excel files. Auto-detect delimiter and encoding.",
+      "category": "data-input"
+    },
+    "encoding-options": {
+      "title": "Text Encoding",
+      "text": "UTF-8, ISO-8859-1, Windows-1252. Auto-detect or manually specify.",
+      "category": "data-input"
+    },
+    "delimiter-options": {
+      "title": "Delimiter Options",
+      "text": "Comma, tab, semicolon, pipe, or custom delimiter for CSV files.",
+      "category": "data-input"
+    }
+  },
+  "categories": {
+    "data-input": {
+      "name": "Data Input",
+      "description": "Loading and importing data files"
+    },
+    "editing": {
+      "name": "Editing",
+      "description": "Data modification and manipulation"
+    },
+    "analysis": {
+      "name": "Analysis",
+      "description": "Data quality and statistics"
+    },
+    "visualization": {
+      "name": "Visualization",
+      "description": "Charts and visual analysis"
+    },
+    "validation": {
+      "name": "Validation",
+      "description": "Data validation and checking"
+    },
+    "integration": {
+      "name": "Integration",
+      "description": "Integration with GoPCA"
+    },
+    "export": {
+      "name": "Export",
+      "description": "Saving and exporting data"
+    },
+    "interface": {
+      "name": "Interface",
+      "description": "UI controls and navigation"
+    }
+  },
+  "metadata": {
+    "version": "1.0.0",
+    "lastUpdated": "2025-01-31",
+    "application": "GoCSV Desktop"
+  }
+}

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -518,12 +518,14 @@ return;
             <header className="sticky top-0 z-50 bg-white dark:bg-gray-800 shadow-lg backdrop-blur-sm bg-opacity-95 dark:bg-opacity-95">
                 <div className="flex items-center justify-between max-w-7xl mx-auto px-4 py-3 h-20">
                     <div className="flex items-center gap-4">
-                        <img
-                            src={logo}
-                            alt="GoPCA - Principal Component Analysis Tool"
-                            className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
-                            onClick={handleLogoClick}
-                        />
+                        <HelpWrapper helpKey="logo-about">
+                            <img
+                                src={logo}
+                                alt="GoPCA - Principal Component Analysis Tool"
+                                className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
+                                onClick={handleLogoClick}
+                            />
+                        </HelpWrapper>
                     </div>
                     <div className="flex-1 mx-8 overflow-hidden">
                         <HelpDisplay
@@ -533,27 +535,29 @@ return;
                         />
                     </div>
                     <div className="flex items-center gap-2">
-                        <button
-                            onClick={() => setShowDocumentation(true)}
-                            className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-                            aria-label="Open documentation"
-                        >
-                            {/* Book icon */}
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                strokeWidth={1.5}
-                                stroke="currentColor"
-                                className="w-5 h-5 text-gray-700 dark:text-gray-300"
+                        <HelpWrapper helpKey="documentation-button">
+                            <button
+                                onClick={() => setShowDocumentation(true)}
+                                className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
+                                aria-label="Open documentation"
                             >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18c-2.305 0-4.408.867-6 2.292m0-14.25v14.25"
-                                />
-                            </svg>
-                        </button>
+                                {/* Book icon */}
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth={1.5}
+                                    stroke="currentColor"
+                                    className="w-5 h-5 text-gray-700 dark:text-gray-300"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18c-2.305 0-4.408.867-6 2.292m0-14.25v14.25"
+                                    />
+                                </svg>
+                            </button>
+                        </HelpWrapper>
                         <ThemeToggle />
                     </div>
                 </div>

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -558,7 +558,9 @@ return;
                                 </svg>
                             </button>
                         </HelpWrapper>
-                        <ThemeToggle />
+                        <HelpWrapper helpKey="theme-toggle">
+                            <ThemeToggle />
+                        </HelpWrapper>
                     </div>
                 </div>
             </header>

--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -190,6 +190,16 @@
       "text": "Heatmap showing correlations between PC scores and metadata variables. Helps identify relationships between components and external factors.",
       "category": "visualization"
     },
+    "scores3d-plot": {
+      "title": "3D Scores Plot",
+      "text": "3D visualization of samples in PC space. Rotate with mouse to explore patterns from different angles.",
+      "category": "visualization"
+    },
+    "biplot3d-plot": {
+      "title": "3D Biplot",
+      "text": "3D biplot combining scores and loadings. Interactive rotation reveals sample-variable relationships.",
+      "category": "visualization"
+    },
     "component-selector": {
       "title": "Component Selection",
       "text": "Choose which PCs to plot. PC1 usually most important. Try different combinations.",
@@ -225,6 +235,16 @@
       "text": "Switch between light and dark modes. Preference saved locally.",
       "category": "interface"
     },
+    "logo-about": {
+      "title": "About GoPCA",
+      "text": "Click to view application version, credits, and licensing information.",
+      "category": "interface"
+    },
+    "documentation-button": {
+      "title": "Documentation",
+      "text": "Open user manual with documentation for all features and PCA concepts.",
+      "category": "interface"
+    },
     "plot-color-palette": {
       "title": "Plot Palettes",
       "text": "Choose between Categorical (distinct colors for groups/categories) or Sequential (gradient for continuous values).",
@@ -243,6 +263,11 @@
     "outlier-detection": {
       "title": "Outlier Detection",
       "text": "High T²: unusual but follows model. High Q: doesn't fit model. Both high: strong outlier.",
+      "category": "analysis"
+    },
+    "diagnostic-threshold": {
+      "title": "Diagnostic Threshold",
+      "text": "Set statistical threshold for outlier detection. 95% for standard, 99% for strict outlier identification.",
       "category": "analysis"
     },
     "row-labels": {
@@ -273,6 +298,11 @@
     "palette-selector": {
       "title": "Color Palette",
       "text": "Choose colors for plot. Categorical: distinct colors for groups. Sequential: gradient for continuous values.",
+      "category": "visualization"
+    },
+    "font-size-control": {
+      "title": "Font Size Control",
+      "text": "Adjust font size for all plot labels and text. Useful for presentations or high-res exports.",
       "category": "visualization"
     },
     "plot-tabs": {


### PR DESCRIPTION
## Summary
This PR adds missing help text entries for GUI elements in both GoPCA and GoCSV desktop applications, improving user experience and feature discoverability.

## Changes

### GoPCA Desktop
**Added help entries to help-content.json:**
- `logo-about`: Click to view application version, credits, and licensing information
- `documentation-button`: Open user manual with documentation for all features and PCA concepts
- `font-size-control`: Adjust font size for all plot labels and text
- `scores3d-plot`: 3D visualization of samples in PC space
- `biplot3d-plot`: 3D biplot combining scores and loadings
- `diagnostic-threshold`: Set statistical threshold for outlier detection

**Added HelpWrapper components:**
- Wrapped logo element with HelpWrapper (helpKey="logo-about")
- Wrapped documentation button with HelpWrapper (helpKey="documentation-button")
- Wrapped theme toggle with HelpWrapper (helpKey="theme-toggle")

### GoCSV Desktop
**Created help-content.json:**
- Comprehensive help entries for all UI elements mentioned in the issue
- Organized into logical categories (data-input, editing, analysis, etc.)
- Foundation for future help system implementation (see new issue #411 for implementation task)

## Testing
- ✅ TypeScript compilation passes
- ✅ JSON validation passes for both help-content.json files
- ✅ Pre-commit hooks pass
- ✅ All help text entries are ≤160 characters as required

## Notes
- GoCSV doesn't currently have HelpWrapper components implemented, so the help-content.json provides the foundation for future implementation
- All help text follows the concise format established in GoPCA
- A follow-up issue will be created for implementing the help system in GoCSV

Closes #409