### PR TITLE
fix: correct error dialog alignment and overflow for long messages

### DIFF
--- a/packages/ui-components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/ui-components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -57,7 +57,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       return (
         <div className="min-h-[200px] flex items-center justify-center p-8">
-          <div className="max-w-md w-full bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+          <div className="max-w-2xl w-full bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
             <div className="flex items-start space-x-3">
               <div className="flex-shrink-0">
                 <svg
@@ -86,7 +86,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                       <summary className="cursor-pointer text-xs underline">
                         Show details
                       </summary>
-                      <pre className="mt-2 text-xs overflow-auto bg-red-100 dark:bg-red-900/30 p-2 rounded">
+                      <pre className="mt-2 text-xs overflow-auto max-w-full break-all bg-red-100 dark:bg-red-900/30 p-2 rounded">
                         {this.state.error.toString()}
                         {this.state.errorInfo && (
                           <>


### PR DESCRIPTION
## Summary
Fixed the error dialog misalignment and overflow issues that occurred when displaying long error messages, particularly stack traces.

## Changes
- Increased container max-width from `max-w-md` (28rem) to `max-w-2xl` (42rem) to better accommodate detailed error messages
- Added `max-w-full` and `break-all` classes to the `<pre>` element to ensure proper text wrapping and containment within the dialog boundaries

## Testing
- Built the ui-components package successfully
- TypeScript compilation passes without errors
- Pre-commit hooks passed

## Visual Impact
The error dialog now:
- Remains properly centered in the viewport
- Contains long error messages without horizontal overflow
- Provides adequate space for stack traces and detailed error information
- Maintains professional appearance in both light and dark themes

Closes #465