### PR TITLE
fix: file loading in GoPCA Desktop (#493)

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1056,8 +1056,8 @@ func (a *App) LoadIrisDataset() (*FileDataJSON, error) {
 	return a.ParseCSV(modifiedContent)
 }
 
-// SelectCSVFile opens a native file dialog for selecting CSV files
-func (a *App) SelectCSVFile() (string, string, error) {
+// SelectCSVFile opens a native file dialog for selecting CSV files and returns parsed data
+func (a *App) SelectCSVFile() (*FileDataJSON, error) {
 	dialogOptions := runtime.OpenDialogOptions{
 		Title: "Select CSV File",
 		Filters: []runtime.FileFilter{
@@ -1074,21 +1074,22 @@ func (a *App) SelectCSVFile() (string, string, error) {
 
 	filePath, err := runtime.OpenFileDialog(a.ctx, dialogOptions)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open file dialog: %w", err)
+		return nil, fmt.Errorf("failed to open file dialog: %w", err)
 	}
 
 	// User cancelled
 	if filePath == "" {
-		return "", "", nil
+		return nil, nil
 	}
 
 	// Read the file content
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	return filePath, string(content), nil
+	// Parse the CSV content and return the result
+	return a.ParseCSV(string(content))
 }
 
 // LoadDatasetFile loads a CSV file from the embedded data

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -306,19 +306,16 @@ return;
         setPcaError(null); // Clear any previous PCA errors
 
         try {
-            const result = await SelectCSVFile();
-            // Result is a tuple: [filePath, content, error]
-            if (!result || !result[0]) {
-                // User cancelled
+            const parseResult = await SelectCSVFile();
+            
+            // User cancelled
+            if (!parseResult) {
                 setLoading(false);
                 return;
             }
 
-            const [filePath, content] = result;
-            const fileName = filePath.split(/[\\/]/).pop() || 'unknown.csv';
-            setFileName(fileName);
-
-            const parseResult = await ParseCSV(content);
+            // Set a generic filename for display purposes
+            setFileName('Selected File');
             setFileData(parseResult);
             setPcaResponse(null);
             // Reset exclusions and selections when loading new data


### PR DESCRIPTION
## Description
Fixes the critical file loading bug in GoPCA Desktop that was introduced in commit 0f8ef1e.

## Problem
The `SelectCSVFile` function was returning three values `(string, string, error)`, which Wails doesn't properly handle in its JavaScript bindings. This caused file loading to silently fail with no error messages.

## Solution
Changed `SelectCSVFile` to return `(*FileDataJSON, error)` to match Wails binding conventions and existing patterns in the codebase (like `LoadCSVFile`, `LoadIrisDataset`). The function now directly parses the CSV content and returns the parsed data.

## Changes
- Modified `SelectCSVFile` in `app.go` to parse CSV and return `FileDataJSON`
- Updated frontend `handleNativeFileSelect` to handle the new return format
- Regenerated Wails bindings to reflect the changes
- Set a generic filename "Selected File" for display purposes

## Testing
- ✅ Frontend builds successfully
- ✅ Wails dev mode starts without errors
- ✅ All existing tests pass (`make ci-test`)
- ✅ File loading functionality restored

## Impact
This is a critical fix that restores core functionality. The change is backward compatible as it only affects the internal implementation of the file dialog feature.

Closes #493