### PR TITLE
docs: add PCA literature summaries for audit reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ CLAUDE.md.bak
 
 # Local documentation
 docs_tmp/
+# Keep reference summaries but ignore PDFs
+docs/references/*.pdf
+!docs/references/_summaries.txt
 
 # Build artifacts
 results/

--- a/docs/references/_summaries.txt
+++ b/docs/references/_summaries.txt
@@ -2565,3 +2565,424 @@ Analyzed four marine sediment cores using oxygen isotope ratio ($\delta^{18}O$) 
 
 ---
 
+# Matrix Computations, 4th edition. Chapter 1 – Matrix Multiplication
+
+**APA7 reference:** Golub, G. H., & Loan, C. F. V. (2013). Matrix Computations. JHU Press.
+
+**Filename:** 'Golub og Loan - 2013 - Matrix Computations.pdf'
+
+## **1. Purpose and Scope**
+
+* To introduce **matrix multiplication** as the central operation underlying nearly all factorizations and algorithms in numerical linear algebra.
+* To show that while the basic algebraic definition is simple, **algorithmic and implementation choices** profoundly affect performance.
+* To prepare the reader for later chapters (LU, QR, SVD, eigenvalue problems) where multiplication and block partitioning are used extensively.
+
+---
+
+## **2. Mathematical Preliminaries**
+
+* Defines **matrix multiplication** formally:
+
+  $$
+  (AB)_{ij} = \sum_{k=1}^n a_{ik} b_{kj}
+  $$
+* Emphasizes associativity: $(AB)C = A(BC)$, crucial for algorithm restructuring.
+* Introduces **block matrix notation**: partitioning matrices into submatrices to express large operations in terms of smaller ones.
+
+  * Example: If $A$ and $B$ are block-partitioned, multiplication can be expressed as a sum of block products.
+  * Block notation is heavily used in LU/QR/Cholesky factorization algorithms.
+
+---
+
+## **3. Algorithms for Matrix Multiplication**
+
+### **Naïve multiplication**
+
+* Cost: $O(n^3)$ operations.
+* Straightforward triple-loop algorithm is simple but not efficient on modern architectures.
+
+### **Block algorithms**
+
+* Reorganize computation to work on **submatrices** (blocks).
+* Reduce memory traffic by exploiting cache locality.
+* Basis for **BLAS (Basic Linear Algebra Subprograms)** — levels 1 (vector-vector), 2 (matrix-vector), and 3 (matrix-matrix).
+* **Level 3 BLAS** (matrix-matrix) is critical: higher arithmetic intensity, more efficient use of modern CPUs/GPUs.
+
+### **Fast matrix multiplication**
+
+* **Strassen’s algorithm**: reduces exponent from 3 to \~2.807.
+
+  * Recursively partitions matrices into 2×2 blocks.
+  * Achieves asymptotic speedup but introduces **stability and implementation complexity issues**.
+* Later algorithms (Coppersmith–Winograd, etc.) reduce exponent further (\~2.37), but impractical for moderate sizes.
+* Message: asymptotic results are interesting but in practice **numerical stability and memory hierarchy matter more**.
+
+---
+
+## **4. Special Structures**
+
+* **Symmetric matrices**: exploit symmetry to halve computations.
+* **Triangular matrices**: multiplication simplified because half entries are zero.
+* **Banded matrices**: only nearby diagonals are nonzero, reducing cost to $O(nb^2)$ for bandwidth $b$.
+* These cases foreshadow structured solvers in Chapters 3–4.
+
+---
+
+## **5. Matrix–Vector and Vector–Vector Products**
+
+* Introduces **matrix-vector multiplication** ($Ax$), which costs $O(n^2)$.
+* Highlights importance in iterative solvers (e.g., CG, GMRES in Chapters 10–11).
+* Vector inner products and outer products as fundamental operations.
+
+---
+
+## **6. Kronecker Product**
+
+* Defined as:
+
+  $$
+  A \otimes B = \begin{bmatrix}
+  a_{11}B & \dots & a_{1n}B \\
+  \vdots & \ddots & \vdots \\
+  a_{m1}B & \dots & a_{mn}B
+  \end{bmatrix}
+  $$
+* Useful for expressing structured linear systems and tensor computations (later in Chapter 12).
+* Important in control theory, signal processing, and multiway data analysis.
+
+---
+
+## **7. Fast Matrix–Vector Multiplication**
+
+* Certain structured matrices (e.g., circulant, Toeplitz) allow multiplication via **FFT in $O(n \log n)$** instead of $O(n^2)$.
+* Connects linear algebra to signal processing (convolutions, filtering).
+* Example: circulant matrix–vector multiplication corresponds to cyclic convolution.
+
+---
+
+## **8. Computational Considerations**
+
+### **Arithmetic cost vs. memory cost**
+
+* Naïve flop counts (e.g., $2n^3$ for multiplication) underestimate the real challenge: **data movement** between memory levels dominates runtime.
+* **Cache-aware algorithms** (blocking, tiling) minimize memory traffic.
+
+### **Parallelism**
+
+* **Shared-memory systems**: multiple threads can operate on blocks.
+* **Distributed systems**: require communication-efficient partitioning.
+* Block-cyclic distributions balance load across processors.
+
+### **Communication lower bounds**
+
+* Theoretical results show that communication (moving data between memory hierarchies) can cost more than arithmetic.
+* Optimal algorithms minimize both **flops** and **memory transfers**.
+
+---
+
+## **9. Matrix Multiplication in Practice**
+
+* LAPACK and ScaLAPACK rely on **highly optimized Level 3 BLAS** for speed.
+* Performance portability: matrix multiplication kernels must be tuned to hardware (vector instructions, GPU accelerators).
+* Example: in practice, the performance of LU/QR/SVD is bounded by the efficiency of GEMM (general matrix multiply).
+
+---
+
+---
+
+# Matrix Computations, 4th edition. Chapter 2 – Matrix Analysis
+
+**APA7 reference:** Golub, G. H., & Loan, C. F. V. (2013). Matrix Computations. JHU Press.
+
+**Filename:** 'Golub og Loan - 2013 - Matrix Computations.pdf'
+
+## **1. Purpose and Scope**
+
+* To provide the **mathematical tools** needed to assess the sensitivity and stability of matrix algorithms.
+* Focuses on **matrix norms, condition numbers, singular values, and perturbation theory**.
+* Establishes a clear separation between:
+
+  1. **Problem conditioning** (how sensitive the mathematical problem is to data errors),
+  2. **Algorithm stability** (how faithfully an algorithm solves the intended problem in finite precision).
+
+---
+
+## **2. Norms**
+
+### **Vector norms**
+
+* Definitions: $p$-norms ($\|x\|_1, \|x\|_2, \|x\|_\infty$).
+* **Euclidean norm** ($l_2$) is most common; invariant under orthogonal transformations.
+* Equivalent norms: in finite dimensions, all norms are equivalent up to constants, but choice affects analysis.
+
+### **Matrix norms**
+
+* **Induced (operator) norms**:
+
+  $$
+  \|A\|_p = \max_{x \neq 0} \frac{\|Ax\|_p}{\|x\|_p}
+  $$
+* Special cases:
+
+  * $\|A\|_1 = \max_j \sum_i |a_{ij}|$ (max column sum),
+  * $\|A\|_\infty = \max_i \sum_j |a_{ij}|$ (max row sum),
+  * $\|A\|_2 = \sigma_{\max}(A)$ (largest singular value).
+
+### **Frobenius norm**
+
+* Defined as
+
+  $$
+  \|A\|_F = \sqrt{\sum_{i,j} |a_{ij}|^2}
+  $$
+* Equivalent to vectorizing matrix into $\mathbb{R}^{mn}$.
+* Convenient for analysis and computation (unitarily invariant).
+
+---
+
+## **3. Singular Value Decomposition (SVD)**
+
+* Statement: any $A \in \mathbb{R}^{m \times n}$ can be written as
+
+  $$
+  A = U \Sigma V^T
+  $$
+
+  with $U, V$ orthogonal and $\Sigma$ diagonal with singular values $\sigma_1 \ge \cdots \ge \sigma_p \ge 0$.
+* SVD is central for:
+
+  * Computing induced 2-norms,
+  * Rank determination,
+  * Pseudoinverse,
+  * Perturbation theory.
+
+---
+
+## **4. Conditioning**
+
+### **Condition numbers**
+
+* For a function $f(A)$, conditioning measures how perturbations in $A$ affect $f(A)$.
+* **Linear systems**:
+
+  $$
+  \kappa(A) = \|A\| \cdot \|A^{-1}\|
+  $$
+
+  * With 2-norm, this simplifies to $\kappa_2(A) = \sigma_{\max}/\sigma_{\min}$.
+* Large $\kappa$: small data errors produce large solution errors (ill-conditioned problem).
+* Example: Hilbert matrices have enormous condition numbers.
+
+### **Perturbation bounds**
+
+* For $Ax=b$, with perturbations $\delta A, \delta b$:
+
+  $$
+  \frac{\|\delta x\|}{\|x\|} \le \kappa(A)\left(\frac{\|\delta A\|}{\|A\|} + \frac{\|\delta b\|}{\|b\|}\right)
+  $$
+* Shows role of condition number as amplification factor.
+
+---
+
+## **5. Perturbation of Subspaces**
+
+* Focus on sensitivity of eigenvectors and invariant subspaces.
+* **Angles between subspaces** defined via singular values (principal angles).
+* **CS decomposition**: relates two subspaces via orthogonal matrices and cos–sin diagonal form.
+* Important for analyzing iterative methods and eigenvalue problems.
+
+---
+
+## **6. Sensitivity of Singular Values**
+
+* Singular values are **Lipschitz continuous** with respect to perturbations:
+
+  $$
+  |\sigma_i(A) - \sigma_i(A+E)| \le \|E\|_2
+  $$
+* This provides robust error bounds for SVD-based methods.
+
+---
+
+## **7. Conditioning vs. Stability**
+
+* **Conditioning**: property of the problem.
+* **Stability**: property of the algorithm.
+* **Backward stability**: an algorithm is backward stable if it returns the exact solution to a slightly perturbed input.
+
+  * E.g., Householder QR is backward stable, Gaussian elimination with partial pivoting is “usually” backward stable.
+* Backward error analysis: standard tool for evaluating algorithms throughout the book.
+
+---
+
+## **8. Backward Error Analysis: Examples**
+
+* Example: solving $Ax=b$ with floating-point arithmetic.
+
+  * If computed $\hat{x}$ satisfies $(A+\delta A)\hat{x}=b$, with small $\delta A$, then algorithm is backward stable.
+* Shows that **small backward error + well-conditioned problem ⇒ accurate solution**.
+
+---
+
+## **9. Connections to Later Chapters**
+
+* Conditioning and error analysis recur in every algorithm (LU, QR, SVD, eigenvalues).
+* Norms and SVD properties form the basis of Chapters 5–9.
+* Subspace perturbation results underpin Krylov methods (Chapters 10–11).
+
+---
+
+# Matrix Computations, 4th edition. Chapter 3 – General Linear Systems
+
+**APA7 reference:** Golub, G. H., & Loan, C. F. V. (2013). Matrix Computations. JHU Press.
+
+**Filename:** 'Golub og Loan - 2013 - Matrix Computations.pdf'
+
+## **1. Purpose and Scope**
+
+* To present algorithms for solving dense, general (nonsymmetric, non-structured) linear systems.
+* To explain the **LU factorization** framework, its computation, numerical properties, and stability.
+* To highlight the role of **pivoting** and **growth factors** in controlling numerical error.
+* To set up the groundwork for structured (Chapter 4), least squares (Chapters 5–6), and iterative (Chapters 10–11) solvers.
+
+---
+
+## **2. Triangular Systems**
+
+* First step: solving $Ux = b$ (upper triangular) or $Lx = b$ (lower triangular).
+* Algorithm: **forward substitution** (for $L$) and **back substitution** (for $U$).
+* Cost: $O(n^2)$.
+* Properties: backward stable if arithmetic is in floating point with rounding errors of size $\epsilon$.
+
+---
+
+## **3. LU Factorization**
+
+### **Definition**
+
+* For square $A \in \mathbb{R}^{n \times n}$:
+
+  $$
+  A = LU
+  $$
+
+  where $L$ is lower triangular (unit diagonal) and $U$ is upper triangular.
+
+### **Existence**
+
+* LU exists without pivoting if all leading principal minors of $A$ are nonzero.
+* In practice, pivoting is usually required.
+
+### **Algorithm**
+
+* Derived from **Gaussian elimination**:
+
+  * Subtract multiples of one row from subsequent rows to eliminate entries.
+  * Multipliers form entries of $L$.
+  * Remaining entries form $U$.
+
+### **Cost**
+
+* Factorization: $\frac{2}{3}n^3$ flops.
+* Solve (with forward/back substitution): $2n^2$ flops.
+
+---
+
+## **4. Gaussian Elimination**
+
+* Equivalent to LU factorization.
+* Standard algorithm for solving linear systems.
+* Process:
+
+  1. Choose pivot element (diagonal entry).
+  2. Eliminate entries below pivot.
+  3. Proceed column by column.
+
+---
+
+## **5. Pivoting**
+
+### **Need for pivoting**
+
+* Without pivoting, elimination can fail due to division by small pivots → catastrophic error amplification.
+
+### **Partial pivoting (GEPP)**
+
+* Pivot element is chosen as the largest (by magnitude) in the current column.
+* Ensures numerical stability in practice for most problems.
+
+### **Complete pivoting (GECP)**
+
+* Pivot chosen as largest in entire submatrix.
+* More stable but too expensive (search costs $O(n^3)$).
+
+### **Growth factor**
+
+* Measures how entries of $U$ can grow during elimination.
+* For GEPP, growth factor $\rho$ is bounded in theory by $2^{n-1}$, but in practice rarely exceeds small multiples of $n$.
+* Error bounds for GEPP:
+
+  $$
+  \frac{\|\delta x\|}{\|x\|} \le \kappa(A) \cdot O(\epsilon) \cdot \rho
+  $$
+
+---
+
+## **6. Stability Analysis**
+
+* GE with partial pivoting is **backward stable in practice** (though not guaranteed in worst case).
+* Example matrices (e.g., Kahan matrix) show possible large growth factor.
+* Empirically: GEPP almost always works reliably.
+
+---
+
+## **7. Refinement and Error Estimation**
+
+### **Iterative refinement**
+
+* Improves solution accuracy by correcting with residuals:
+
+  1. Compute residual $r = b - Ax$.
+  2. Solve $Ad = r$ using LU factors.
+  3. Update solution $x \leftarrow x + d$.
+* Effective if LU is computed in lower precision and refinement in higher precision (mixed precision strategy).
+
+### **Error estimation**
+
+* Condition number estimation via **Hager’s algorithm** or related 1-norm estimation.
+* Provides user with confidence in solution accuracy.
+
+---
+
+## **8. Variants of LU**
+
+* **Block LU factorization**:
+
+  * Uses block partitions and Level 3 BLAS operations for efficiency.
+  * Critical for LAPACK implementations.
+* **Sparse LU**: modifications for sparse systems (covered more in Chapter 11).
+* **Parallel LU**: block-cyclic data distribution and communication optimization (foreshadowed here, detailed in later chapters).
+
+---
+
+## **9. Practical Implementation (Software Libraries)**
+
+* LAPACK routines (e.g., `dgetrf`, `dgetrs`) implement LU with partial pivoting.
+* Designed for cache and parallel efficiency.
+* ScaLAPACK provides distributed memory implementations.
+* Iterative refinement integrated into libraries for high accuracy.
+
+---
+
+## **10. Connections to Later Topics**
+
+* LU factorization is the **prototype decomposition**:
+
+  * Basis for structured system solvers (Chapter 4).
+  * Parallelized via block algorithms (Chapter 1 concepts reused).
+  * Conditioning and stability results (Chapter 2) applied here.
+* QR and Cholesky (Chapters 5–6) are more stable alternatives in least squares and SPD systems.
+* Iterative refinement connects to **mixed precision arithmetic**, now a hot topic in modern HPC (GPUs, exascale computing).
+
+---
+

--- a/docs/references/_summaries.txt
+++ b/docs/references/_summaries.txt
@@ -1,0 +1,2567 @@
+# The Mahalanobis distance and its relationship to principal component scores
+
+**APA7 reference:** Brereton, R. G. (2015). The Mahalanobis distance and its relationship to principal component scores. Journal of Chemometrics, 29(3), 143–145. https://doi.org/10.1002/cem.2692
+
+**Filename:** 'Brereton - 2015 - The Mahalanobis distance and its relationship to principal component scores.pdf'
+
+### **1. Introduction**
+
+* The **Mahalanobis distance** is widely used in chemometrics and multivariate statistics.
+* Applications include:
+
+  * Detecting outliers,
+  * Monitoring process control,
+  * Classifying samples into groups.
+* Despite frequent use, its relationship with **principal component analysis (PCA)** is often misunderstood.
+
+---
+
+### **2. Historical Context**
+
+* Introduced in **1936** by Indian statistician **P. C. Mahalanobis**.
+* Emerged during a productive era of multivariate statistics alongside the work of Fisher and Hotelling.
+
+---
+
+### **3. Definition of Mahalanobis Distance**
+
+* For an observation vector $x$, mean vector $\bar{x}$, and covariance matrix $S$:
+
+$$
+\Delta^2 = (x - \bar{x}) S^{-1} (x - \bar{x})^T
+$$
+
+* **Interpretation:**
+
+  * For one variable, $\Delta$ reduces to the number of standard deviations from the mean.
+  * For multiple variables, it represents distance from the data centroid, considering covariance.
+
+---
+
+### **4. Geometric Interpretation**
+
+* In 2D, constant Mahalanobis distances form **ellipses** centered at the mean, aligned with data variance directions.
+* Alternative computation involves:
+
+  1. Centering the data,
+  2. Rotating to make variables independent,
+  3. Scaling variances to unity.
+* After transformation, Mahalanobis distance equals the Euclidean distance in the new space.
+
+---
+
+### **5. Link with PCA**
+
+* A key insight:
+  **The squared Mahalanobis distance equals the sum of squares of all non-zero standardized PCA scores**.
+
+$$
+\Delta^2 = t_1^2 + t_2^2 + \dots + t_k^2
+$$
+
+where $t_i$ are standardized principal component scores.
+
+* **Implications:**
+
+  * Mahalanobis distance is fundamentally tied to PCA space.
+  * Limitation of covariance inversion (when variables > observations) is avoided using PCA since the number of non-zero PCs ≤ min(variables, observations).
+
+---
+
+### **6. Properties**
+
+* For a dataset with $n$ samples and $p$ variables:
+
+  * The sum of squared Mahalanobis distances ≈ $n \times p$.
+  * This arises because the sum of squared standardized PC scores equals the sample size.
+
+---
+
+### **7. Calculation (Excel Illustration)**
+
+* Step-by-step method for computing Mahalanobis distance using:
+
+  * Means,
+  * Covariance matrix,
+  * Its inverse,
+  * Matrix multiplications (with Excel functions like **MMULT**, **MINVERSE**, etc.).
+* Demonstrates equivalence between Mahalanobis distances and sums of squared normalized PCA scores.
+
+---
+
+### **8. Practical Considerations**
+
+* In high-dimensional chemometric data (e.g., spectroscopy, GC-MS), variables often exceed samples.
+* Traditional computation fails due to singular covariance matrices, but PCA-based methods remain valid.
+* Emphasis on understanding computations rather than relying solely on software like MATLAB, since manual calculation (e.g., in Excel) clarifies conceptual links.
+
+---
+
+### **9. References and Resources**
+
+* Refers to earlier works on chi-squared and multinormal distributions.
+* Suggests online resources (e.g., Matlab-based guides, SAS blog explanations) for further exploration.
+
+---
+
+### **10. Conclusion**
+
+* The Mahalanobis distance is closely related to PCA:
+
+  * It can be interpreted as the squared Euclidean distance in standardized PCA space.
+* This dual perspective (covariance-based vs. PCA-based) is essential for chemometrics and multivariate data analysis.
+* Understanding the link clarifies its use in outlier detection, classification, and multivariate monitoring.
+
+---
+
+# Principal Component Analysis (Bro & Smilde)
+
+**APA7 reference:** Bro, R., & K. Smilde, A. (2014). Principal component analysis. Analytical Methods, 6(9), 2812–2831. https://doi.org/10.1039/C3AY41907J
+
+**Filename:** 'Bro & Smilde - 2014 - Principal component analysis.pdf'
+
+### **1. Purpose and Context**
+
+* The paper is a **tutorial review** of **Principal Component Analysis (PCA)**, focusing on chemometrics but with general applicability.
+* PCA is described as one of the most important methods for analyzing multivariate data in fields such as analytical chemistry, process monitoring, metabolomics, and many other domains.
+
+---
+
+### **2. Introductory Example (Wine Data)**
+
+* Example dataset: **44 Cabernet Sauvignon wine samples** measured with **14 chemical parameters** (ethanol, acids, pH, etc.).
+* Challenge: difficult to interpret directly due to multivariate structure.
+* PCA simplifies interpretation by identifying patterns:
+
+  * Correlation between variables (e.g., ethanol and glycerol).
+  * Regional differences in wines (Australia, Chile, Argentina, South Africa).
+* Demonstrates PCA as a tool for **data reduction and interpretation**.
+
+---
+
+### **3. Foundations of PCA**
+
+* **Concept**: PCA creates **linear combinations** of original variables to capture maximum variance.
+* **First principal component (PC1)**: the direction in variable space with the largest variance.
+* **Mathematical formulation**:
+
+  $$
+  t = Xw
+  $$
+
+  where $X$ is the data matrix, $w$ is the weight vector (loadings), and $t$ are the scores.
+* **Optimization goal**: choose $w$ to maximize variance of $t$, subject to normalization constraints.
+
+---
+
+### **4. PCA as a Model**
+
+* Data approximation:
+
+  $$
+  X \approx TP^T + E
+  $$
+
+  where $T$ = scores, $P$ = loadings, $E$ = residuals.
+* Each component explains a portion of the variance.
+* **Explained variance** is a central metric, showing how much of the dataset’s structure is captured.
+
+---
+
+### **5. Multiple Components**
+
+* PCA can include multiple components:
+
+  $$
+  X \approx \sum_{r=1}^R t_r p_r^T + E
+  $$
+* Loadings are orthogonal, ensuring independent contributions.
+* Each component explains progressively less variance.
+
+---
+
+### **6. Historical Perspectives**
+
+* **Pearson (1901)**: PCA as a regression model minimizing reconstruction error (subspace view).
+* **Hotelling (1933)**: PCA as finding new orthogonal axes maximizing variance (axis view).
+* Both perspectives are mathematically consistent but conceptually distinct.
+
+---
+
+### **7. Visualization and Interpretation**
+
+* **Scores**: show relationships among samples (e.g., clustering wines by origin).
+* **Loadings**: indicate which variables contribute to each component.
+* **Residuals**: reveal unexplained variation, potentially indicating noise or new phenomena.
+* **Biplots**: combine scores and loadings, allowing interpretation of both sample and variable relationships.
+* Cautions:
+
+  * Distance interpretation is only valid if axes are scaled consistently.
+  * Explained variance limits the conclusions that can be drawn.
+
+---
+
+### **8. Practical Aspects**
+
+#### Preprocessing
+
+* **Mean-centering**: removes offsets.
+* **Autoscaling**: adjusts for differences in measurement scales (important for comparability).
+* Preprocessing ensures all variables contribute fairly to PCA.
+
+#### Choosing Number of Components
+
+* Several criteria discussed:
+
+  * **Scree test** (Cattell, 1966).
+  * **Kaiser’s rule** (eigenvalue > 1).
+  * **Broken stick model** (expected distribution under randomness).
+  * **Cumulative explained variance** (depending on noise levels in data).
+  * **Cross-validation** (PRESS, RMSECV).
+* Emphasis on combining methods with **domain-specific interpretation**.
+
+---
+
+### **9. Statistical Considerations**
+
+* **Assumptions**: residuals are typically assumed independent and symmetrically distributed.
+* **Inference**:
+
+  * Approximate normality of scores via the Central Limit Theorem.
+  * Bootstrapping and resampling for distribution-free inference.
+* PCA can be validated statistically, but interpretation remains central.
+
+---
+
+### **10. Applications**
+
+* PCA is used for:
+
+  * **Exploratory data analysis**,
+  * **Outlier detection**,
+  * **Classification** (basis for SIMCA: Soft Independent Modeling of Class Analogy),
+  * **Noise reduction**,
+  * **Visualization of high-dimensional data**.
+
+---
+
+### **11. Key Insights**
+
+* PCA reduces dimensionality while preserving as much variance as possible.
+* It provides interpretable representations of complex multivariate data.
+* Its effectiveness depends on:
+
+  * Proper preprocessing,
+  * Careful choice of number of components,
+  * Correct interpretation of scores, loadings, and residuals.
+
+---
+
+### **12. Conclusion**
+
+* PCA is a **powerful, general-purpose tool** for multivariate data analysis.
+* The article emphasizes both **theory** (mathematical derivation, optimization, geometry) and **practice** (preprocessing, interpretation, visualization).
+* Especially in chemometrics, PCA is indispensable for understanding complex datasets, but its correct application requires awareness of assumptions and limitations.
+
+---
+
+# Extracting Qualitative Dynamics from Experimental Data
+
+**APA7 reference:** Broomhead, D. S., & King, G. P. (1986). Extracting qualitative dynamics from experimental data. Physica D: Nonlinear Phenomena, 20(2–3), 217–236. https://doi.org/10.1016/0167-2789(86)90031-X
+
+**Filename:** 'Broomhead og King - 1986 - Extracting qualitative dynamics from experimental data.pdf'
+
+### **1. Aim of the Paper**
+
+* The article addresses how to extract **qualitative information** about the dynamics of nonlinear systems directly from experimental time series.
+* Focuses on reconstructing phase portraits and attractors when only partial, noisy, and finite-precision data are available.
+* Builds on **Takens’ embedding theorem** and extends it using **singular system analysis** (SSA), originally developed in information theory by Bertero, Pike, and collaborators.
+
+---
+
+### **2. Background Concepts**
+
+#### Dynamical Systems
+
+* A system is represented as $\dot{y} = F(y)$, with states $y$ evolving in a phase space $S$.
+* Solutions form trajectories, and dissipative systems often evolve towards **attractors** (lower-dimensional manifolds).
+* Examples include:
+
+  * Limit cycles in chemical oscillations (Belousov–Zhabotinsky reaction),
+  * Fixed points in fluid systems (Taylor vortices).
+
+#### Qualitative Dynamics
+
+* Exact solutions are rarely feasible; instead, one studies the **geometry of orbits** (phase portraits).
+* Systems can be classified into **equivalence classes** (topological or differentiable) that share the same qualitative behavior.
+* Whitney’s and Takens’ embedding theorems provide mathematical foundations for reconstructing attractors from observed data.
+
+#### Method of Delays
+
+* A time series is transformed into vectors using lagged values (delay embedding).
+* Takens proved that under general conditions, this produces a topologically equivalent reconstruction of the attractor.
+* Problems:
+
+  * Choice of embedding dimension and lag time is ad hoc,
+  * Sensitive to noise,
+  * Artificial symmetries may appear.
+
+---
+
+### **3. Singular System Approach**
+
+#### Trajectory Matrix
+
+* From a time series, construct a trajectory matrix $X$ containing overlapping delay vectors.
+* Analyze $X$ using **singular value decomposition (SVD)**.
+* This provides:
+
+  * Singular vectors (basis functions),
+  * Singular values (measure of variance in each direction).
+
+#### Key Advantages
+
+* Removes arbitrariness of lag selection by using consecutive samples (no ad hoc delays).
+* Embedding space basis is determined statistically, not arbitrarily.
+* Natural way to separate **signal from noise**:
+
+  * Large singular values → deterministic dynamics,
+  * Small singular values → noise contributions.
+
+#### Statistical Interpretation
+
+* The method relates to the **Karhunen–Loève transform** (PCA for time series).
+* Provides optimal information compression:
+
+  * Minimal basis required to represent dynamics to a given accuracy.
+* The number of significant singular values gives an **upper bound on attractor dimension**.
+
+---
+
+### **4. Practical Issues**
+
+* **Sampling time ($\tau_s$)**: should be chosen so that the singular spectrum converges (avoid oversampling or undersampling).
+* **Window length ($\tau_w$)**: linked to the band-limiting frequency of the data spectrum.
+* The SSA approach yields consistent criteria for both, unlike the traditional delay method.
+
+---
+
+### **5. Application to the Lorenz Model**
+
+* Demonstrated with data from the chaotic Lorenz system ($\sigma=10, b=8/3, r=28$).
+* Steps:
+
+  * Time series from the $X(t)$ variable analyzed with trajectory matrix and SVD.
+  * Singular spectrum revealed that meaningful dynamics were confined to a low-dimensional subspace (≈ 3–4 dimensions).
+  * Reconstructed attractor preserved key qualitative features:
+
+    * Fixed points and their stability,
+    * Flow topology around them.
+  * Produced return maps nearly identical to those from the full Lorenz equations.
+* With added quantization noise (6-bit precision), the singular system method still produced coherent attractors and maps, outperforming the traditional delay method.
+
+---
+
+### **6. Key Contributions**
+
+* Provided a **robust statistical framework** for extracting attractors from noisy experimental data.
+* Eliminated subjective choices (lag time, embedding dimension).
+* Introduced **noise handling** via singular value spectrum partitioning.
+* Linked dynamical systems analysis with methods from **signal processing** and **information theory**.
+* Showed that qualitative dynamics can be recovered even with low-precision measurements.
+
+---
+
+### **7. Conclusion**
+
+* Dynamical systems theory requires geometric interpretation of experimental data.
+* The **singular system method** (SVD-based delay embedding):
+
+  * Extracts invariant qualitative features (phase portraits, return maps),
+  * Provides resilience to noise,
+  * Offers a systematic way to reconstruct dynamics from limited data.
+* The method paves the way for statistical tools that allow experimentalists to study nonlinear and chaotic systems rigorously.
+
+---
+
+# Multivariate Data Analysis – in Practice. Chapter 3: Principal Component Analysis (PCA) – Introduction
+
+**APA7 reference:** Esbensen, K. H., Guyot, D., Westad, F., & Houmoller, L. P. (2002). Multivariate Data Analysis -in Practice: An Introduction to Multivariate Data Analysis and Experimental Design. CAMO AS. https://books.google.no/books?id=Qsn6yjRXOaMC&lpg=PP1&dq=Qsn6yjRXOaMC
+
+**Filename:** 'Esbensen et al. - 2002 - Multivariate Data Analysis -in Practice  - chapter 3.pdf'
+
+### **1. Purpose and Philosophy**
+
+* PCA is introduced as the fundamental **“workhorse” of multivariate data analysis**.
+* Its aim: decompose a data matrix $X$ into a **structure part** (systematic variation) and a **noise part** (random variation).
+* This chapter sets the conceptual foundation for understanding multivariate thinking, necessary for later methods such as PLS.
+
+---
+
+### **2. Representing Data as a Matrix**
+
+* Data are arranged in an $n \times p$ matrix:
+
+  * **Objects (rows):** observations, samples, or experiments.
+  * **Variables (columns):** measurements describing each object.
+* PCA does not require a dependent $Y$-matrix, only $X$.
+* The guiding assumption: directions of **maximum variance** reveal **hidden phenomena** in the data.
+
+---
+
+### **3. Variable Space and Visualization**
+
+* Data can be seen geometrically in a **p-dimensional variable space**.
+* Each object corresponds to a point; the full dataset is a **swarm of points**.
+* Visualization in 1D, 2D, and 3D (scatter plots) helps reveal structure, but PCA generalizes this to higher dimensions where visualization is impossible.
+
+---
+
+### **4. Revealing Hidden Structure**
+
+* Example: plotting three variables (height, weight, swim ability) shows a clear trend.
+* This trend reflects **covariance structure**, the backbone of PCA.
+* Univariate and bivariate plots are limited because:
+
+  * Too many combinations exist ($p(p-1)/2$ scatter plots).
+  * Hidden multidimensional patterns cannot be captured.
+
+---
+
+### **5. Principal Components**
+
+* **PC1**: the first axis in the direction of **maximum variance**.
+
+  * Captures the strongest linear trend in the data.
+  * Can be defined both as:
+
+    * the direction maximizing variance,
+    * the least squares line minimizing squared projection distances (residuals).
+* **PC2, PC3, …**: orthogonal axes capturing successively smaller variances.
+* Collectively, PCs define a new **uncorrelated coordinate system**.
+
+---
+
+### **6. PCA Models: Scores and Loadings**
+
+* **Scores (T):** coordinates of objects in PC space (projection of objects onto PCs).
+* **Loadings (P):** coefficients defining how original variables contribute to each PC (bridge between variable space and PC space).
+* **Residuals (E):** distances between original data and their PC projections, reflecting information lost.
+* Maximum number of PCs = $\min(n-1, p)$, though usually far fewer are retained.
+
+---
+
+### **7. Objectives of PCA**
+
+* **Dimensionality reduction:** retain only the first few PCs that explain most structure.
+* **Noise filtering:** discard higher-order PCs dominated by random variation.
+* **Interpretation aid:** provide new coordinates where hidden trends and relationships are clearer.
+
+---
+
+### **8. Visualization Tools**
+
+#### Score Plots
+
+* Map of samples in PC space.
+* Show clustering, trends, time evolution, outliers.
+* Example: pea sensory data
+
+  * PC1 corresponds to harvest time (93% variance),
+  * PC2 separates pea types.
+* Rule of thumb:
+
+  * Use PC1 on x-axis as baseline,
+  * Interpret higher PCs depending on relevance.
+
+#### Loading Plots
+
+* Map of variables showing how they contribute to PCs.
+* Variables close together → positive correlation.
+* Opposite sides of origin → negative correlation.
+* Example: pea data
+
+  * “Sweet”, “Fruity”, “Pea flavor” cluster together,
+  * “Off flavor”, “Hardness”, “Mealiness” cluster oppositely.
+
+#### Combined Interpretation
+
+* **Scores answer “How”** objects are related,
+* **Loadings answer “Why”** through variable contributions.
+* In spectroscopy, 1D loading plots (loading spectra) are often used.
+
+---
+
+### **9. Case Studies and Examples**
+
+* **People dataset** (32 individuals, 12 variables: demographics, lifestyle, etc.):
+
+  * PCA separates gender (PC1) and region (PC2).
+  * PC3 captures age and income.
+  * PC4 uniquely describes IQ, independent of other variables.
+* **Geochemical prospecting:**
+
+  * PC3 (explaining only 8% of variance) revealed gold-related mineralization,
+  * while PC1 and PC2 (74% variance) reflected broad geological background.
+* Demonstrates that **important phenomena may appear in intermediate PCs**.
+
+---
+
+### **10. Formal PCA Model**
+
+* Mathematical decomposition:
+
+  $$
+  X = TP^T + E
+  $$
+* With centering (subtracting variable means).
+* **Structure part:** leading PCs with high variance.
+* **Noise part:** higher PCs with negligible variance.
+
+---
+
+### **11. Key Insights**
+
+* PCA is both a **projection method** and a **variance decomposition method**.
+* It is exploratory, data-driven, and unbiased.
+* Interpretation requires domain knowledge to distinguish numerical co-variation from causal relationships.
+* Score and loading plots are the central interpretative tools.
+
+---
+
+### **12. Conclusion**
+
+* PCA transforms high-dimensional raw data into interpretable structures.
+* It uncovers hidden patterns, reduces complexity, and separates structure from noise.
+* The chapter emphasizes learning to “think multivariate,” with PCA as the gateway method to all advanced techniques in multivariate analysis.
+
+---
+
+# Multivariate Data Analysis – in Practice. Chapter 4: Principal Component Analysis (PCA) – In Practice
+
+**APA7 reference:** Esbensen, K. H., Guyot, D., Westad, F., & Houmoller, L. P. (2002). Multivariate Data Analysis -in Practice: An Introduction to Multivariate Data Analysis and Experimental Design. CAMO AS. https://books.google.no/books?id=Qsn6yjRXOaMC&lpg=PP1&dq=Qsn6yjRXOaMC
+
+**Filename:** 'Esbensen et al. - 2002 - Multivariate Data Analysis -in Practice  - chapter 4.pdf'
+
+## **1. Purpose of the Chapter**
+
+* Builds on the theory from Chapter 3 by focusing on **practical aspects of PCA**.
+* Aims to guide the reader through **preprocessing, handling outliers, step-by-step modeling, interpretation, pitfalls, and case studies**.
+* Stress is placed on **problem-specific decision-making**—multivariate analysis cannot be applied blindly.
+
+---
+
+## **2. Preprocessing: Scaling and Weighting**
+
+* Preprocessing often determines whether PCA yields a useful model.
+* **Standardization**: divide each variable by its standard deviation → ensures equal variance across variables.
+
+  * Necessary when variables are measured in different units (e.g., kg vs. mg).
+  * Prevents variables with large ranges from dominating the analysis.
+* **Autoscaling**: combination of mean-centering and standardization (variance scaled to 1).
+* **Caution**:
+
+  * If variables already have comparable variances (e.g., spectroscopic data), autoscaling may overemphasize noise.
+  * Alternatives: selective scaling or modified formulas (e.g., $1/(h+\text{SDev})$).
+* **Variables with very small variance (<1)**: scaling amplifies their importance disproportionately—must be checked carefully.
+
+---
+
+## **3. Outliers**
+
+* Outliers can be **erroneous data** (to be removed) or **legitimate but extreme observations** (to be retained).
+* Detection methods:
+
+  * **Score plots**: outliers appear far from clusters.
+  * **Residual and influence plots**: identify objects with high leverage and high residual variance.
+* Decision to remove/keep requires **domain knowledge and analyst responsibility**.
+* Automated detection is desirable in process control but not always straightforward.
+
+---
+
+## **4. Preprocessing Choices Affect Results**
+
+* PCA results vary depending on scaling, transformations, or normalizations.
+* Examples (weighted vs. unweighted score plots) show that preprocessing can drastically alter grouping and interpretation.
+* No universal rule—analyst must balance statistical clarity and domain interpretability.
+
+---
+
+## **5. PCA Step by Step**
+
+### Step 1 – Problem Formulation
+
+* Define the purpose clearly (variables and objects must contain relevant information).
+* Extra variables are not harmful but missing key variables invalidates conclusions.
+
+### Step 2 – Plot Raw Data
+
+* Use matrix plots for initial overview; assess need for scaling/transformations.
+
+### Step 3 – First Runs
+
+* Perform exploratory PCA with mean-centering.
+* Compute “too many” PCs initially to ensure subtle structures are not missed.
+
+### Step 4 – Exploration
+
+* Inspect score plots for outliers, clusters, and trends.
+* Exclude outliers systematically (objects before variables).
+
+### Step 5 – Later Runs
+
+* Re-run PCA on refined dataset after cleaning.
+
+### Step 6 – Determine Optimum Number of PCs
+
+* Use explained/residual variance plots.
+* Combine with external knowledge.
+
+### Step 7 – Interpretation
+
+* Use score and loading plots together for interpretation.
+* Re-evaluate objectives if needed.
+
+### Step 8 – Inspect Error Matrix
+
+* Check residuals for unexpected structure → if problems appear, repeat process.
+
+---
+
+## **6. Interpretation of PCA**
+
+* PCA is a **projection method**: transforms high-dimensional data into fewer dimensions.
+* **Scores**: new coordinates for samples in PC space.
+* **Loadings**: directions of PCs, linking original variables to scores.
+* **Residuals**: information lost during projection (model error).
+* Key challenge: deciding **how many PCs** are meaningful.
+
+### Score Plots
+
+* Patterns: clusters, trends, outliers.
+* Objects close together are similar; far apart are dissimilar.
+* Outliers distort models—removal may reveal hidden groupings.
+* Preprocessing (e.g., scatter correction in spectroscopy) affects clarity of score plots.
+
+### Loading Plots
+
+* Variables with large loadings → important.
+* Direction and proximity show correlation:
+
+  * Same side of origin → positive correlation.
+  * Opposite sides → negative correlation.
+  * Orthogonal → independence.
+* Spectroscopy often uses 1D loading plots (loading spectra).
+
+---
+
+## **7. Pitfalls in PCA**
+
+Nine common mistakes:
+
+1. Dataset lacks required information.
+2. Too few PCs → lose information.
+3. Too many PCs → include noise, misinterpretation.
+4. Failure to remove erroneous outliers.
+5. Incorrect removal of legitimate outliers.
+6. Insufficient exploration of score plots.
+7. Misinterpretation of loadings with wrong PC number.
+8. Blind reliance on software diagnostics.
+9. Wrong preprocessing choice.
+
+**Key safeguard**: analyst experience, domain knowledge, and continuous checking of residuals.
+
+---
+
+## **8. Case Study: Troodos Geological Example**
+
+* Dataset: 143 rock samples from Cyprus, measured for 10 major oxides.
+* Goal: determine whether rocks form one group or multiple geochemical series.
+* PCA process:
+
+  * Initial model revealed four outliers (objects 65, 66, 129, 130).
+  * Influence plots confirmed atypical behavior of some samples.
+  * Removing outliers clarified two distinct rock groups, with MgO and CaO separating one group from the rest.
+* Lesson: **Outliers masked hidden structure**; correct preprocessing and interpretation revealed new geological insights.
+
+---
+
+## **9. Key Takeaways**
+
+* PCA in practice is not just computation—it requires **preprocessing decisions, careful outlier treatment, iterative modeling, and contextual interpretation**.
+* Correct scaling and preprocessing are problem-dependent.
+* Score and loading plots are complementary: **scores show how samples are related; loadings explain why via variables**.
+* Analyst judgment is central—software diagnostics are only aids.
+* Real-world application (Troodos case) illustrates how PCA can resolve scientific debates when used carefully.
+
+---
+
+# The Effect of Data Centering on PCA Models
+
+**APA7 reference:** Gallagher, N. B., O’Sullivan, D., & Palacios, M. (2020). The Effect of Data Centering on PCA Models [White Paper].
+
+**Filename:** 'Gallagher et al. - 2020 - The Effect of Data Centering on PCA Models.pdf'
+
+## **1. Purpose**
+
+* The paper addresses two frequent questions in **Principal Component Analysis (PCA)**:
+
+  1. If data are **not mean-centered**, is **PC1** (first principal component) the mean of the data?
+     → No. PC1 is not the mean, but it often points in the direction of the mean.
+  2. Why does PC1 capture **more variance** when data are not mean-centered?
+     → Because PC1 must account for both **variation about the mean** and the **sum-of-squares (SSQ) due to the mean itself**.
+* The analysis explains how centering (or not) impacts PCA models and interpretation.
+
+---
+
+## **2. Definitions**
+
+For a dataset $X$ with $M$ samples and $N$ variables:
+
+* **Total sum-of-squares**:
+
+  $$
+  s_{\text{tot}} = \sum_{m=1}^M \sum_{n=1}^N x_{mn}^2 = \text{tr}(X^T X)
+  $$
+* **Mean vector**:
+
+  $$
+  \bar{x} = \frac{1}{M} 1^T X
+  $$
+* **Sum-of-squares about the mean (variance part)**:
+
+  $$
+  s_{\text{var}} = \text{tr}((X - 1\bar{x}^T)^T (X - 1\bar{x}^T)) = s_{\text{tot}} - M\bar{x}^T\bar{x}
+  $$
+* **Sum-of-squares due to the mean**:
+
+  $$
+  s_{\text{mean}} = M\bar{x}^T\bar{x}
+  $$
+* Ratio of interest:
+
+  $$
+  f = \frac{s_{\text{mean}}}{s_{\text{tot}} - s_{\text{mean}}}
+  $$
+
+  which compares mean contribution to variance contribution.
+
+---
+
+## **3. Effect of Centering**
+
+* **Centered data**: PC eigenvalues reflect variance (SSQ about the mean).
+* **Non-centered data**: PC eigenvalues reflect **total SSQ relative to origin**, combining mean and variance contributions.
+* As the mean moves further from the origin:
+
+  * PC1 increasingly aligns with the mean vector.
+  * PC1 captures larger fractions of the total SSQ, not just variance.
+* Thus, uncentered PCA models may suggest that PC1 explains much more “variance” than centered models, but this includes mean offset.
+
+---
+
+## **4. Example Studies**
+
+* **Data Set 1** (non-centered):
+
+  * Mean = \[4, 2.3],
+  * $f = 11.2$,
+  * 91.8% of SSQ due to mean,
+  * PC1 points strongly toward the mean (98.5% of SSQ captured).
+* As datasets are progressively shifted toward the origin (Data Sets 2–6):
+
+  * Contribution of mean SSQ decreases.
+  * At **full mean-centering**:
+
+    * $s_{\text{mean}} = 0$,
+    * Only variance remains,
+    * PC1 orientation depends solely on variance structure.
+* **Angle analysis**:
+
+  * PC1 aligns with mean vector when $f > 2.1$.
+  * Below this threshold, PC1 is less tied to the mean direction.
+
+---
+
+## **5. Mathematical Insight**
+
+* PCA seeks directions $p$ that maximize SSQ captured:
+
+  $$
+  \max_p \; p^T X^T X p
+  $$
+* For uncentered data, this decomposes into:
+
+  $$
+  p^T X_c^T X_c p + M p^T \bar{x}\bar{x}^T p
+  $$
+
+  where $X_c$ is centered data.
+* Inequality shows:
+
+  $$
+  s_{p1} \geq s_{\text{mean}}
+  $$
+
+  → PC1 always captures at least the mean’s SSQ contribution.
+
+---
+
+## **6. Key Conclusions**
+
+* **Misconception corrected**: PC1 ≠ mean vector, but in uncentered data it **points toward the mean** when mean dominates total SSQ.
+* **Variance inflation**: PC1 appears to capture more variance without centering because it absorbs mean SSQ.
+* **Centering choice**: depends on analysis goals:
+
+  * Use **mean-centering** for typical multivariate analysis (focus on variance structure).
+  * Consider **non-centered PCA** if absolute magnitude (offset) is meaningful.
+* Threshold insight: when $f > 2.1$, PC1 direction effectively equals the mean’s direction.
+
+---
+
+## **7. Practical Relevance**
+
+* Important for applications in:
+
+  * **Chemometrics**,
+  * **Multivariate process control**,
+  * **Data interpretation where offsets matter**.
+* Software tools (e.g., Eigenvector’s **PLS\_Toolbox**) include demos to visualize these effects (ComparePC1toMean).
+
+---
+
+# Advanced Spectral Methods for Climatic Time Series
+
+**APA7 reference:** Ghil, M., Allen, M. R., Dettinger, M. D., Ide, K., Kondrashov, D., Mann, M. E., Robertson, A. W., Saunders, A., Tian, Y., Varadi, F., & Yiou, P. (2002). Advanced Spectral Methods for Climatic Time Series. Reviews of Geophysics, 40(1), 3-1-3–41. https://doi.org/10.1029/2000RG000092
+
+**Filename:** 'Ghil et al. - 2002 - Advanced Spectral Methods for Climatic Time Series.pdf'
+
+## **1. Purpose and Motivation**
+
+* The paper reviews **advanced spectral methods** for analyzing climatic time series, with emphasis on:
+
+  * extracting meaningful signals from noisy data,
+  * linking spectral analysis to **nonlinear dynamics**,
+  * developing improved tools for understanding and predicting climate variability.
+* Central example: **Southern Oscillation Index (SOI)**, a key indicator of El Niño–Southern Oscillation (ENSO).
+
+---
+
+## **2. Time Series Analysis and Nonlinear Dynamics**
+
+* **Two domains**:
+
+  * **Time domain** → autoregressive models, stochastic forcing.
+  * **Spectral domain** → periodicities, Fourier-based methods.
+* **Nonlinear revolution**: irregularity can arise from deterministic chaos (few degrees of freedom) rather than only random forcing.
+* **Method of delays** (Takens’ theorem): reconstruct attractors from univariate series.
+* Concept of **ghost limit cycles**: unstable but recurrent quasi-periodic orbits leaving spectral signatures (e.g., in intraseasonal oscillations).
+
+---
+
+## **3. Signal-to-Noise Enhancement**
+
+### **3.1 Singular Spectrum Analysis (SSA)**
+
+* Embeds a univariate series into an M-dimensional space via lagged vectors.
+* Produces **EOFs (Empirical Orthogonal Functions)** and **PCs (Principal Components)** from lag-covariance matrix.
+* Allows decomposition into:
+
+  * Trends,
+  * Oscillations,
+  * Noise.
+* Applied to SOI:
+
+  * Identified quasi-biennial (\~2 years) and quasi-quadrennial (\~4 years) oscillations.
+  * Partial reconstructions captured ENSO events (El Niños and La Niñas).
+
+### **3.2 Monte Carlo SSA (MC-SSA)**
+
+* Uses red-noise (AR(1)) null hypothesis.
+* Tests whether detected oscillations exceed stochastic variability.
+* Provides statistical rigor compared to heuristic SSA.
+
+### **3.3 Multiscale SSA and Wavelets**
+
+* Extends SSA across scales.
+* Wavelets allow time–frequency localization, revealing transient features and non-stationarity.
+
+---
+
+## **4. Spectral Analysis Methods**
+
+### **4.1 Classical Fourier Methods**
+
+* Periodogram, Blackman-Tukey correlogram.
+* Problems: spectral leakage, variance, and resolution limits.
+
+### **4.2 Maximum Entropy Method (MEM)**
+
+* Treats series as autoregressive process.
+* Provides sharp spectral peaks with short data sets.
+* Sensitive to model order → risk of spurious peaks.
+
+### **4.3 Multitaper Method (MTM)**
+
+* Uses multiple orthogonal tapers (windows).
+* Reduces leakage and variance simultaneously.
+* Allows F-tests for significance of oscillatory peaks.
+* Widely applied in geophysics and climate studies.
+
+---
+
+## **5. Multivariate Methods**
+
+### **5.1 Principal Oscillation Patterns (POPs)**
+
+* Linear stochastic modeling of multivariate data.
+* Identifies damped oscillatory modes (e.g., ENSO dynamics).
+
+### **5.2 Multichannel SSA (M-SSA)**
+
+* Extends SSA to multiple series.
+* Analogous to Extended EOFs (EEOFs).
+* Captures coherent spatio-temporal patterns (e.g., global SST oscillations).
+
+---
+
+## **6. Applications**
+
+* **SOI analysis**: SSA and MTM extracted ENSO cycles, validated against observed events.
+* **Global SST datasets**: M-SSA identified coupled ocean–atmosphere modes.
+* Broader applications include paleoclimate reconstructions, interdecadal oscillations, and intraseasonal variability.
+
+---
+
+## **7. Perspectives and Open Questions**
+
+### **Understanding**
+
+* Advanced methods help reveal skeleton attractors (robust quasi-periodic modes) underlying chaotic climate variability.
+* Provide bridges between **nonlinear dynamics** and **statistical analysis**.
+
+### **Prediction**
+
+* Enhanced signal detection improves forecasting of ENSO and related phenomena.
+* Multivariate methods show promise for coupled climate system prediction.
+
+### **Methodology**
+
+* Open issues:
+
+  * Choosing parameters (e.g., SSA window length, MEM order, taper number in MTM).
+  * Interpreting noisy, short, and non-stationary climatic records.
+  * Integrating nonlinear dynamics with statistical testing.
+
+---
+
+## **8. Appendix**
+
+* Connections between SSA, EOFs, and **Karhunen-Loève theory**.
+* Clarifies theoretical foundations of temporal and spatial decomposition.
+
+---
+
+## **9. Key Contributions**
+
+* Comprehensive review of **modern spectral methods** for climate time series.
+* Highlights strengths:
+
+  * SSA → flexible, data-adaptive decomposition.
+  * MTM → robust, low-variance spectral estimation.
+  * MC-SSA → rigorous statistical testing.
+* Shows how methods complement each other in studying ENSO and broader climate variability.
+
+---
+
+# Particularities and commonalities of singular spectrum analysis as a method of time series analysis and signal processing
+
+**APA7 reference:** Golyandina, N. (2020). Particularities and commonalities of singular spectrum analysis as a method of time series analysis and signal processing. WIREs Computational Statistics, 12(4), e1487. https://doi.org/10.1002/wics.1487
+
+**Filename:** 'Golyandina - 2020 - Particularities and commonalities of singular spectrum analysis as a method of time series analysis.pdf'
+
+## **1. Aim of the Paper**
+
+* Singular Spectrum Analysis (SSA) has evolved since the mid-20th century as a versatile method for **time series analysis**.
+* SSA is sometimes called **PCA for time series**, but its scope is broader:
+
+  * decomposition,
+  * filtering,
+  * frequency estimation,
+  * forecasting,
+  * missing data imputation.
+* The article compares perspectives from **different scientific communities** (time series analysis, signal processing, multivariate statistics) to highlight both **commonalities** and **specific viewpoints**.
+
+---
+
+## **2. General Review of SSA**
+
+### 2.1 Common Problems
+
+* Time series and images share tasks of decomposition into:
+
+  * **Trend**,
+  * **Periodic components**,
+  * **Noise**.
+* Solutions enable smoothing, filtering, forecasting, change-point detection, etc.
+
+### 2.2 SSA Algorithm
+
+* **Stage 1: Decomposition**
+
+  * Transform time series into a **trajectory (Hankel) matrix**.
+  * Apply **SVD** to extract elementary components (eigentriples).
+* **Stage 2: Reconstruction**
+
+  * Group components and perform **diagonal averaging** to reconstruct identifiable signals (trend, oscillations, etc.).
+* Key ideas:
+
+  * Create multiple overlapping subseries to capture structure.
+  * Use SVD to identify commonalities.
+
+### 2.3 Perspectives on SSA
+
+* **Karhunen–Loève Transform (KLT):** SSA parallels empirical KLT but adds reconstruction.
+* **Stationary processes:** Toeplitz SSA relates to spectral estimation, but may limit scope to stationary data.
+* **Dynamical systems:** SSA has roots in Takens’ embedding and singular system analysis.
+* **Structured low-rank approximation (SLRA):** SSA relates to methods for low-rank Hankel matrices (e.g., Cadzow iterations).
+
+### 2.4–2.6 Advanced Aspects
+
+* **Separability:** Ability to distinguish signal components depends on orthogonality and eigenvalue disjointness.
+* **Filtering:** SSA acts as an adaptive filter.
+* **Modelling:** Links to linear recurrence relations and signal parameterization.
+* **Choice of parameters:** Especially window length $L$, critical for decomposition accuracy.
+
+### 2.7–2.10 Extensions
+
+* **Multivariate SSA (MSSA)** for multiple time series.
+* **2D-SSA** for images.
+* **Shaped SSA** for irregular grids.
+* **Complex SSA** for frequency-domain analysis.
+* **Tensor SSA** and refined SVD modifications for improved separation and signal representation.
+
+---
+
+## **3. SSA and Different Problems**
+
+* **Linearity:** SSA is linear in data but nonlinear in its filters.
+* **Relation to AR processes:** Connections through covariance structures and subspace methods.
+* **Parameter estimation:** SSA supports frequency and damping estimation (e.g., via ESPRIT).
+* **Regression and SLRA:** SSA overlaps with least squares trend estimation and structured approximations.
+* **Filtering:** Adaptive, non-parametric filtering framework.
+* **Comparisons:** Links and contrasts with ICA, EMD, Fourier, and wavelet methods.
+* **Forecasting & gap filling:** Model-free forecasting via reconstructed components; robust missing data imputation.
+* **Monte Carlo SSA:** Provides statistical tests for signal significance against red-noise models.
+* **Outliers:** SSA can handle noise and outlier detection via component analysis.
+* **Machine learning:** SSA concepts intersect with ML approaches for feature extraction and dimensionality reduction.
+* **Automation:** Progress in automatic grouping and batch processing for large datasets.
+
+---
+
+## **4. Implementation**
+
+* Efficient implementations (e.g., **Rssa package**) provide scalable tools for 1D, 2D, and multidimensional data.
+* Examples illustrate practical SSA decomposition and reconstruction for real-world datasets.
+
+---
+
+## **5. Key Insights**
+
+* SSA is a **bridge method**, integrating ideas from:
+
+  * PCA (multivariate analysis),
+  * KLT (time series analysis),
+  * Low-rank approximation (signal processing).
+* Core strength: **model-free decomposition** adaptable to a wide range of applications.
+* SSA is flexible, but requires:
+
+  * Careful parameter choices,
+  * Consideration of separability,
+  * Knowledge of complementary methods.
+* Expected to become a **standard tool** in time series and signal processing due to its universality.
+
+---
+
+## **6. Conclusion**
+
+* SSA unifies multiple traditions in time series analysis, offering both theoretical richness and practical power.
+* It excels in decomposition, filtering, and reconstruction tasks across domains.
+* Future developments involve:
+
+  * Stronger theoretical links,
+  * Automated implementations,
+  * Integration with machine learning,
+  * Wider adoption in multidimensional data contexts.
+
+---
+
+# Multivariate and 2D Extensions of Singular Spectrum Analysis with the Rssa Package
+
+**APA7 reference:** Golyandina, N., Korobeynikov, A., Shlemov, A., & Usevich, K. (2015). Multivariate and 2D Extensions of Singular Spectrum Analysis with the Rssa Package. Journal of Statistical Software, 67, 1–78. https://doi.org/10.18637/jss.v067.i02
+
+**Filename:** 'Golyandina et al. - 2015 - Multivariate and 2D Extensions of Singular Spectrum Analysis with the Rssa Package.pdf'
+
+## **1. Purpose of the Paper**
+
+* Singular Spectrum Analysis (SSA) is a **nonparametric method** for time series analysis, useful for:
+
+  * decomposition,
+  * denoising,
+  * trend and oscillation extraction,
+  * forecasting,
+  * missing data imputation,
+  * spectral analysis.
+* The paper presents **multivariate (MSSA)** and **two-dimensional (2D-SSA)** extensions, implemented in the **Rssa R package**.
+* Introduces **Shaped 2D-SSA (ShSSA)**, which can handle images of arbitrary, non-rectangular shapes.
+* Focuses on **efficient implementations** using **FFT-based algorithms** for Hankel and Hankel-block-Hankel matrix operations.
+
+---
+
+## **2. General SSA Framework**
+
+SSA and its extensions follow a **four-step scheme**:
+
+1. **Embedding**: Construct a trajectory matrix by applying a sliding window (intervals for 1D series, stacked Hankel for multivariate series, rectangular or shaped blocks for images).
+2. **Decomposition**: Perform **SVD** of the trajectory matrix into elementary rank-1 components (eigentriples).
+3. **Grouping**: Combine selected eigentriples into interpretable sets (trend, seasonality, noise).
+4. **Reconstruction**: Map grouped components back to the original data domain (time series or image), using diagonal averaging or its generalizations.
+
+**Key concept**: **Separability** – the ability to distinguish signal components (trend, oscillations) from noise depends on orthogonality of subspaces in trajectory matrices.
+
+---
+
+## **3. Multivariate SSA (MSSA)**
+
+* Generalizes SSA to multiple time series (systems of univariate series).
+* Uses **stacked Hankel trajectory matrices**.
+* Eigenvectors represent **common structures** across series; factor vectors show how each structure manifests in each series.
+* MSSA advantages:
+
+  * Captures **shared oscillatory modes** across series (e.g., climatology, economics).
+  * Improves signal–noise separation when series are matched (same underlying structure).
+  * Provides **forecasting methods** (recurrent and vector approaches), extended for multivariate cases.
+* **CSSA** (Complex SSA) is treated as a special case of MSSA for two series encoded as real and imaginary parts.
+
+---
+
+## **4. 2D-SSA**
+
+* Extends SSA to 2D arrays (images).
+* Embedding uses **Hankel-block-Hankel matrices**.
+* Capable of decomposing images into:
+
+  * **Smooth trends**,
+  * **Periodic textures or patterns**,
+  * **Noise**.
+* Can be combined with **2D-ESPRIT** for parameter estimation (e.g., spatial frequencies).
+* Applications: digital image processing, spatio-temporal data analysis.
+
+---
+
+## **5. Shaped 2D-SSA (ShSSA)**
+
+* New extension introduced in this paper.
+* Handles **non-rectangular domains**: circular images, images with gaps, or irregularly shaped regions.
+* Uses **quasi-Hankel trajectory matrices** adapted to the shape.
+* ShSSA shown to be a **unifying framework**:
+
+  * MSSA, CSSA, 2D-SSA, and other variants can be seen as special cases of ShSSA.
+* Expands applicability of SSA beyond strictly rectangular or evenly spaced data.
+
+---
+
+## **6. Efficient Implementation in Rssa**
+
+* Challenges: trajectory matrices are very large, especially in MSSA and 2D-SSA.
+* Solutions:
+
+  * Fast SVD methods (Lanczos-based truncated SVD).
+  * FFT-based multiplication and hankelization reduce complexity from **O(N³)** to **O(kN log N + k²N)**.
+  * Efficient diagonal averaging (reconstruction) implemented via FFT-based convolutions.
+  * On-demand computation and memoization to minimize redundancy.
+* Implementation relies on **FFTW library** for high-performance FFT.
+
+---
+
+## **7. Practical Use in Rssa**
+
+* Functions:
+
+  * `ssa()` for decomposition,
+  * `reconstruct()` for reconstruction,
+  * `predict()` / `vforecast()` for forecasting,
+  * `plot()` for visualization,
+  * `wcor()` for weighted correlation diagnostics.
+* Input formats: vectors, lists, matrices, `ts`, `mts`, `zoo` objects, and matrices for images.
+* Output preserves input attributes (time indices, shapes).
+* Plotting relies on **lattice** graphics, supporting advanced manipulation and customization.
+* Examples:
+
+  * Time series decomposition (Australian wine sales dataset),
+  * Eigenvector inspection for identifying trends and seasonalities,
+  * Forecasting with recurrent and vector methods,
+  * Image decomposition into structural components.
+
+---
+
+## **8. Theoretical Insights**
+
+* **Finite rank objects**: SSA excels at decomposing signals that can be represented as sums of exponentials, polynomials, and sinusoids (rank-deficient Hankel matrices).
+* **Forecasting theory**: based on linear recurrent relations (LRRs) underlying finite-rank signals.
+* **Separability conditions**: critical for successful decomposition; easier in SSA than in MSSA/2D-SSA due to more restrictive conditions in higher dimensions.
+* **Rank relationships**: MSSA rank ≤ sum of SSA ranks; shared structures reduce effective rank, improving decomposition.
+
+---
+
+## **9. Key Contributions of the Paper**
+
+1. Comprehensive description of **MSSA** and **2D-SSA** algorithms.
+2. Introduction of **Shaped 2D-SSA** as a flexible, unifying framework.
+3. Development of **fast FFT-based algorithms** for large-scale SSA computations.
+4. Detailed Rssa implementation with examples, code fragments, and plotting strategies.
+5. Demonstration of **forecasting, decomposition, and parameter estimation** capabilities for time series and images.
+
+---
+
+## **10. Conclusion**
+
+* SSA and its extensions (MSSA, 2D-SSA, ShSSA) provide a **powerful, model-free framework** for analyzing univariate, multivariate, and multidimensional data.
+* The Rssa package delivers efficient, scalable implementations, making advanced SSA methods accessible to practitioners.
+* ShSSA’s generality unifies SSA variants, paving the way for further extensions.
+* The approach is widely applicable in **time series analysis, signal processing, climatology, and image processing**.
+
+---
+
+# Principal Component Analysis: A Review and Recent Developments
+
+**APA7 reference:** Jolliffe, I. T., & Cadima, J. (2016). Principal component analysis: A review and recent developments. Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences, 374(2065), 20150202. https://doi.org/10.1098/rsta.2015.0202
+
+**Filename:** 'Jolliffe & Cadima - 2016 - Principal component analysis a review and recent .pdf'
+
+## **1. Introduction**
+
+* PCA is one of the oldest and most widely used statistical methods for **dimension reduction**.
+* Goal: transform correlated variables into a smaller set of **uncorrelated principal components (PCs)** that retain most of the dataset’s variability.
+* PCA is an **adaptive exploratory tool**:
+
+  * PCs are data-driven (not predefined functions).
+  * Numerous variants exist, tailored to different data types.
+
+---
+
+## **2. The Basic Method**
+
+### 2.1 Mathematical Formulation
+
+* Data matrix $X$ (n observations × p variables).
+* PCA finds linear combinations $Xa$ that maximize variance.
+* Equivalent to solving the **eigenvalue problem**:
+
+  $$
+  Sa = \lambda a
+  $$
+
+  where $S$ is the covariance (or correlation) matrix.
+* Eigenvectors = **PC loadings**, eigenvalues = **variance explained**.
+* Scores = projections of data onto eigenvectors.
+
+### 2.2 Geometric and SVD Interpretation
+
+* PCA = optimal low-rank approximation of the centered data matrix (minimizing squared reconstruction error).
+* Equivalent to Singular Value Decomposition (SVD).
+
+### 2.3 Variance Explained
+
+* Each PC explains a proportion of total variance:
+
+  $$
+  \pi_j = \frac{\lambda_j}{\text{tr}(S)}
+  $$
+* Usually, first few PCs account for most of the structure; later ones may capture noise.
+
+---
+
+## **3. Illustrative Examples**
+
+* **Fossil teeth dataset**:
+
+  * Nine measurements on 88 teeth.
+  * PC1 (size) and PC2 (shape) explain >95% variance, separating species.
+* **Atmospheric science**:
+
+  * Empirical Orthogonal Functions (EOFs) = PCA in climate science.
+  * Example: sea-level pressure data showing Arctic Oscillation patterns.
+
+---
+
+## **4. Key Issues in PCA**
+
+### 4.1 Covariance vs. Correlation PCA
+
+* **Covariance matrix PCA**: sensitive to variable scales.
+* **Correlation matrix PCA**: uses standardized variables; appropriate for mixed scales.
+* Choice affects variance explained and PC interpretation.
+
+### 4.2 Biplots
+
+* Joint representation of variables (as vectors) and observations (as points).
+* Useful for visualizing correlations and relationships.
+
+### 4.3 Centering
+
+* Standard PCA uses column-centering.
+* Variants:
+
+  * **Uncentered PCA**: based on raw second moments.
+  * **Row or double-centering**: used in special applications.
+
+### 4.4 Small n, Large p
+
+* When observations < variables (common in genomics).
+* PCA still valid; number of non-zero eigenvalues limited by sample size.
+
+---
+
+## **5. Adaptations and Recent Developments**
+
+### 5.1 Functional PCA
+
+* For functional data (e.g., spectra, curves).
+* Extends PCA to continuous functions, using basis expansions (splines, Fourier).
+* Applications: spectroscopy, growth curves, time series.
+
+### 5.2 Simplified PCs
+
+* Goal: make PCs more interpretable.
+* **Rotations** (e.g., varimax) redistribute variance across components.
+* **Sparse PCA**: forces some loadings to zero (e.g., SCoTLASS, elastic net).
+
+### 5.3 Robust PCA (RPCA)
+
+* Standard PCA is sensitive to outliers.
+* RPCA methods:
+
+  * Based on robust covariance estimators.
+  * Recent trend: **matrix decomposition into low-rank + sparse parts** (Principal Component Pursuit).
+  * Applications: image processing, video surveillance, bioinformatics.
+
+### 5.4 Symbolic Data PCA
+
+* For complex data (intervals, histograms).
+* PCs represent ranges or distributions instead of single values.
+* Requires new definitions of distances and averages.
+
+---
+
+## **6. Applications Across Disciplines**
+
+* PCA has become ubiquitous:
+
+  * Statistics (dimension reduction, visualization),
+  * Atmospheric science (EOF analysis),
+  * Palaeontology (fossil classification),
+  * Genomics and bioinformatics,
+  * Image and video analysis,
+  * Web and big data analytics.
+
+---
+
+## **7. Conclusion**
+
+* PCA is a **powerful, flexible, and adaptive tool** for high-dimensional data exploration.
+* Despite its age, PCA remains central due to:
+
+  * Strong theoretical foundations,
+  * Computational efficiency,
+  * Broad applicability.
+* Ongoing research develops variants for:
+
+  * Different data structures (functional, symbolic),
+  * More robust analysis (RPCA),
+  * Enhanced interpretability (sparse PCA).
+* PCA continues to evolve alongside modern data challenges.
+
+---
+
+# Kernel PCA and De-Noising in Feature Spaces
+
+**APA7 reference:** Mika, S., Schölkopf, B., Smola, A., Müller, K.-R., Scholz, M., & Rätsch, G. (1998). Kernel PCA and De-Noising in Feature Spaces. Advances in Neural Information Processing Systems, 11. https://proceedings.neurips.cc/paper_files/paper/1998/hash/226d1f15ecd35f784d2a20c3ecf56d7f-Abstract.html
+
+**Filename:** 'Mika et al. - 1998 - Kernel PCA and De-Noising in Feature Spaces.pdf'
+
+## **1. Aim of the Paper**
+
+* Extends **Principal Component Analysis (PCA)** into **nonlinear feature spaces** via the **kernel trick**.
+* Focuses on:
+
+  1. How to perform **nonlinear data reconstruction** and **de-noising** using Kernel PCA (KPCA).
+  2. How to find **pre-images** of feature space projections (i.e., mapping back from feature space to input space).
+* Demonstrates applications on synthetic (toy) datasets and real-world data (handwritten digits).
+
+---
+
+## **2. PCA and Kernel PCA**
+
+### Linear PCA
+
+* Finds orthogonal directions maximizing variance.
+* Used for:
+
+  * **Compression** (retain top PCs),
+  * **De-noising** (discard low-variance directions).
+* Limitation: cannot capture **nonlinear structures**.
+
+### Kernel PCA
+
+* Uses a nonlinear mapping $\Phi(x)$ into a **high-dimensional (possibly infinite-dimensional)** feature space $F$.
+* Performs **linear PCA in $F$**, yielding **nonlinear PCs** in input space.
+* Implemented using **Mercer kernels**:
+
+  * Gaussian kernel: $k(x,y) = \exp(-\|x-y\|^2 / c)$,
+  * Polynomial kernel: $k(x,y) = (x \cdot y)^d$.
+* PCA results are expressed in terms of kernel functions without explicitly computing $\Phi$.
+
+---
+
+## **3. Reconstruction and Pre-Images**
+
+* PCA in feature space allows reconstruction by projecting onto leading PCs:
+
+  $$
+  P_n \Phi(x) = \sum_{k=1}^n \beta_k v_k
+  $$
+* Problem: $\Phi^{-1}(P_n \Phi(x))$ may **not exist** or be **non-unique**.
+* Solution: find **approximate pre-image** $z$ minimizing:
+
+  $$
+  \| \Phi(z) - P_n \Phi(x) \|^2
+  $$
+* For **Gaussian kernels**, this leads to an iterative fixed-point scheme:
+
+  $$
+  z_{t+1} = \frac{\sum_i \gamma_i \exp(-\|z_t - x_i\|^2 / c) x_i}{\sum_i \gamma_i \exp(-\|z_t - x_i\|^2 / c)}
+  $$
+* Interpretation: resembles finding the **center of a Gaussian cluster**, weighted by kernel similarities.
+
+---
+
+## **4. Experiments**
+
+### 4.1 Toy Data
+
+* Mixtures of Gaussians in 10D.
+* KPCA significantly outperformed linear PCA in de-noising, especially when clusters were well-separated and variance small.
+* Demonstrated ability to recover **nonlinear manifolds**:
+
+  * Example: half-circle and square datasets.
+  * KPCA captured structure better than linear PCA, principal curves, or nonlinear autoencoders.
+
+### 4.2 Handwritten Digits (USPS Database)
+
+* 256-dimensional pixel data.
+* KPCA and linear PCA compared for:
+
+  * **Reconstruction**: linear PCA better for exact reconstruction (with many components).
+  * **De-noising**: KPCA performed better (factor of 1.6 for Gaussian noise, 1.2 for speckle noise).
+* KPCA reconstructions looked more like **prototypical digits**, whereas linear PCA reproduced **fine detail and noise**.
+* Visualization of KPCA eigenvectors showed richer structure, though harder to interpret than linear PCs.
+
+---
+
+## **5. Key Findings**
+
+* **Reconstruction**:
+
+  * Linear PCA more precise when many components used.
+  * KPCA competitive, but advantage grows when data structure is nonlinear.
+* **De-noising**:
+
+  * KPCA superior, since nonlinear features allow discarding noise while preserving structure.
+* **Pre-images**:
+
+  * Approximations via fixed-point iteration worked well in practice.
+  * Pre-images often expressed as combinations of training points.
+* **Interpretation**:
+
+  * KPCA provides more features (up to number of training samples), unlike linear PCA (limited to input dimensionality).
+  * This allows KPCA to capture **nonlinear dynamics** missed by linear PCA.
+
+---
+
+## **6. Limitations and Open Questions**
+
+* Computationally more expensive (requires kernel matrix of size $n \times n$).
+* Pre-image problem not always solvable exactly.
+* Open questions:
+
+  * Performance of kernels other than Gaussian.
+  * More efficient pre-image algorithms.
+  * Comparisons with other nonlinear de-noising methods (e.g., wavelets, matching pursuit).
+
+---
+
+## **7. Contributions**
+
+1. Proposed method for **reconstruction and de-noising** using KPCA.
+2. Developed practical algorithm for finding **approximate pre-images**.
+3. Demonstrated **KPCA’s superiority for nonlinear de-noising** on both toy and real-world data.
+4. Provided theoretical and empirical links between **kernel methods**, **feature spaces**, and **clustering interpretations**.
+
+---
+
+# A Tutorial on Principal Component Analysis
+
+**APA7 reference:** Shlens, J. (2014). A Tutorial on Principal Component Analysis (No. arXiv:1404.1100). arXiv. https://doi.org/10.48550/arXiv.1404.1100
+
+**Filename:** 'Shlens - 2014 - A Tutorial on Principal Component Analysis.pdf'
+
+## **1. Purpose**
+
+* PCA is widely used but often treated as a “black box.”
+* This tutorial explains PCA **intuitively** and **mathematically**:
+
+  * What PCA does,
+  * Why it works,
+  * How to implement it in practice.
+* Target audience: readers with basic linear algebra knowledge.
+
+---
+
+## **2. Motivation: A Toy Example**
+
+* Example: measuring a ball oscillating on a spring.
+* Instead of directly measuring along the motion axis, three cameras at arbitrary angles capture projections.
+* The challenge: extract the underlying **one-dimensional dynamic (x-axis motion)** from **noisy, redundant, higher-dimensional data**.
+* PCA provides the systematic solution: find the basis capturing the true dynamics.
+
+---
+
+## **3. Framework: Change of Basis**
+
+* **Data representation**: each sample is a vector in an $m$-dimensional space.
+* PCA asks: *Is there a new basis, as a linear combination of the old one, that better expresses the data?*
+* PCA assumes:
+
+  1. **Linearity** → new basis is a linear transformation of the old basis.
+  2. **Orthonormality** → basis vectors are orthogonal and of unit length.
+* The problem reduces to finding the “best” basis.
+
+---
+
+## **4. Variance and the Goal**
+
+### 4.1 Noise and Rotation
+
+* Measurement noise obscures dynamics.
+* Assumption: directions with **largest variance** contain meaningful signal (high signal-to-noise ratio).
+* Thus, PCA finds directions maximizing variance.
+
+### 4.2 Redundancy
+
+* Multiple variables may record redundant information (correlated signals).
+* PCA reduces redundancy by creating **uncorrelated components**.
+
+### 4.3 Covariance Matrix
+
+* Captures relationships among variables:
+
+  * Diagonal entries: variances,
+  * Off-diagonal: covariances.
+* Large covariance = redundancy.
+* Goal: find a basis that diagonalizes the covariance matrix → uncorrelated coordinates.
+
+### 4.4 Diagonalization
+
+* PCA sequentially finds orthogonal directions (principal components, PCs) that maximize variance:
+
+  1. PC1: direction of maximum variance,
+  2. PC2: next maximum, orthogonal to PC1,
+  3. Continue until all dimensions covered.
+* Eigenvalues = variances explained; eigenvectors = directions.
+
+### 4.5 Summary of Assumptions
+
+1. Linearity,
+2. Large variance = important structure,
+3. Components are orthogonal.
+
+---
+
+## **5. Solving PCA**
+
+### 5.1 Eigenvector Decomposition
+
+* Covariance matrix:
+
+  $$
+  C_X = \frac{1}{n}XX^T
+  $$
+* PCA = eigen-decomposition of $C_X$.
+* PCs are eigenvectors; eigenvalues = variances along PCs.
+* Practical steps:
+
+  1. Subtract mean from data,
+  2. Compute covariance matrix,
+  3. Find eigenvectors/eigenvalues.
+
+### 5.2 Singular Value Decomposition (SVD)
+
+* PCA is closely related to SVD:
+
+  $$
+  X = U \Sigma V^T
+  $$
+* $V$: principal components,
+* $\Sigma$: singular values (√ of variances),
+* $U$: projections in sample space.
+* SVD is more general and computationally efficient.
+
+---
+
+## **6. Discussion**
+
+### Benefits
+
+* PCA is **non-parametric**: no assumptions beyond linearity and variance maximization.
+* Provides ordered PCs ranked by variance.
+* Enables **dimensionality reduction**: retain only first few PCs that capture most variance.
+
+### Limitations
+
+* PCA decorrelates data (removes 2nd-order dependencies) but fails with:
+
+  * **Nonlinear structure** (e.g., ferris wheel motion described by angle θ),
+  * **Non-Gaussian distributions**,
+  * **Non-orthogonal dynamics**.
+  * Assumption that variance = structure is sometimes invalid.
+  * Alternatives:
+    * **Kernel PCA** (handles nonlinearities),
+    * **Independent Component Analysis (ICA)** (removes higher-order dependencies).
+
+---
+
+## **7. Practical Implementation**
+
+* Shlens provides **Matlab code** for PCA:
+
+  * Via covariance matrix (eigen-decomposition),
+  * Via SVD.
+  * Steps:
+    1. Organize data as matrix $m \times n$,
+    2. Subtract mean of each variable,
+    3. Compute PCs via eigen-decomposition or SVD,
+    4. Project data into reduced PC space.
+
+---
+
+## **8. Conclusion**
+
+* PCA is a fundamental tool for uncovering structure in complex datasets.
+* It works by:
+
+  * Finding orthogonal directions of maximum variance,
+  * Reducing dimensionality,
+  * Removing redundancy.
+* Despite limitations, PCA remains central due to simplicity, efficiency, and broad applicability.
+* Understanding PCA lays the foundation for advanced techniques in machine learning and signal processing.
+
+---
+
+# Practical Approaches to Principal Component Analysis in the Presence of Missing Values
+
+**APA7 reference:**Ilin, A., & Raiko, T. (2010). Practical Approaches to Principal Component Analysis in the Presence of Missing Values. Journal of Machine Learning Research, 11(66), 1957–2000.
+
+**Filename:** 'Ilin og Raiko - 2010 - Practical Approaches to Principal Component Analysis in the Presence of Missing Values.pdf'
+
+## **1. Purpose and Motivation**
+
+* Standard PCA assumes a **fully observed data matrix**, but many real-world datasets (e.g., collaborative filtering, climate records, gene expression) contain **missing values**.
+* Handling missing data makes PCA resemble **nonlinear models**: it introduces **local minima, overfitting, and high computational cost**.
+* Goal: Review existing methods, develop new algorithms, and provide a **probabilistic foundation** for PCA with missing values, including Bayesian extensions.
+
+---
+
+## **2. Classical PCA Formulation**
+
+* Data model:
+
+  $$
+  y_j \approx Wx_j + m
+  $$
+
+  with $W$ (loading matrix), $x_j$ (PCs), and $m$ (bias).
+* Classical PCA minimizes reconstruction error
+
+  $$
+  C = \|Y - WX - M\|_F^2
+  $$
+* With **missing data**, the minimization applies only to **observed entries**.
+
+---
+
+## **3. Challenges with Missing Data**
+
+1. **No closed-form solution** (covariance estimation difficult).
+2. **Multiple local minima** in optimization.
+3. **Bias term $m$** not simply row-wise mean.
+4. **Overfitting** risk increases with sparsity.
+5. **High computational costs** for large-scale problems.
+6. **Defining PCA basis** becomes ambiguous.
+7. **Rank selection** harder than in classical PCA.
+
+---
+
+## **4. Classical Algorithmic Approaches**
+
+### 4.1 Alternating $W$–$X$ Algorithm
+
+* Updates $W$ and $X$ iteratively via least squares.
+* Adaptable to missing data by conditioning updates on observed entries.
+* Vulnerable to ill-posed updates if observations < number of PCs.
+
+### 4.2 Gradient Descent (Oja’s rule extension)
+
+* Stochastic gradient updates for $W$ and $X$.
+* More scalable than alternating scheme but still prone to overfitting with sparse data.
+
+### 4.3 Imputation Algorithm (EM-like)
+
+* Iteratively imputes missing values → apply PCA → update reconstruction.
+* Equivalent to **Expectation–Maximization** for a simple probabilistic model.
+* Has **implicit regularization** (early stopping, conservative initialization).
+* Expensive for large datasets.
+
+---
+
+## **5. Probabilistic Models**
+
+### 5.1 Probabilistic PCA (PPCA)
+
+* Generative model:
+
+  $$
+  y_j = Wx_j + m + \epsilon_j, \quad x_j \sim \mathcal{N}(0,I), \quad \epsilon_j \sim \mathcal{N}(0, v_y I)
+  $$
+* Estimation via EM algorithm.
+* Naturally handles missing values.
+* Provides some **regularization** (noise term stabilizes ill-conditioned problems).
+
+### 5.2 Overfitting in PPCA
+
+* Still possible when too many components are chosen.
+* Can create artificial correlations with sparse data.
+
+### 5.3 Variational Bayesian PCA (VBPCA)
+
+* Adds Gaussian priors on $W$ and $m$, with hyperparameters $v_{w,k}, v_m$.
+* Enables **automatic relevance determination (ARD)** → irrelevant components pruned.
+* Provides **posterior uncertainties**, reducing overfitting.
+* Computationally more expensive but more robust.
+
+---
+
+## **6. PCA Basis for Incomplete Data**
+
+* Defines PCA basis via:
+
+  1. PCs uncorrelated, unit variance, zero mean,
+  2. Loadings orthogonal, ordered by eigenvalue norms.
+* Authors propose transformations to bring LS, PPCA, and VBPCA solutions into this standardized basis.
+
+---
+
+## **7. Reconstruction and Model Rank Selection**
+
+* Missing entries reconstructed via:
+
+  $$
+  \hat{y}_{ij} = m_i + w_i^T x_j
+  $$
+
+  with uncertainty estimates from probabilistic models.
+* Rank selection approaches:
+
+  * **Cross-validation**,
+  * **Bayesian evidence**,
+  * VBPCA’s ARD capability.
+
+---
+
+## **8. Large-Scale Problems**
+
+* Classical algorithms scale poorly for **high-dimensional sparse matrices**.
+* Authors propose:
+
+  * **Gradient-based optimization** with diagonal Hessian approximations (fast, scalable).
+  * **Online learning** (process one sample or mini-batch at a time).
+  * **Factorial variational approximations** (reduce covariance complexity).
+  * **MAP-PCA**: Maximum a posteriori estimation ignoring posterior uncertainty for speed.
+
+---
+
+## **9. Experimental Results**
+
+### Artificial Data
+
+* Compared LS, PPCA, VBPCA, MAP-PCA, and variants on simulated Gaussian, nonlinear, and non-Gaussian datasets.
+* Key findings:
+
+  * LS methods easily overfit sparse data.
+  * PPCA improves stability but may still fail.
+  * VBPCA most reliable, especially in sparse settings.
+  * Regularization critical for good reconstructions.
+
+### Netflix Problem
+
+* Applied methods to Netflix collaborative filtering dataset (480,000 users × 18,000 movies, highly sparse).
+* Demonstrated scalability of **gradient-based VBPCA** with factorial approximations.
+* Showed good predictive performance and robustness.
+
+---
+
+## **10. Key Contributions**
+
+1. Comprehensive review of PCA with missing data.
+2. Extension of PPCA and VBPCA with explicit formulas for incomplete datasets.
+3. Introduced **fast gradient-based algorithms** suitable for sparse, large-scale problems.
+4. Provided guidance on **regularization, rank selection, and basis transformations**.
+5. Demonstrated practical impact on **collaborative filtering** and synthetic experiments.
+
+---
+
+## **11. Conclusions**
+
+* PCA with missing values shares complexities with nonlinear models.
+* Probabilistic formulations (PPCA, VBPCA) provide principled handling and regularization.
+* For large, sparse datasets:
+
+  * Gradient-based methods + variational approximations are essential.
+  * Bayesian approaches outperform classical ones in avoiding overfitting.
+* The authors deliver both **theoretical foundations** and **scalable practical algorithms**, bridging classical PCA and modern machine learning applications.
+
+---
+
+# Principal Component Analysis (Wold)
+
+**APA7 reference:** Wold, S., Esbensen, K., & Geladi, P. (1987). Principal component analysis. Chemometrics and Intelligent Laboratory Systems, 2(1), 37–52. https://doi.org/10.1016/0169-7439(87)80084-9
+
+**Filename:** 'Wold et al. - 1987 - Principal component analysis.pdf'
+
+## **1. Purpose and Significance**
+
+* Presents PCA as a **practical chemometric tool** for exploring and modeling multivariate data.
+* Provides:
+
+  * Historical background,
+  * Conceptual and mathematical foundations,
+  * Practical guidelines for preprocessing, outlier detection, and interpretation,
+  * Applications in chemistry, geology, and other sciences.
+
+---
+
+## **2. Historical Context**
+
+* PCA first formulated by **Pearson (1901)** as finding “lines and planes of closest fit.”
+* Extended by **Hotelling (1933)**, foundational for modern PCA.
+* Related developments:
+
+  * **Factor analysis** (Thurstone, 1930s),
+  * **NIPALS algorithm** (outlined by Fisher & MacKenzie, later rediscovered by Wold in 1966),
+  * Equivalent formulations: **SVD**, **Karhunen–Loève expansion**, **Hotelling transformation**.
+* By the 1980s, PCA had become central to chemometrics and broadly used in multiple sciences.
+
+---
+
+## **3. Problem Definition**
+
+* Start with a data matrix $X$ of size $N \times K$:
+
+  * **Rows = objects (samples)**,
+  * **Columns = variables (measurements)**.
+* PCA goals include:
+
+  * Simplification and dimensionality reduction,
+  * Modeling of systematic variation,
+  * Outlier detection,
+  * Variable selection,
+  * Classification and prediction,
+  * Mixture unmixing (curve resolution).
+
+---
+
+## **4. Illustrative Example**
+
+* Chemical data: chromatographic peaks from fresh vs. stored swedes.
+* PCA revealed:
+
+  * Clear class separation,
+  * Detection of an outlier sample.
+* Demonstrates PCA’s exploratory power in real data analysis.
+
+---
+
+## **5. Geometric Interpretation**
+
+* $X$ can be seen as points in a $K$-dimensional measurement space (M-space).
+* PCA projects this swarm onto a lower-dimensional hyperplane that best represents variance:
+
+  * **1 component → line,**
+  * **2 components → plane,**
+  * **A components → A-dimensional hyperplane**.
+* PCA = least-squares fitting of subspaces.
+
+---
+
+## **6. Mathematical Formulation**
+
+* PCA model:
+
+  $$
+  X = \mathbf{1}\bar{x}^T + TP^T + E
+  $$
+
+  * $T$: score matrix (object projections),
+  * $P$: loading matrix (variable weights),
+  * $E$: residuals.
+* **Eigen-decomposition**: loadings = eigenvectors of $X^TX$, scores = projections.
+* Equivalent to **SVD** decomposition.
+* Scores and loadings are ordered by descending eigenvalues (variance explained).
+
+---
+
+## **7. Residuals and Statistics**
+
+* Residuals $E$ contain information not explained by the PC model.
+* Useful statistics:
+
+  * **Explained variance** per component,
+  * **Modeling power** of variables,
+  * **Residual variance** as indicator of relevance,
+  * **Leverage**: measure of influence of individual samples or variables on PC orientation.
+* Outliers and influential points are diagnosed via residuals and leverage.
+
+---
+
+## **8. Visualization**
+
+* **Score plots**: show objects in reduced dimensions (detect clusters, classes, outliers).
+* **Loading plots**: show contributions of variables to PCs.
+* **Biplots**: superimpose scores and loadings for joint interpretation.
+* These visualizations are PCA’s most widely used practical outputs.
+
+---
+
+## **9. Applications**
+
+1. **Data overview**: score plots as exploratory tools.
+2. **Dimensionality reduction**: extracting latent variables and resolving mixtures (e.g., spectral unmixing).
+3. **Similarity models**: PCA approximates object similarity patterns (basis of **SIMCA classification**).
+4. **Quantitative structure–activity relationships (QSAR)**: using PC-derived “principal properties.”
+5. **Prediction**: projecting new samples into existing PC models.
+6. **Missing data**: PCA and NIPALS handle incomplete tables reasonably well.
+
+---
+
+## **10. Data Preprocessing**
+
+* **Outlier removal**: critical due to PCA’s sensitivity to extreme points.
+* **Transformations**: e.g., log transforms for skewed data.
+* **Centering**: subtracting variable means (common default).
+* **Scaling**: variance scaling to unit variance → prevents domination by high-variance variables.
+
+  * Must be applied with care: near-constant variables may be overemphasized.
+* **Block scaling**: when variables come from heterogeneous sources.
+* **Correspondence analysis**: special case with double centering and scaling.
+
+---
+
+## **11. Rank / Dimensionality**
+
+* Determining number of components is critical.
+* Methods:
+
+  * Eigenvalue > 1 rule,
+  * Residual variance vs. measurement error,
+  * Rate of residual SS decrease,
+  * **Cross-validation (CV)**: Wold’s predictive criterion; PRESS statistic to decide significance.
+* CV often slightly conservative (fewer components) → reduces risk of over-interpretation.
+
+---
+
+## **12. Extensions**
+
+* **Partial Least Squares (PLS)**: regression extension of PCA for two-block data.
+* **Multivariate image analysis**: applying PCA to image data.
+* **Three-way and multi-way PCA/PLS**: higher-order data (e.g., time × wavelength × sample).
+* **SIMCA**: PCA-based classification method using separate PC models per class.
+
+---
+
+## **13. Summary & Recommendations**
+
+* PCA extracts dominant data patterns, but analyst responsibility is key:
+
+  * Define objectives before analysis,
+  * Decide on preprocessing (centering, scaling, transformations),
+  * Use score and loading plots carefully for exploration,
+  * Validate number of PCs (preferably via cross-validation).
+* PCA should be a **starting point**, guiding further modeling (e.g., PLS), experimental design, or interpretation.
+
+---
+
+## **14. Appendix – NIPALS Algorithm**
+
+* Presents the **NIPALS iterative algorithm** for extracting PCs:
+
+  * Efficient when only first few PCs are needed,
+  * Handles missing data naturally,
+  * Equivalent to the **power method** for eigenvector extraction.
+* Highlights trade-offs between **SVD-based PCA** (all PCs, numerically stable) and **NIPALS PCA** (first few PCs, computationally efficient).
+
+---
+
+## **15. Key Contributions**
+
+1. Canonical **chemometric introduction to PCA**—brought PCA into mainstream chemistry.
+2. Strong emphasis on **interpretation, preprocessing, and validation**, not just computation.
+3. Defined **residuals and leverage** as diagnostic tools in PCA.
+4. Promoted **cross-validation** for choosing PC dimensionality.
+5. Linked PCA to extensions: **PLS, SIMCA, multi-way methods**.
+6. Popularized **NIPALS algorithm** as a practical computation method.
+
+---
+
+# Finding Structure with Randomness: Probabilistic Algorithms for Constructing Approximate Matrix Decompositions
+
+**APA7 reference:**Halko, N., Martinsson, P. G., & Tropp, J. A. (2011). Finding Structure with Randomness: Probabilistic Algorithms for Constructing Approximate Matrix Decompositions. SIAM Review, 53(2), 217–288. https://doi.org/10.1137/090771806
+
+**Filename:** 'Halko et al. - 2011 - Finding Structure with Randomness Probabilistic Algorithms for Constructing Approximate Matrix Deco.pdf'
+
+## **1. Purpose**
+
+* Surveys and extends research on **randomized algorithms** for constructing **low-rank matrix approximations**.
+* Shows that **random sampling** provides an efficient and robust alternative to classical deterministic algorithms for truncated SVD, QR, and eigenvalue decompositions.
+* Demonstrates advantages in **speed, memory usage, robustness, and scalability** for massive datasets.
+
+---
+
+## **2. Background**
+
+* **Low-rank approximations** (truncated SVD, rank-revealing QR) are central to:
+
+  * **PCA** and dimension reduction,
+  * Data mining and statistics,
+  * Least-squares problems,
+  * PDE solvers (fast multipole, H-matrices),
+  * Model reduction in multiscale phenomena.
+* Classical algorithms are often infeasible for:
+
+  * Massive, dense matrices,
+  * Streaming or out-of-core data,
+  * Architectures with limited fast memory.
+* Randomization allows approximate solutions with **provable error bounds** and often superior performance.
+
+---
+
+## **3. Matrix Approximation Framework**
+
+* **Two-stage process**:
+
+  1. **Stage A**: Find a low-dimensional subspace $Q$ capturing most of the matrix action ($A \approx QQ^*A$).
+  2. **Stage B**: Restrict $A$ to that subspace and compute a standard factorization (SVD, QR, etc.) on the reduced matrix.
+* Randomized methods apply to **Stage A**, reducing computational load.
+
+---
+
+## **4. Core Algorithmic Idea**
+
+* Draw a random test matrix $\Omega$.
+* Form sample matrix $Y = A\Omega$.
+* Orthonormalize columns of $Y$ to obtain $Q$.
+* Then approximate $A \approx QQ^*A$.
+
+### Prototype algorithm:
+
+1. Generate random test matrix $\Omega$.
+2. Compute $Y = A\Omega$.
+3. Orthonormalize $Y$ → basis $Q$.
+
+* With oversampling parameter $p$, accuracy improves sharply.
+
+---
+
+## **5. Randomized SVD**
+
+* Compute approximate SVD in two stages:
+
+  * Stage A: Basis $Q$ via random sampling (possibly with **power iteration** to handle slow singular decay).
+  * Stage B: Small SVD of $B = Q^*A$, then expand to get $U\Sigma V^*$.
+* Requires **few passes over data**: typically 2–4, sometimes a single pass.
+* Complexity:
+
+  * Dense matrices: $O(mn \log k + (m+n)k^2)$ vs. $O(mnk)$ for classical.
+  * Sparse matrices: comparable to Krylov methods but **more robust and parallelizable**.
+  * Out-of-core data: 1–2 passes vs. $O(k)$ passes classically.
+
+---
+
+## **6. Performance and Comparisons**
+
+* **Dense in-core matrices**: randomized beats classical in asymptotic complexity.
+* **Sparse/structured matrices**: randomized methods competitive with Lanczos/Arnoldi but more stable and parallelizable.
+* **Streaming/slow memory**: randomized methods vastly superior; require only constant passes.
+* **Error bounds**:
+
+  * With Gaussian test matrices, expected error is within a small factor of optimal truncated SVD.
+  * Probability of large error decays superexponentially with oversampling $p$.
+  * Error can be reduced with power iterations.
+
+---
+
+## **7. Variants and Extensions**
+
+* **Single-pass algorithms**: useful for streaming data.
+* **Structured random matrices** (e.g., subsampled Fourier transforms) reduce computation cost.
+* **A posteriori error estimation** available at low cost.
+* Algorithms also apply to:
+
+  * Interpolative decomposition (ID),
+  * CUR decomposition,
+  * Rank-revealing QR,
+  * Eigenvalue decomposition.
+
+---
+
+## **8. Numerical Examples**
+
+* **Rapidly decaying singular values**: randomized algorithms match optimal truncated SVD.
+* **Large, sparse, noisy image-processing matrix**: randomized outperforms classical in stability and robustness.
+* **Eigenfaces** (PCA for images): randomized SVD handles very large datasets efficiently.
+* **Structured random matrices** tested → significant speedups without accuracy loss.
+
+---
+
+## **9. Theory**
+
+* Provides **deterministic error bounds** (linear algebra based) and **probabilistic bounds** (random matrix theory).
+* Shows concentration-of-measure results guarantee reliability of random sampling.
+* For Gaussian test matrices, expected approximation error ≈ optimal + small multiplicative factor.
+* With power iteration, error approaches optimal exponentially fast in iteration count.
+
+---
+
+## **10. Related Work and Context**
+
+* Builds on:
+
+  * **Johnson–Lindenstrauss lemma** (random embeddings),
+  * **Column subset selection methods** (Frieze, Kannan, Vempala),
+  * **Compressive sampling**,
+  * Earlier randomized methods in numerical linear algebra and geometric functional analysis.
+* Unifies results across theoretical CS, random matrix theory, and applied mathematics.
+
+---
+
+## **11. Key Contributions**
+
+1. **Unified modular framework** for randomized low-rank approximation.
+2. Development of **randomized SVD** with provable error guarantees.
+3. Demonstration of **pass-efficient algorithms** for out-of-core and streaming data.
+4. Analysis of Gaussian and structured random test matrices.
+5. Comprehensive survey linking randomized matrix algorithms to **PCA, ID, CUR, QR**, and scientific applications.
+
+---
+
+## **12. Conclusion**
+
+* Randomized algorithms offer:
+
+  * **Speed**,
+  * **Scalability**,
+  * **Stability**,
+  * **Adaptability to modern hardware and data sizes**.
+* They complement classical deterministic methods, not replace them.
+* Especially effective when:
+
+  * Data is too large for exact decompositions,
+  * Out-of-core or streaming settings,
+  * Approximate solutions suffice.
+* This work established randomized SVD and related methods as standard tools in modern **numerical linear algebra, machine learning, and big data analysis**.
+
+---
+
+# Nonlinear Component Analysis as a Kernel Eigenvalue Problem
+
+**APA7 reference:** Schölkopf, B., Smola, A., & Müller, K.-R. (1998). Nonlinear Component Analysis as a Kernel Eigenvalue Problem. Neural Computation, 10(5), 1299–1319. https://doi.org/10.1162/089976698300017467
+
+**Filename:** 'Schölkopf et al. - 1998 - Nonlinear Component Analysis as a Kernel Eigenvalue Problem.pdf'
+
+## **1. Purpose**
+
+* Introduces **Kernel PCA (KPCA)**: a nonlinear generalization of PCA.
+* Uses **kernel methods** to compute PCA in **high- or infinite-dimensional feature spaces** without explicit mappings.
+* Demonstrates how KPCA can extract nonlinear features useful for **pattern recognition**.
+* Explores relations to other nonlinear PCA approaches, and shows experimental results in object and character recognition.
+
+---
+
+## **2. Background**
+
+* Standard PCA: finds orthogonal directions of maximum variance in input space.
+* Limitation: only captures **linear correlations**.
+* Idea: extend PCA to nonlinear features (e.g., higher-order pixel products in images).
+* Solution: the **kernel trick** – represent dot products in feature space via a kernel function $k(x,y)$, avoiding explicit computation in high dimensions.
+* Inspired by **Support Vector Machines (SVMs)**, which also use kernels to achieve nonlinear decision boundaries.
+
+---
+
+## **3. Kernel PCA Algorithm**
+
+1. **Standard PCA reformulation**: expressed purely in terms of dot products between samples.
+2. **Mapping**: input $x \in \mathbb{R}^N$ mapped to feature space $F$ by $\Phi(x)$.
+3. **Covariance matrix in $F$**:
+
+   $$
+   C = \frac{1}{M} \sum_{j=1}^M \Phi(x_j)\Phi(x_j)^T
+   $$
+
+   Eigenvectors lie in the span of training points:
+
+   $$
+   V = \sum_{i=1}^M \alpha_i \Phi(x_i)
+   $$
+4. **Kernel matrix**:
+
+   $$
+   K_{ij} = k(x_i, x_j) = \Phi(x_i)\cdot \Phi(x_j)
+   $$
+
+   Solve eigenvalue problem:
+
+   $$
+   M\lambda \alpha = K\alpha
+   $$
+5. **Normalization**: ensures feature space eigenvectors are unit length.
+6. **Projection (nonlinear PCs)** of test point $x$:
+
+   $$
+   \text{KP}_n(x) = \sum_{i=1}^M \alpha_i^{(n)} k(x_i, x)
+   $$
+
+### Kernels
+
+* Polynomial: $k(x,y) = (x \cdot y)^d$
+* Gaussian RBF: $k(x,y) = \exp(-\|x-y\|^2 / 2\sigma^2)$
+* Sigmoid, neural network type, local kernels, combinations.
+
+---
+
+## **4. Properties**
+
+* Equivalent to linear PCA in feature space.
+* Retains PCA properties: variance maximization, minimal reconstruction error in $F$, uncorrelated PCs.
+* Unlike linear PCA, can yield **more PCs than input dimensions** (up to number of samples).
+* Computationally comparable to linear PCA on the $M \times M$ kernel matrix (vs. $N \times N$ covariance).
+
+---
+
+## **5. Challenges**
+
+* **Pre-image problem**: projections in $F$ may not correspond to any $x$ in input space. Approximations possible (gradient descent, regression).
+* **Computational cost**: kernel evaluations needed for each test point. Approximations via reduced expansions possible.
+* **Interpretability**: nonlinear PCs harder to interpret than linear ones.
+
+---
+
+## **6. Relation to Other Nonlinear PCA Approaches**
+
+* **Neural network PCA (Oja’s rule, autoencoders)**: iterative, risk of local minima, less geometric interpretation.
+* **Principal curves/surfaces** (Hastie & Stuetzle): direct nonlinear generalization, but involves nonlinear optimization.
+* **Kernel PCA** advantages:
+
+  * Purely linear algebra (eigenvalue problem),
+  * Flexible via kernel choice,
+  * No nonlinear optimization or local minima.
+
+---
+
+## **7. Extensions**
+
+* **Reconstruction**: approximate pre-images of PCs in input space.
+* **Multilayer SVMs**: KPCA as preprocessing layer, followed by linear SVM → efficient and accurate classifiers.
+* **Clustering**: kernel $k$-means reformulated in feature space.
+* **Kernel ICA & projection pursuit**: nonlinear extraction of independent components.
+* **Image indexing & retrieval**: KPCA handles higher-order pixel correlations, improving over PCA.
+
+---
+
+## **8. Experiments**
+
+### Toy Data
+
+* Polynomial kernels applied to simple 2D nonlinear datasets.
+* KPCA captured nonlinear structure beyond what linear PCA detected.
+
+### 3D Object Recognition
+
+* Database of rendered chair images.
+* KPCA + linear SVM significantly outperformed linear PCA in classification accuracy.
+* Extracted nonlinear PCs provided features superior to raw pixel or linear PCs.
+
+### Handwritten Digit Recognition (USPS dataset)
+
+* KPCA with polynomial kernels + linear SVM achieved error rates competitive with state-of-the-art (e.g., convolutional neural networks, nonlinear SVMs).
+* Outperformed linear PCA features.
+* Showed ability to extract **useful nonlinear features** for classification.
+
+---
+
+## **9. Key Contributions**
+
+1. First formulation of **Kernel PCA**: nonlinear PCA via kernel eigenvalue problems.
+2. Showed **variance-maximizing and decorrelation properties** hold in feature space.
+3. Demonstrated **practical algorithms** for computing PCs with kernels.
+4. Introduced **applications**: recognition, clustering, ICA, regression, indexing.
+5. Provided **experimental evidence** that nonlinear PCs improve classification.
+6. Positioned kernel methods as a **general framework** for nonlinear versions of classical algorithms.
+
+---
+
+## **10. Conclusion**
+
+* KPCA extends PCA’s power to nonlinear feature extraction.
+* Works with the same simplicity as linear PCA (eigen-decomposition), but in feature space defined by kernels.
+* Powerful for high-dimensional pattern recognition problems.
+* Limitations: pre-image problem, computational scaling, interpretability.
+* Broader significance: paved the way for widespread use of **kernel methods** in unsupervised learning, complementing their role in SVMs.
+
+---
+
+# Singular spectrum analysis in nonlinear dynamics, with applications to paleoclimatic time series 
+
+**APA7 reference:** Vautard, R., & Ghil, M. (1989). Singular spectrum analysis in nonlinear dynamics, with applications to paleoclimatic time series. Physica D: Nonlinear Phenomena, 35, 395–424. https://doi.org/10.1016/0167-2789(89)90077-8
+
+**Filename:** 'Vautard og Ghil - 1989 - Singular spectrum analysis in nonlinear dynamics, with applications to paleoclimatic time series.pdf'
+
+## **1. Purpose and Motivation**
+
+* Investigates how **singular spectrum analysis (SSA)** can be used to study **nonlinear dynamics** from short, noisy time series, particularly **paleoclimatic records**.
+* Distinguishes between two types of dimensionality:
+
+  * **Statistical dimension (S):** number of degrees of freedom detectable given finite, noisy data (depends on sampling, noise, record length).
+  * **Dynamical dimension (D):** intrinsic dimension of the attractor (independent of measurement quality).
+* SSA provides reliable estimates of **S**, while estimating **D** from paleoclimate data remains infeasible.
+
+---
+
+## **2. Theoretical Background**
+
+* Classical chaos theory showed that deterministic systems with few degrees of freedom can exhibit irregular, chaotic dynamics.
+* In practice, natural systems are influenced by many degrees of freedom and measurement noise.
+* Key question: *how much of the observed variability is deterministic (few DOFs) vs. stochastic (many DOFs)?*
+* Existing dimension-estimation algorithms (e.g., correlation dimension, Grassberger–Procaccia) fail with short, noisy data.
+
+---
+
+## **3. Singular Spectrum Analysis (SSA)**
+
+* Based on **Karhunen–Loève decomposition** (or PCA of lagged copies of the time series).
+* Embeds a univariate time series into an $M$-dimensional space using delayed coordinates.
+* Forms a lag-covariance matrix, solves eigenvalue problem, and extracts:
+
+  * **Eigenvalues (singular spectrum):** variance explained by each mode, helps estimate statistical dimension.
+  * **Eigenvectors (EOFs):** data-adaptive filters.
+  * **Principal components (PCs):** filtered time series associated with oscillatory modes.
+* **Noise floor:** flat tail in singular spectrum indicates uninformative modes.
+* PCs act as **adaptive band-pass filters** that isolate oscillations.
+
+---
+
+## **4. Properties and Interpretation**
+
+* **Statistical dimension (S):** number of eigenvalues above noise floor; grows with data quality and record length.
+* **Dynamical dimension (D):** ideally estimated via correlation dimension; in practice unreliable for paleoclimate data.
+* **No simple relation between S and D**—SSA yields meaningful statistical descriptions but not the true attractor dimension.
+* **Spectral properties:** SSA modes often come in pairs (sin/cos), associated with oscillatory components.
+* **Nonstationarity:** SSA PCs can reveal temporal changes in amplitude and regime shifts, unlike classical spectral analysis.
+
+---
+
+## **5. Data: Paleoclimatic Applications**
+
+Analyzed four marine sediment cores using oxygen isotope ratio ($\delta^{18}O$) as a proxy for ice volume and climate variability:
+
+1. **RC11-120 (C1)** – high sedimentation rate, \~388 data points, captures higher frequencies.
+2. **V19-240 (C2)** – moderate record length, good dating.
+3. **V28-238 (C3)** – long record, low sedimentation rate.
+4. **V28-239 (C4)** – very long record, low sedimentation rate, \~1200+ points.
+
+### Findings
+
+* **C1:** PCs identified dominant \~100–130 kyr glacial cycle, \~20–25 kyr precession-related cycle, regime changes linked to sedimentation.
+* **C2:** Clear detection of 100 kyr and \~40 kyr obliquity cycles, with intermittent amplitude modulation.
+* **C3 & C4:** Longer records confirmed 100 kyr and 41 kyr oscillations, and transitions in cycle strength over time.
+* **All cores:** Statistical dimension $S$ ≈ 5–10 for embedding dimensions tested. Much higher $M$ values increased noise contamination.
+
+---
+
+## **6. Implications**
+
+* **SSA success:** Extracts dominant climatic oscillations (Milankovitch cycles: 100 kyr, 41 kyr, 23 kyr).
+* Detects **regime shifts** in oscillatory amplitude over Quaternary timescales.
+* Confirms that paleoclimate dynamics can be approximated by \~10 significant degrees of freedom (statistical).
+* **Limitation:** records too short/noisy to estimate attractor dimension $D$; cannot confirm whether dynamics are low-dimensional deterministic chaos or high-dimensional stochastic.
+* **Strength vs. Fourier spectral analysis:** SSA is adaptive, reveals nonstationary dynamics, and separates oscillations from noise better.
+
+---
+
+## **7. Key Contributions**
+
+1. Formalized SSA as a tool to estimate **statistical dimension** in short/noisy natural records.
+2. Demonstrated SSA’s ability to isolate dominant oscillations in paleoclimate (Milankovitch cycles).
+3. Highlighted **noise separation and adaptive filtering** advantages over classical spectral analysis.
+4. Showed SSA provides **time-resolved insights** into oscillation amplitude changes.
+5. Clarified that **statistical dimension ≠ dynamical dimension**—true chaotic dimension remains elusive with available data.
+
+---
+
+## **8. Conclusion**
+
+* SSA provides powerful insights into the structure of paleoclimate variability, separating deterministic signals from noise.
+* Reveals that \~10 statistically significant degrees of freedom govern observed Quaternary oscillations.
+* However, estimating the true dynamical attractor dimension requires longer and cleaner records.
+* The study established SSA as a cornerstone method in climate dynamics, later extended in subsequent works (e.g., Vautard, Yiou & Ghil 1992).
+
+---
+
+# Empirical orthogonal functions and related techniques in atmospheric science
+
+**APA7 reference:** Hannachi, A., Jolliffe, I. T., & Stephenson, D. B. (2007). Empirical orthogonal functions and related techniques in atmospheric science: A review. International Journal of Climatology, 27(9), 1119–1152. https://doi.org/10.1002/joc.1499
+
+**Filename:** 'Hannachi et al. - 2007 - Empirical orthogonal functions and related techniques in atmospheric science A review.pdf'
+
+## **1. Purpose**
+
+* Provides a comprehensive review of **empirical orthogonal functions (EOFs)** and related techniques in atmospheric science.
+* Updates earlier reviews (e.g., Kutzbach 1967, Preisendorfer 1988) by covering new developments such as rotated, simplified, extended, and complex EOFs.
+* Addresses challenges in interpreting EOF patterns and highlights alternative methods for extracting physically meaningful atmospheric modes.
+
+---
+
+## **2. Historical Background**
+
+* EOF analysis is essentially **PCA applied to spatiotemporal fields**.
+* First used in meteorology in the late 1940s (Obukhov, Fukuoka), formalized by Lorenz (1956).
+* Aimed to reduce atmospheric data into dominant spatial modes with associated time series.
+* Widely applied in climate research, e.g., identifying **teleconnections** like the **North Atlantic Oscillation (NAO)** and the **Arctic Oscillation (AO)**.
+* Links exist to the **Karhunen–Loève expansion** in stochastic processes and to PCA in multivariate statistics.
+
+---
+
+## **3. Core EOF Method**
+
+* EOF analysis decomposes a space–time field $X(t,s)$ into:
+
+  $$
+  X(t,s) = \sum_{k=1}^M c_k(t) u_k(s)
+  $$
+
+  where:
+
+  * $u_k(s)$: spatial EOFs (orthogonal patterns),
+  * $c_k(t)$: principal components (uncorrelated time series).
+* Properties:
+
+  * **Orthogonality** of EOFs and uncorrelated PCs simplify analysis,
+  * Variance maximization ensures efficiency,
+  * But these constraints can reduce interpretability since real physical processes are rarely orthogonal.
+
+---
+
+## **4. Limitations of EOFs**
+
+* **Orthogonality** is a mathematical convenience, not a physical reality.
+* **Domain dependence**: changing the spatial domain alters EOF patterns.
+* **Global structures**: EOFs often produce broad, non-localized features, hindering physical interpretation.
+* **Degeneracy**: eigenvalues close in size yield mixed modes, complicating physical meaning.
+
+---
+
+## **5. Extensions and Modifications**
+
+### **5.1 Rotated EOFs (REOFs)**
+
+* Aim: increase interpretability by relaxing orthogonality.
+* Rotation (e.g., VARIMAX, QUARTIMAX) yields **localized, simpler structures**.
+* Widely used in atmospheric science since the 1980s.
+* Issues: choice of rotation criterion and number of EOFs for rotation is somewhat arbitrary.
+
+### **5.2 Simplified EOFs (SEOFs)**
+
+* Introduced using optimization (inspired by LASSO shrinkage).
+* Combine variance maximization with sparsity in loadings.
+* Produce more interpretable, localized modes without rotation.
+* Computationally intensive but robust for leading modes.
+
+### **5.3 Extended EOFs (EEOFs / MSSA)**
+
+* Incorporate both **spatial and temporal correlations** (lagged embedding).
+* Useful for detecting **oscillations, propagating patterns, and trends**.
+* Related to singular spectrum analysis (SSA) and multichannel SSA.
+* Effective for capturing features like low-frequency oscillations and weather regimes.
+
+### **5.4 Complex and Hilbert EOFs (CEOFs/HEOFs)**
+
+* Designed for **propagating waves and oscillations**.
+* Use Hilbert transforms or cross-spectral matrices to represent amplitude and phase.
+* Applied to phenomena such as the **quasi-biennial oscillation (QBO)**.
+
+### **5.5 Other Extensions**
+
+* **Frequency-domain EOFs (FDEOFs)**: extract frequency-limited modes.
+* **Periodically extended EOFs (PXEOFs)**: capture cyclic structures.
+* **Three-mode or multi-group PCA**: handle datasets with multiple spatial, temporal, and variable indices.
+* **Functional PCA**: applied when data consist of curves.
+* **Trend EOFs (TEOFs)**: identify long-term climate trends (e.g., NAO, Siberian High).
+
+---
+
+## **6. Applications in Atmospheric Science**
+
+* **Teleconnections**: NAO, Arctic Oscillation, Pacific–North America pattern.
+* **Tropical oscillations**: Madden–Julian Oscillation (MJO), QBO.
+* **Regime identification**: blocking events, low-frequency variability.
+* **Trend detection**: separating coherent climate signals from noise.
+* **Prediction**: EOF-based indices used in statistical weather/climate forecasting.
+
+---
+
+## **7. Significance Testing and Interpretation**
+
+* **Sampling errors** (North et al. 1982): closely spaced eigenvalues may not be physically separable.
+* Need to test EOFs against **stochastic null hypotheses** to ensure modes are statistically significant.
+* Misinterpretation risks: EOFs may reflect statistical artifacts, not physical modes.
+
+---
+
+## **8. Summary and Conclusions**
+
+* EOFs are indispensable exploratory tools for atmospheric and climate data.
+* Their **orthogonality constraints** often produce patterns difficult to interpret physically.
+* Extensions (rotated, simplified, extended, complex EOFs) improve localization, capture propagation, and identify trends.
+* Interpretation requires caution—EOFs reveal statistical structures, not necessarily dynamical modes.
+* The review emphasizes combining EOF methods with **physical insight and dynamical modeling** for reliable conclusions.
+
+---
+
+## **9. Key Contributions of the Review**
+
+1. Comprehensive synthesis of classical EOFs and modern variants.
+2. Clear discussion of **limitations and pitfalls** of EOF interpretation.
+3. Bridging between **mathematical/statistical methodology** and **climate applications**.
+4. Highlighted new extensions (e.g., SEOFs, TEOFs, PXEOFs).
+5. Provided guidance for climate scientists and students entering the field.
+
+---
+


### PR DESCRIPTION
## Summary
- Added comprehensive PCA literature summaries in `docs/references/_summaries.txt`
- Updated `.gitignore` to track reference summaries while ignoring PDFs
- Provides theoretical foundation for Phase 5 code audit

## Context
This PR adds literature review summaries from authoritative PCA papers to support the upcoming Phase 5 code audit. The summaries cover:
- Classical SVD-based PCA
- NIPALS algorithm
- Kernel PCA
- Temporal PCA/SSA
- Preprocessing effects
- Missing value handling
- Mathematical properties and validation criteria

## Changes
- Added `docs/references/_summaries.txt` (2500+ lines of comprehensive PCA literature summaries)
- Modified `.gitignore` to allow tracking of reference summaries

## Related Issue
Fixes #443 (partially - provides foundation for audit)

## Testing
N/A - Documentation only