### PR TITLE
feat: add row index as continuous coloring option for samples

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -209,8 +209,17 @@ function AppContent() {
     // Helper function to get column data and type
     const getColumnData = (columnName: string | null): { values?: string[] | number[], type?: 'categorical' | 'continuous' } => {
         if (!columnName || !fileData) {
-return {};
-}
+            return {};
+        }
+
+        // Handle special "Row Index" column
+        if (columnName === 'Row Index') {
+            // Generate 1-based row indices for the current data
+            // Use the actual number of samples in the PCA result if available
+            const numSamples = pcaResponse?.result?.scores?.length || fileData.data.length;
+            const indices = Array.from({length: numSamples}, (_, i) => i + 1);
+            return { values: indices, type: 'continuous' };
+        }
 
         // CRITICAL FIX: Use filtered data from PCA response when rows have been dropped
         // This ensures categorical/numeric column data aligns with the reduced scores matrix
@@ -1355,6 +1364,10 @@ return;
                                                             if (!selectedValue) {
                                                                 setMode('none');
                                                                 setShowEllipses(false);
+                                                            } else if (selectedValue === 'Row Index') {
+                                                                // Row Index is always continuous
+                                                                setMode('continuous');
+                                                                setShowEllipses(false); // Ellipses only work with categorical data
                                                             } else if (fileData.numericTargetColumns && selectedValue in fileData.numericTargetColumns) {
                                                                 setMode('continuous');
                                                                 setShowEllipses(false); // Ellipses only work with categorical data
@@ -1365,6 +1378,8 @@ return;
                                                         }}
                                                         options={[
                                                             { value: '', label: 'None' },
+                                                            // Row Index - always available as a continuous option
+                                                            { value: 'Row Index', label: '📊 Row Index', group: 'Continuous' },
                                                             // Categorical columns
                                                             ...(fileData.categoricalColumns && Object.keys(fileData.categoricalColumns).length > 0 
                                                                 ? Object.keys(fileData.categoricalColumns).map((colName) => ({

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1347,10 +1347,8 @@ return;
                                 {/* Tier 2: Context-Sensitive Controls */}
                                 <div className="mb-4">
                                     <div className="flex flex-wrap items-center gap-4">
-                                        {/* Data Display Group */}
-                                        {(selectedPlot === 'scores' || selectedPlot === 'scores3d' || selectedPlot === 'biplot' || selectedPlot === 'biplot3d') && fileData &&
-                                         ((fileData.categoricalColumns && Object.keys(fileData.categoricalColumns).length > 0) ||
-                                          (fileData.numericTargetColumns && Object.keys(fileData.numericTargetColumns).length > 0)) && (
+                                        {/* Data Display Group - Always show Color by control since Row Index is always available */}
+                                        {(selectedPlot === 'scores' || selectedPlot === 'scores3d' || selectedPlot === 'biplot' || selectedPlot === 'biplot3d') && fileData && (
                                             <div className="flex items-center gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
                                                 <HelpWrapper helpKey="group-coloring" className="flex items-center gap-2">
                                                     <label className="text-sm text-gray-600 dark:text-gray-400">Color by:</label>

--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -280,6 +280,11 @@
       "text": "Display sample IDs on plots. First column if non-numeric, else row numbers. Useful for identifying specific points.",
       "category": "visualization"
     },
+    "group-coloring": {
+      "title": "Color by Column",
+      "text": "Color samples by categorical columns (discrete colors), continuous #target columns (gradient), or Row Index (gradient showing sample order, useful for time series).",
+      "category": "visualization"
+    },
     "diagnostic-metrics": {
       "title": "Calculate Diagnostic Metrics",
       "text": "Compute T² (Hotelling) and Q (SPE) residuals for outlier detection. Not available for Kernel PCA.",


### PR DESCRIPTION
## Summary
This PR adds the ability to color samples/observations by their row index (position in the data matrix) as a continuous variable. This feature is particularly useful for time series data where row order represents temporal progression.

## Changes
- Added "Row Index" as a special column option in the color-by dropdown
- Modified `getColumnData()` function to handle row index generation
- Row indices are 1-based (user-friendly, matching CSV row numbers)
- Correctly handles filtered/excluded data
- Added appropriate help text

## Implementation Details
- **Frontend Only**: No backend changes required - row indices are generated on the frontend
- **Always Available**: Row Index option appears regardless of data content
- **Continuous Type**: Treated as continuous data with gradient coloring
- **Responsive to Filtering**: When rows are excluded, indices map correctly to remaining samples

## Testing
- ✅ Built frontend without TypeScript errors
- ✅ Row Index appears in dropdown with 📊 indicator
- ✅ Generates correct 1-based indices
- ✅ Switches to continuous color mode when selected
- ✅ Help text is displayed

## Use Cases
- Time series analysis where samples are ordered chronologically
- Process monitoring data where row order represents sequence
- Any dataset where sample order has meaning

## Screenshots
The Row Index option appears in the color dropdown alongside categorical and continuous columns, marked with the 📊 indicator to show it's a continuous variable.

## Issue
Closes #428