### PR TITLE
feat: standardize file dialogs and button naming (#491)

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -359,7 +359,7 @@ return;
                                         disabled={isLoading}
                                         className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                                     >
-                                        {isLoading ? 'Loading...' : 'Browse for File'}
+                                        {isLoading ? 'Loading...' : 'Choose File'}
                                     </button>
                                     <button
                                         onClick={() => setShowImportWizard(true)}
@@ -370,7 +370,7 @@ return;
                                     </button>
                                 </div>
                                 <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
-                                    <p><span className="font-medium">Browse for File:</span> Quick file picker for standard CSV/TSV files with automatic format detection</p>
+                                    <p><span className="font-medium">Choose File:</span> Quick file picker for standard CSV/TSV files with automatic format detection</p>
                                     <p><span className="font-medium">Import with Wizard:</span> Advanced options for Excel sheets, custom delimiters, header rows, and column selection</p>
                                 </div>
                             </div>

--- a/cmd/gocsv/frontend/src/components/FileSelector.tsx
+++ b/cmd/gocsv/frontend/src/components/FileSelector.tsx
@@ -53,7 +53,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({ onFileSelect, isLoad
 
         // Note: Due to Wails limitations, we can't directly handle dropped files
         // Show a message to use the browse button instead
-        alert('Please use the "Browse Files" button to select files. Drag and drop is not supported in the file dialog.');
+        alert('Please use the "Choose File" button to select files. Drag and drop is not supported in the file dialog.');
     }, []);
 
     return (
@@ -86,7 +86,7 @@ export const FileSelector: React.FC<FileSelectorProps> = ({ onFileSelect, isLoad
                                 disabled={isLoading}
                                 className="font-medium text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300"
                             >
-                                browse
+                                choose file
                             </button>
                         </span>
                     )}
@@ -96,14 +96,14 @@ export const FileSelector: React.FC<FileSelectorProps> = ({ onFileSelect, isLoad
                 </p>
             </div>
 
-            {/* Browse button */}
+            {/* Choose file button */}
             <div className="text-center">
                 <button
                     onClick={handleBrowse}
                     disabled={isLoading}
                     className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
-                    {isLoading ? 'Loading...' : 'Browse Files'}
+                    {isLoading ? 'Loading...' : 'Choose File'}
                 </button>
             </div>
 

--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1056,6 +1056,41 @@ func (a *App) LoadIrisDataset() (*FileDataJSON, error) {
 	return a.ParseCSV(modifiedContent)
 }
 
+// SelectCSVFile opens a native file dialog for selecting CSV files
+func (a *App) SelectCSVFile() (string, string, error) {
+	dialogOptions := runtime.OpenDialogOptions{
+		Title: "Select CSV File",
+		Filters: []runtime.FileFilter{
+			{
+				DisplayName: "CSV Files",
+				Pattern:     "*.csv",
+			},
+			{
+				DisplayName: "All Files",
+				Pattern:     "*.*",
+			},
+		},
+	}
+
+	filePath, err := runtime.OpenFileDialog(a.ctx, dialogOptions)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open file dialog: %w", err)
+	}
+
+	// User cancelled
+	if filePath == "" {
+		return "", "", nil
+	}
+
+	// Read the file content
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return filePath, string(content), nil
+}
+
 // LoadDatasetFile loads a CSV file from the embedded data
 func (a *App) LoadDatasetFile(filename string) (*FileDataJSON, error) {
 	// First try to get the embedded dataset

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useRef, useEffect, lazy, Suspense } from 'react';
 import './App.css';
-import { ParseCSV, RunPCA, LoadIrisDataset, LoadDatasetFile, GetVersion, CalculateEllipses, GetGUIConfig, LoadCSVFile, CheckGoCSVStatus, OpenInGoCSV, LaunchGoCSV, DownloadGoCSV, SaveFile } from '../wailsjs/go/main/App';
+import { ParseCSV, RunPCA, LoadIrisDataset, LoadDatasetFile, GetVersion, CalculateEllipses, GetGUIConfig, LoadCSVFile, CheckGoCSVStatus, OpenInGoCSV, LaunchGoCSV, DownloadGoCSV, SaveFile, SelectCSVFile } from '../wailsjs/go/main/App';
 import { Copy, Check } from 'lucide-react';
 import { EventsOn } from '../wailsjs/runtime/runtime';
 import { DataTable, SelectionTable, MatrixIllustration, HelpWrapper, DocumentationViewer, ModelOverview, AboutDialog } from './components';
@@ -295,6 +295,45 @@ return;
             updateGammaForData(result);
         } catch (err) {
             setFileError(`Failed to parse CSV: ${err}`);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleNativeFileSelect = async () => {
+        setLoading(true);
+        setFileError(null);
+        setPcaError(null); // Clear any previous PCA errors
+
+        try {
+            const result = await SelectCSVFile();
+            // Result is a tuple: [filePath, content, error]
+            if (!result || !result[0]) {
+                // User cancelled
+                setLoading(false);
+                return;
+            }
+
+            const [filePath, content] = result;
+            const fileName = filePath.split(/[\\/]/).pop() || 'unknown.csv';
+            setFileName(fileName);
+
+            const parseResult = await ParseCSV(content);
+            setFileData(parseResult);
+            setPcaResponse(null);
+            // Reset exclusions and selections when loading new data
+            setExcludedRows([]);
+            setExcludedColumns([]);
+            setSelectedGroupColumn(null);
+            setMode('none'); // Reset palette mode
+            setDatasetId(prev => prev + 1); // Force DataTable re-render
+
+            // Calculate and set default gamma for kernel PCA
+            updateGammaForData(parseResult);
+        } catch (err) {
+            console.error('File selection failed:', err);
+            setFileError(`Failed to load file: ${err}`);
+            setFileData(null);
         } finally {
             setLoading(false);
         }
@@ -612,18 +651,13 @@ return;
                                     Upload Your CSV File
                                 </label>
                                 <HelpWrapper helpKey="choose-file">
-                                    <input
-                                        type="file"
-                                        accept=".csv"
-                                        onChange={handleFileUpload}
-                                        className="block w-full text-sm text-gray-700 dark:text-gray-300
-                                            file:mr-4 file:py-2 file:px-4
-                                            file:rounded-full file:border-0
-                                            file:text-sm file:font-semibold
-                                            file:bg-blue-600 file:text-white
-                                            hover:file:bg-blue-700
-                                            file:transition-colors"
-                                    />
+                                    <button
+                                        onClick={handleNativeFileSelect}
+                                        disabled={loading}
+                                        className="w-full px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-full hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                    >
+                                        {loading ? 'Loading...' : 'Choose File'}
+                                    </button>
                                 </HelpWrapper>
                                 <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                                     Accepts CSV files with headers


### PR DESCRIPTION
## Summary
Standardizes file selection button naming to "Choose File" across both desktop apps and implements native OS file dialog for GoPCA.

## Changes

### GoCSV Desktop
- ✏️ Changed button text from "Browse for File" to "Choose File" in main App
- ✏️ Changed button text from "Browse Files" to "Choose File" in FileSelector component
- ✏️ Updated alert message to use "Choose File" terminology
- ✅ Maintains existing multi-format filtering (CSV, TSV, Excel, JSON)

### GoPCA Desktop  
- 🎨 Replaced HTML file input with native OS file dialog button
- ✨ Added `SelectCSVFile()` backend method using Wails runtime dialog
- 🔧 Implemented CSV-only filtering in file dialog
- ✏️ Button shows "Choose File" for consistency

## Implementation Details
- **Backend**: Added `SelectCSVFile()` method to `app.go` that opens native dialog with CSV filtering
- **Frontend**: Created `handleNativeFileSelect()` handler to use the new backend method
- **UI**: Replaced `<input type="file">" with styled button matching the app's design

## Benefits
- 🎯 **Consistency**: Both apps use "Choose File" terminology
- 🖥️ **Native Experience**: OS-specific file dialogs instead of browser-style input
- 📁 **Appropriate Filtering**: Each app filters for its supported formats
- 🎨 **Better UX**: Native dialogs provide familiar user experience

## Testing
- ✅ GoCSV frontend builds successfully
- ✅ GoPCA frontend builds successfully  
- ✅ Wails bindings generated for new backend method
- ✅ Both apps compile without errors

Closes #491