### PR TITLE
fix: temporal PCA not displaying explained variance in CLI output (#470)

### DIFF
--- a/internal/cobra/output.go
+++ b/internal/cobra/output.go
@@ -116,9 +116,9 @@ func outputTableFormat(result *types.PCAResult, data *pkgcsv.Data,
 		}
 	}
 
-	// Output loadings table (skip for kernel PCA which doesn't have loadings)
+	// Output loadings table (skip for kernel PCA and temporal PCA which have different loading structures)
 	if outputLoadings {
-		if result.Method != "kernel" {
+		if result.Method != "kernel" && result.Method != "temporal" {
 			fmt.Println("\nPCA Loadings:")
 			fmt.Println("──────────────────────────────────────────────────────────────")
 
@@ -162,8 +162,10 @@ func outputTableFormat(result *types.PCAResult, data *pkgcsv.Data,
 			if nFeatures > 25 {
 				fmt.Printf("\nShowing first 20 and last 5 of %d features\n", nFeatures)
 			}
-		} else {
+		} else if result.Method == "kernel" {
 			fmt.Println("\nNote: Loadings are not available for Kernel PCA")
+		} else if result.Method == "temporal" {
+			fmt.Println("\nNote: Temporal PCA loadings have a different structure (components × lagged features)")
 		}
 	}
 

--- a/internal/core/temporal_pca.go
+++ b/internal/core/temporal_pca.go
@@ -336,12 +336,16 @@ func (t *TemporalPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types
 			temporalEigenvectors.Set(i, 0, 1.0/math.Sqrt(float64(t.numLags))) // Normalized vector
 		}
 
+		// Generate component labels for single component
+		componentLabels := []string{"PC1"}
+
 		return &types.PCAResult{
 			Scores:               utils.MatrixToSlice(scores),
 			Loadings:             utils.MatrixToSlice(t.loadings),
 			ExplainedVar:         t.explainedVar,
 			ExplainedVarRatio:    []float64{100.0}, // Single component explains 100%
-			CumulativeVar:        []float64{1.0},
+			CumulativeVar:        []float64{100.0}, // Cumulative should also be 100%
+			ComponentLabels:      componentLabels,
 			SingularValues:       t.singularVals,
 			Method:               "temporal",
 			Means:                nil, // Not applicable for temporal PCA with SSA approach
@@ -453,6 +457,12 @@ func (t *TemporalPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types
 		}
 	}
 
+	// Generate component labels
+	componentLabels := make([]string, t.nComponents)
+	for i := 0; i < t.nComponents; i++ {
+		componentLabels[i] = fmt.Sprintf("PC%d", i+1)
+	}
+
 	// Prepare result
 	result := &types.PCAResult{
 		Scores:               utils.MatrixToSlice(scores),
@@ -460,6 +470,7 @@ func (t *TemporalPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types
 		ExplainedVar:         t.explainedVar[:t.nComponents],
 		ExplainedVarRatio:    explainedVarRatio,
 		CumulativeVar:        cumulativeVar,
+		ComponentLabels:      componentLabels,
 		SingularValues:       t.singularVals,
 		Means:                nil, // Not applicable for temporal PCA with SSA approach
 		StdDevs:              nil, // Not applicable for temporal PCA with SSA approach


### PR DESCRIPTION
## Summary

Fixes temporal PCA not displaying explained variance in the CLI output. The variance section appeared empty when running temporal PCA analysis.

## Problem

When running temporal PCA analysis, the explained variance table showed headers but no values:
```
Explained Variance:
──────────────────────────────────────────────────────────────
Component             Variance     Cumulative
──────────────────────────────────────────────────────────────
```

## Root Cause

The temporal PCA implementation was not generating `ComponentLabels` (PC1, PC2, etc.) in the PCAResult. The CLI output code requires these labels to display the variance table correctly.

## Solution

1. Added ComponentLabels generation to temporal PCA implementation (both single sample edge case and regular case)
2. Updated output formatting to skip standard loadings display for temporal PCA since its loadings have a different structure (components × lagged features)
3. Fixed cumulative variance in single sample case to be 100% instead of 1.0

## Testing

- Tested with stock data (AAPL): Explained variance now displays correctly
- Tested with iris dataset: Works as expected
- All existing temporal PCA tests pass
- Full test suite passes without regressions

## Example Output

```
Explained Variance:
──────────────────────────────────────────────────────────────
Component             Variance     Cumulative
──────────────────────────────────────────────────────────────
PC1                      65.4%          65.4%
PC2                       8.9%          74.3%
PC3                       6.3%          80.6%
```

Closes #470