### PR TITLE
feat: add range syntax support for --exclude-rows and --exclude-columns (#416)

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -32,6 +32,33 @@ import { FontSizeControl } from './components/FontSizeControl';
 import { config } from '../wailsjs/go/models';
 import logo from './assets/images/GoPCA-logo-1024-transp.png';
 
+// Utility function to optimize indices to range notation
+function optimizeToRanges(indices: number[]): string {
+    if (indices.length === 0) return '';
+    
+    // Sort indices first
+    const sorted = [...indices].sort((a, b) => a - b);
+    const ranges: string[] = [];
+    let start = sorted[0];
+    let end = sorted[0];
+    
+    for (let i = 1; i < sorted.length; i++) {
+        if (sorted[i] === end + 1) {
+            // Consecutive number, extend range
+            end = sorted[i];
+        } else {
+            // Non-consecutive, save current range and start new one
+            ranges.push(start === end ? `${start}` : `${start}-${end}`);
+            start = end = sorted[i];
+        }
+    }
+    
+    // Add the last range
+    ranges.push(start === end ? `${start}` : `${start}-${end}`);
+    
+    return ranges.join(',');
+}
+
 function AppContent() {
     const { currentHelp, currentHelpKey } = useHelp();
     const { setMode } = usePalette();
@@ -414,15 +441,17 @@ return;
         // Add excluded columns if any
         if (excludedColumns.length > 0) {
             // Convert 0-indexed to 1-indexed for CLI
-            const columnIndices = excludedColumns.map(c => c + 1).join(',');
-            cmd += ` --exclude-cols ${columnIndices}`;
+            const columnIndices = excludedColumns.map(c => c + 1);
+            const rangeStr = optimizeToRanges(columnIndices);
+            cmd += ` --exclude-cols ${rangeStr}`;
         }
 
         // Add excluded rows if any
         if (excludedRows.length > 0) {
             // Convert 0-indexed to 1-indexed for CLI
-            const rowIndices = excludedRows.map(r => r + 1).join(',');
-            cmd += ` --exclude-rows ${rowIndices}`;
+            const rowIndices = excludedRows.map(r => r + 1);
+            const rangeStr = optimizeToRanges(rowIndices);
+            cmd += ` --exclude-rows ${rangeStr}`;
         }
 
         return cmd;

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -118,8 +118,8 @@ pca analyze [OPTIONS] <input.csv>
 **Note:** The `native` strategy is only available with the NIPALS method. When using SVD (default), you must choose a preprocessing strategy (drop, mean, median, or zero) if your data contains missing values.
 
 ##### Data Selection
-- `--exclude-rows <string>` - Comma-separated list of row indices to exclude (1-based)
-- `--exclude-columns <string>` - Comma-separated list of column names or indices to exclude
+- `--exclude-rows <string>` - Row indices to exclude (1-based). Supports individual indices and ranges: `1,3,5` or `1-5,8-10`
+- `--exclude-columns <string>` - Column indices/names to exclude. Supports ranges for indices: `1-3,5` or `col1,col2`
 - `--target-columns <string>` - Comma-separated list of target columns to exclude
 
 ##### Group and Correlation Analysis
@@ -196,7 +196,7 @@ When verbose mode is enabled, the CLI will report:
 # Exclude specific columns
 pca analyze --exclude-columns "id,timestamp" data.csv
 
-# Exclude specific rows
+# Exclude specific rows (individual and ranges)
 pca analyze --exclude-rows "1,5,10-15" data.csv
 
 # Exclude target columns
@@ -299,7 +299,7 @@ pca transform model.json new_data.csv
 # Save to specific file with JSON format
 pca transform -f json -o results/ model.json new_data.csv
 
-# Exclude specific rows
+# Exclude specific rows (using range syntax)
 pca transform --exclude-rows 1,5-10 model.json new_data.csv
 
 # Include diagnostic metrics

--- a/internal/cobra/analyze.go
+++ b/internal/cobra/analyze.go
@@ -165,9 +165,9 @@ EXAMPLES:
 
 	// Exclude options
 	cmd.Flags().StringVar(&opts.ExcludeRows, "exclude-rows", "",
-		"Comma-separated list of row indices to exclude (1-based)")
+		"Row indices to exclude (1-based): e.g., '1,3,5' or '1-5,8-10'")
 	cmd.Flags().StringVar(&opts.ExcludeColumns, "exclude-columns", "",
-		"Comma-separated list of column names or indices to exclude")
+		"Column indices/names to exclude: e.g., '1,3' or '1-5' or 'col1,col2'")
 
 	// Verbose output
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false,
@@ -389,37 +389,114 @@ func runAnalyze(opts *AnalyzeOptions, inputFile string) error {
 
 // Helper functions for parsing exclude options
 func parseExcludeIndices(excludeStr string) []int {
-	var indices []int
+	indexSet := make(map[int]bool)
 	parts := strings.Split(excludeStr, ",")
+
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
-		var idx int
-		if _, err := fmt.Sscanf(part, "%d", &idx); err == nil {
-			indices = append(indices, idx-1) // Convert to 0-based
+
+		if strings.Contains(part, "-") {
+			// Parse range format "start-end"
+			rangeParts := strings.SplitN(part, "-", 2)
+			if len(rangeParts) == 2 {
+				var start, end int
+				if _, err := fmt.Sscanf(rangeParts[0], "%d", &start); err == nil {
+					if _, err := fmt.Sscanf(rangeParts[1], "%d", &end); err == nil {
+						// Add all indices in range (inclusive)
+						for i := start; i <= end; i++ {
+							if i > 0 { // Ensure positive indices
+								indexSet[i-1] = true // Convert to 0-based
+							}
+						}
+					}
+				}
+			}
+		} else {
+			// Parse individual number
+			var idx int
+			if _, err := fmt.Sscanf(part, "%d", &idx); err == nil && idx > 0 {
+				indexSet[idx-1] = true // Convert to 0-based
+			}
 		}
 	}
-	return indices
-}
 
-func parseExcludeColumns(excludeStr string, headers []string) []int {
-	var indices []int
-	parts := strings.Split(excludeStr, ",")
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
+	// Convert map to sorted slice
+	indices := make([]int, 0, len(indexSet))
+	for idx := range indexSet {
+		indices = append(indices, idx)
+	}
 
-		// Try to parse as index first
-		var idx int
-		if _, err := fmt.Sscanf(part, "%d", &idx); err == nil {
-			indices = append(indices, idx-1) // Convert to 0-based
-		} else {
-			// Try to match by name
-			for i, header := range headers {
-				if header == part {
-					indices = append(indices, i)
-					break
+	// Sort the indices
+	if len(indices) > 1 {
+		// Simple bubble sort for small arrays
+		for i := 0; i < len(indices)-1; i++ {
+			for j := 0; j < len(indices)-i-1; j++ {
+				if indices[j] > indices[j+1] {
+					indices[j], indices[j+1] = indices[j+1], indices[j]
 				}
 			}
 		}
 	}
+
+	return indices
+}
+
+func parseExcludeColumns(excludeStr string, headers []string) []int {
+	indexSet := make(map[int]bool)
+	parts := strings.Split(excludeStr, ",")
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+
+		if strings.Contains(part, "-") {
+			// Parse range format "start-end" (only for numeric indices)
+			rangeParts := strings.SplitN(part, "-", 2)
+			if len(rangeParts) == 2 {
+				var start, end int
+				if _, err := fmt.Sscanf(rangeParts[0], "%d", &start); err == nil {
+					if _, err := fmt.Sscanf(rangeParts[1], "%d", &end); err == nil {
+						// Add all indices in range (inclusive)
+						for i := start; i <= end; i++ {
+							if i > 0 && i <= len(headers) { // Ensure valid range
+								indexSet[i-1] = true // Convert to 0-based
+							}
+						}
+					}
+				}
+			}
+		} else {
+			// Try to parse as index first
+			var idx int
+			if _, err := fmt.Sscanf(part, "%d", &idx); err == nil && idx > 0 && idx <= len(headers) {
+				indexSet[idx-1] = true // Convert to 0-based
+			} else {
+				// Try to match by name
+				for i, header := range headers {
+					if header == part {
+						indexSet[i] = true
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Convert map to sorted slice
+	indices := make([]int, 0, len(indexSet))
+	for idx := range indexSet {
+		indices = append(indices, idx)
+	}
+
+	// Sort the indices
+	if len(indices) > 1 {
+		for i := 0; i < len(indices)-1; i++ {
+			for j := 0; j < len(indices)-i-1; j++ {
+				if indices[j] > indices[j+1] {
+					indices[j], indices[j+1] = indices[j+1], indices[j]
+				}
+			}
+		}
+	}
+
 	return indices
 }

--- a/internal/cobra/analyze_test.go
+++ b/internal/cobra/analyze_test.go
@@ -1,0 +1,159 @@
+// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package cobra
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseExcludeIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []int
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []int{},
+		},
+		{
+			name:     "single index",
+			input:    "5",
+			expected: []int{4}, // 0-based
+		},
+		{
+			name:     "multiple indices",
+			input:    "1,3,5",
+			expected: []int{0, 2, 4}, // 0-based
+		},
+		{
+			name:     "single range",
+			input:    "1-5",
+			expected: []int{0, 1, 2, 3, 4}, // 0-based
+		},
+		{
+			name:     "multiple ranges",
+			input:    "1-3,8-10",
+			expected: []int{0, 1, 2, 7, 8, 9}, // 0-based
+		},
+		{
+			name:     "mixed indices and ranges",
+			input:    "1,3-5,8,10-12",
+			expected: []int{0, 2, 3, 4, 7, 9, 10, 11}, // 0-based
+		},
+		{
+			name:     "overlapping ranges",
+			input:    "1-5,3-7",
+			expected: []int{0, 1, 2, 3, 4, 5, 6}, // 0-based, deduplicated
+		},
+		{
+			name:     "duplicate indices",
+			input:    "1,2,2,3,1",
+			expected: []int{0, 1, 2}, // 0-based, deduplicated
+		},
+		{
+			name:     "with spaces",
+			input:    " 1 - 3 , 5 , 7 - 9 ",
+			expected: []int{0, 1, 2, 4, 6, 7, 8}, // 0-based
+		},
+		{
+			name:     "single element range",
+			input:    "5-5",
+			expected: []int{4}, // 0-based
+		},
+		{
+			name:     "unsorted input",
+			input:    "10,5,1-3",
+			expected: []int{0, 1, 2, 4, 9}, // 0-based, sorted
+		},
+		{
+			name:     "invalid indices ignored",
+			input:    "0,1,2,-5",
+			expected: []int{0, 1}, // 0 and negative indices ignored
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseExcludeIndices(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseExcludeIndices(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseExcludeColumns(t *testing.T) {
+	headers := []string{"col1", "col2", "col3", "col4", "col5"}
+
+	tests := []struct {
+		name     string
+		input    string
+		headers  []string
+		expected []int
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			headers:  headers,
+			expected: []int{},
+		},
+		{
+			name:     "single index",
+			input:    "2",
+			headers:  headers,
+			expected: []int{1}, // 0-based
+		},
+		{
+			name:     "range of indices",
+			input:    "1-3",
+			headers:  headers,
+			expected: []int{0, 1, 2}, // 0-based
+		},
+		{
+			name:     "single column name",
+			input:    "col3",
+			headers:  headers,
+			expected: []int{2}, // 0-based
+		},
+		{
+			name:     "mixed names and indices",
+			input:    "1,col3,5",
+			headers:  headers,
+			expected: []int{0, 2, 4}, // 0-based
+		},
+		{
+			name:     "mixed names and ranges",
+			input:    "col1,2-3,col5",
+			headers:  headers,
+			expected: []int{0, 1, 2, 4}, // 0-based
+		},
+		{
+			name:     "out of range indices ignored",
+			input:    "1,10,3",
+			headers:  headers,
+			expected: []int{0, 2}, // 10 is out of range
+		},
+		{
+			name:     "invalid column names ignored",
+			input:    "col1,invalid,col3",
+			headers:  headers,
+			expected: []int{0, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseExcludeColumns(tt.input, tt.headers)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseExcludeColumns(%q, %v) = %v, want %v", tt.input, tt.headers, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Implements range syntax support for the `--exclude-rows` and `--exclude-columns` CLI flags, allowing users to specify ranges like `1-5,8-10` instead of listing each index individually.

## Related Issue
Closes #416

## Changes Made

### CLI Parser Enhancements
- Enhanced `parseExcludeIndices()` function to parse range syntax (e.g., `1-5`)
- Enhanced `parseExcludeColumns()` function with same range parsing capability
- Both functions now handle:
  - Individual indices: `1,3,5`
  - Ranges: `1-5` (inclusive)
  - Mixed syntax: `1-5,8-10,17,20`
  - Overlapping ranges and duplicates (automatically deduplicated)
  - Invalid indices (ignored)
- Updated help text to document the new syntax

### GoPCA Desktop Enhancements
- Added `optimizeToRanges()` function to generate compact CLI commands
- Converts arrays like `[1,2,3,4,5,8,9,10]` to `"1-5,8-10"`
- Reduces command line length significantly for large exclusion lists

### Documentation Updates
- Updated `docs/cli_reference.md` with range syntax examples
- Clarified that ranges are supported for numeric indices
- Updated help text in CLI to show the new syntax format

### Testing
- Comprehensive unit tests for both parsing functions
- Tests cover edge cases: empty input, single elements, overlapping ranges, duplicates
- Verified backward compatibility with existing comma-separated syntax
- Tested with actual CSV files to ensure functionality

## Example Usage

**Before:**
```bash
pca analyze iris.csv --exclude-rows 1,2,3,4,5,8,9,10,17,20
```

**After:**
```bash
pca analyze iris.csv --exclude-rows 1-5,8-10,17,20
```

## Testing Performed
- [x] Unit tests pass for range parsing
- [x] CLI correctly parses range syntax into individual indices
- [x] GoPCA Desktop generates optimized commands with ranges
- [x] Backward compatibility maintained
- [x] Documentation updated

## Known Issue (Pre-existing)
During testing, I discovered that row exclusions are not being properly applied during PCA analysis - the CLI still outputs all 150 samples even when some are excluded. This is a **pre-existing bug** unrelated to the range syntax feature and should be addressed in a separate issue.

## Benefits
- ✅ Shorter, more readable CLI commands
- ✅ Better user experience for large datasets
- ✅ Reduced command line length (important for shell limits)
- ✅ Consistent with common CLI tools (sed, awk, etc.)
- ✅ Maintains full backward compatibility