### PR TITLE
feat: enable Plotly selection tools in BiPlot and DiagnosticPlot

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1650,6 +1650,8 @@ return;
                                                 }
                                                 showEllipses={showEllipses && !!selectedGroupColumn && getColumnData(selectedGroupColumn).type === 'categorical'}
                                                 confidenceLevel={confidenceLevel}
+                                                onSelectionChange={handlePlotSelectionChange}
+                                                excludedRows={pcaHasExclusions ? [] : excludedRows}
                                             />
                                         ) : selectedPlot === 'biplot3d' ? (
                                             <Biplot3D
@@ -1689,6 +1691,8 @@ return;
                                                 maxLabelsToShow={maxLabelsToShow}
                                                 confidenceLevel={confidenceLevel === 0.90 ? 0.95 : confidenceLevel}
                                                 fontScale={plotFontScale}
+                                                onSelectionChange={handlePlotSelectionChange}
+                                                excludedRows={pcaHasExclusions ? [] : excludedRows}
                                             />
                                         ) : selectedPlot === 'eigencorrelation' ? (
                                             <EigencorrelationPlot

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -29,6 +29,8 @@ interface BiplotProps {
   vectorScale?: number;
   maxVariables?: number; // Maximum number of loading vectors to display
   fontScale?: number;
+  onSelectionChange?: (indices: number[]) => void;
+  excludedRows?: number[]; // Indices of rows excluded from PCA
 }
 
 export const Biplot: React.FC<BiplotProps> = ({
@@ -48,7 +50,9 @@ export const Biplot: React.FC<BiplotProps> = ({
   showLoadings = true,
   vectorScale = 1.0,
   maxVariables = 100,
-  fontScale
+  fontScale,
+  onSelectionChange,
+  excludedRows = []
 }) => {
   const { theme } = useTheme();
   const { qualitativePalette, sequentialPalette } = usePalette();
@@ -85,11 +89,21 @@ export const Biplot: React.FC<BiplotProps> = ({
     maxVariables
   };
 
+  // Handle selection callback
+  const handleSelection = React.useCallback((indices: number[]) => {
+    console.log('Biplot wrapper: Selection received', indices);
+    if (onSelectionChange) {
+      onSelectionChange(indices);
+    }
+  }, [onSelectionChange]);
+
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <PCABiplot
         data={plotlyData}
         config={plotlyConfig}
+        onSelection={handleSelection}
+        excludedRows={excludedRows}
       />
     </div>
   );

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
@@ -21,6 +21,8 @@ interface DiagnosticScatterPlotProps {
   showRowLabels?: boolean;
   maxLabelsToShow?: number;
   fontScale?: number;
+  onSelectionChange?: (indices: number[]) => void;
+  excludedRows?: number[]; // Indices of rows excluded from PCA
 }
 
 export const DiagnosticScatterPlot: React.FC<DiagnosticScatterPlotProps> = ({
@@ -32,7 +34,9 @@ export const DiagnosticScatterPlot: React.FC<DiagnosticScatterPlotProps> = ({
   confidenceLevel = 0.95,
   showRowLabels = false,
   maxLabelsToShow = 10,
-  fontScale
+  fontScale,
+  onSelectionChange,
+  excludedRows = []
 }) => {
   const { theme } = useTheme();
   const { qualitativePalette } = usePalette();
@@ -70,11 +74,21 @@ export const DiagnosticScatterPlot: React.FC<DiagnosticScatterPlotProps> = ({
     labelThreshold: maxLabelsToShow
   };
 
+  // Handle selection callback
+  const handleSelection = React.useCallback((indices: number[]) => {
+    console.log('DiagnosticScatterPlot wrapper: Selection received', indices);
+    if (onSelectionChange) {
+      onSelectionChange(indices);
+    }
+  }, [onSelectionChange]);
+
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <PCADiagnosticPlot
         data={plotlyData}
         config={plotlyConfig}
+        onSelection={handleSelection}
+        excludedRows={excludedRows}
       />
     </div>
   );

--- a/packages/ui-components/src/charts/pca/PlotlyBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyBiplot.tsx
@@ -162,6 +162,7 @@ export class PlotlyBiplot {
           name: 'Scores',
           hovertext: hovertext,
           hovertemplate: '%{hovertext}<extra></extra>',
+          customdata: scoresX.map((_, i) => [i]), // Add global indices for selection
           marker: {
             size: getScaledMarkerSize(this.config.pointSize || 8, this.config.fontScale || 1.0),
             color: groupValues, // Use raw numeric values
@@ -197,6 +198,7 @@ export class PlotlyBiplot {
             x: groupX,
             y: groupY,
             name: group,
+            customdata: indices.map(idx => [idx]), // Add global indices for selection
             marker: {
               color: this.config.colorScheme
                 ? this.config.colorScheme[i % this.config.colorScheme.length]
@@ -248,6 +250,7 @@ export class PlotlyBiplot {
           x: scoresX,
           y: scoresY,
           name: 'Scores',
+          customdata: scoresX.map((_, i) => [i]), // Add global indices for selection
           marker: {
             color: this.config.colorScheme?.[0] || '#3b82f6',
             size: getScaledMarkerSize(this.config.pointSize || 8, this.config.fontScale || 1.0),
@@ -500,15 +503,67 @@ return { x: 0, y: 0 };
 export const PCABiplot: React.FC<{
   data: BiplotData;
   config?: BiplotConfig;
-}> = ({ data, config }) => {
+  onSelection?: (indices: number[]) => void;
+  excludedRows?: number[];
+}> = ({ data, config, onSelection, excludedRows = [] }) => {
   const plot = useMemo(() => new PlotlyBiplot(data, config), [data, config]);
+  
+  // Apply opacity to excluded rows
+  const tracesWithOpacity = useMemo(() => {
+    const traces = plot.getTraces();
+    if (excludedRows.length > 0 && traces.length > 0) {
+      // The first trace is typically the scores/points
+      const scoresTrace: any = { ...traces[0] };
+      if (scoresTrace.marker) {
+        const numPoints = (scoresTrace.x as number[]).length;
+        const opacity = new Array(numPoints).fill(1);
+        excludedRows.forEach(idx => {
+          if (idx < numPoints) {
+            opacity[idx] = 0.2;
+          }
+        });
+        scoresTrace.marker = {
+          ...scoresTrace.marker,
+          opacity
+        };
+      }
+      return [scoresTrace, ...traces.slice(1)];
+    }
+    return traces;
+  }, [plot, excludedRows]);
+
+  // Handle selection events
+  const handlePlotlyEvent = React.useCallback((event: any) => {
+    if (event?.points && onSelection) {
+      const indices = event.points.map((point: any) => {
+        // Use customdata if available, otherwise use pointIndex
+        return point.customdata?.[0] ?? point.pointIndex;
+      }).filter((idx: number) => idx !== undefined && idx !== null);
+      
+      if (indices.length > 0) {
+        console.log('PCABiplot: Selection event', indices);
+        onSelection(indices);
+      }
+    }
+  }, [onSelection]);
+
+  // Get layout with lasso selection enabled
+  const layoutWithSelection = useMemo(() => {
+    const baseLayout = plot.getEnhancedLayout();
+    return {
+      ...baseLayout,
+      dragmode: 'lasso' as const,
+      selectdirection: 'diagonal' as const
+    };
+  }, [plot]);
 
   return (
     <PlotlyWithFullscreen
-      data={plot.getTraces()}
-      layout={plot.getEnhancedLayout()}
+      data={tracesWithOpacity}
+      layout={layoutWithSelection}
       config={plot.getConfig()}
       style={{ width: '100%', height: '100%' }}
+      onSelected={handlePlotlyEvent}
     />
   );
 };

--- a/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
@@ -128,6 +128,7 @@ return;
         x: cat.indices.map(i => mahalanobisDistances[i]),
         y: cat.indices.map(i => residualSumOfSquares[i]),
         name: cat.name,
+        customdata: cat.indices.map(i => [i]), // Add global indices for selection
         marker: {
           color: cat.color,
           size: getScaledMarkerSize(this.config.pointSize || 8, this.config.fontScale || 1.0),
@@ -365,15 +366,76 @@ return;
 export const PCADiagnosticPlot: React.FC<{
   data: DiagnosticPlotData;
   config?: DiagnosticPlotConfig;
-}> = ({ data, config }) => {
+  onSelection?: (indices: number[]) => void;
+  excludedRows?: number[];
+}> = ({ data, config, onSelection, excludedRows = [] }) => {
   const plot = useMemo(() => new PlotlyDiagnosticPlot(data, config), [data, config]);
+  
+  // Apply opacity to excluded rows
+  const tracesWithOpacity = useMemo(() => {
+    const traces = plot.getTraces();
+    if (excludedRows.length > 0) {
+      return traces.map(trace => {
+        const traceAny = trace as any;
+        if (traceAny.customdata) {
+          const updatedTrace: any = { ...trace };
+          const numPoints = (traceAny.x as number[]).length;
+          const opacity = new Array(numPoints).fill(1);
+          
+          // Get the global indices from customdata
+          const globalIndices = (traceAny.customdata as number[][]).map(cd => cd[0]);
+          globalIndices.forEach((globalIdx, localIdx) => {
+            if (excludedRows.includes(globalIdx)) {
+              opacity[localIdx] = 0.2;
+            }
+          });
+          
+          if (updatedTrace.marker) {
+            updatedTrace.marker = {
+              ...updatedTrace.marker,
+              opacity
+            };
+          }
+          return updatedTrace;
+        }
+        return trace;
+      });
+    }
+    return traces;
+  }, [plot, excludedRows]);
+
+  // Handle selection events
+  const handlePlotlyEvent = React.useCallback((event: any) => {
+    if (event?.points && onSelection) {
+      const indices = event.points.map((point: any) => {
+        // Use customdata if available, otherwise use pointIndex
+        return point.customdata?.[0] ?? point.pointIndex;
+      }).filter((idx: number) => idx !== undefined && idx !== null);
+      
+      if (indices.length > 0) {
+        console.log('PCADiagnosticPlot: Selection event', indices);
+        onSelection(indices);
+      }
+    }
+  }, [onSelection]);
+
+  // Get layout with lasso selection enabled
+  const layoutWithSelection = useMemo(() => {
+    const baseLayout = plot.getEnhancedLayout();
+    return {
+      ...baseLayout,
+      dragmode: 'lasso' as const,
+      selectdirection: 'diagonal' as const
+    };
+  }, [plot]);
 
   return (
     <PlotlyWithFullscreen
-      data={plot.getTraces()}
-      layout={plot.getEnhancedLayout()}
+      data={tracesWithOpacity}
+      layout={layoutWithSelection}
       config={plot.getConfig()}
       style={{ width: '100%', height: '100%' }}
+      onSelected={handlePlotlyEvent}
     />
   );
 };


### PR DESCRIPTION
## Summary
This PR extends the interactive sample selection functionality from PR #415 to the BiPlot and DiagnosticPlot components, ensuring consistent selection capabilities across all visualizations that display sample points.

## Context
PR #415 successfully implemented the Plotly lasso selection tool for the Scores Plot, allowing users to visually select samples for exclusion from PCA model fitting. This PR completes the feature by adding the same functionality to BiPlot and DiagnosticPlot.

## Changes Made

### 1. BiPlot Component
- Added `onSelectionChange` and `excludedRows` props to `Biplot.tsx`
- Updated `PlotlyBiplot.tsx` UI component to:
  - Enable lasso dragmode in layout configuration
  - Handle `plotly_selected` events
  - Apply opacity (0.2) to excluded points
  - Add customdata with global indices for selection tracking

### 2. DiagnosticPlot Component  
- Added `onSelectionChange` and `excludedRows` props to `DiagnosticScatterPlot.tsx`
- Updated `PlotlyDiagnosticPlot.tsx` UI component with same selection features
- Ensured all categorical traces include customdata for consistent selection

### 3. App.tsx Integration
- Connected both BiPlot and DiagnosticPlot to existing `handlePlotSelectionChange` callback
- Pass `excludedRows` state to both components with conditional logic for PCA re-runs
- Selection state syncs across all views and with data table checkboxes

## Implementation Pattern
Following the Core Development Principles:
- **DRY**: Reused existing `handlePlotSelectionChange` logic from ScoresPlot
- **KISS**: Simple extension of proven pattern, no new complexity
- **Separation of Concerns**: UI components handle rendering, App.tsx manages state
- **Readability**: Clear callback names and consistent prop patterns

## Testing Performed
- ✅ Built UI components package successfully
- ✅ Built GoPCA Desktop frontend successfully  
- ✅ TypeScript compilation passes
- ✅ Pre-commit checks pass

## Testing Checklist
- [ ] Test lasso selection in BiPlot with iris dataset
- [ ] Test lasso selection in DiagnosticPlot with iris dataset
- [ ] Verify selection syncs with data table checkboxes
- [ ] Verify excluded samples remain dimmed after PCA re-run
- [ ] Confirm selection tool remains disabled in Scree Plot and Circle of Correlations
- [ ] Test with wine and corn datasets
- [ ] Test with continuous coloring in BiPlot
- [ ] Test with categorical groups in BiPlot

## Related Issues
- Closes #422
- Extends functionality from PR #415

## Screenshots
The implementation follows the same visual pattern as the Scores Plot - selected samples are dimmed to 0.2 opacity and selections sync with the data table checkboxes.

## Notes
- Selection tools are correctly disabled for plots without sample points (Scree Plot, Circle of Correlations)
- 3D plots already have selection disabled as expected
- The implementation maintains backward compatibility with existing code