### PR TITLE
fix: add missing help entry and shorten label for Temporal Loadings visualization

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1297,7 +1297,7 @@ return;
                                                     // Loadings plot not available for kernel PCA (different space) or temporal PCA (dimension mismatch)
                                                     ...(pcaResponse.result.method !== 'kernel' && pcaResponse.result.method !== 'temporal' ? [{ value: 'loadings', label: 'Loadings Plot' }] : []),
                                                     // Temporal loadings pattern - only for temporal PCA
-                                                    ...(pcaResponse.result.method === 'temporal' ? [{ value: 'temporal-loadings', label: 'Temporal Loadings Pattern' }] : []),
+                                                    ...(pcaResponse.result.method === 'temporal' ? [{ value: 'temporal-loadings', label: 'Temporal Loadings' }] : []),
                                                     // Biplot - available for standard PCA with preprocessing (not for kernel PCA or temporal PCA)
                                                     ...(pcaResponse.result.preprocessing_applied && pcaResponse.result.method !== 'kernel' && pcaResponse.result.method !== 'temporal' ? [{ value: 'biplot', label: 'Biplot' }] : []),
                                                     // 3D Biplot and Circle of Correlations - not available for kernel PCA or temporal PCA

--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -225,6 +225,11 @@
       "text": "3D biplot combining scores and loadings. Interactive rotation reveals sample-variable relationships.",
       "category": "visualization"
     },
+    "temporal-loadings-plot": {
+      "title": "Temporal Loadings",
+      "text": "Shows how each component's loadings evolve across time lags for each variable. Reveals temporal patterns and dependencies captured by principal components.",
+      "category": "visualization"
+    },
     "component-selector": {
       "title": "Component Selection",
       "text": "Choose which PCs to plot. PC1 usually most important. Try different combinations.",


### PR DESCRIPTION
## Summary
This PR fixes two UI issues with the Temporal Loadings visualization:
1. Adds the missing help entry for `temporal-loadings-plot` in the help system
2. Shortens the dropdown label from "Temporal Loadings Pattern" to "Temporal Loadings" for UI consistency

## Changes
- Added help entry for `temporal-loadings-plot` in `cmd/gopca-desktop/frontend/src/help/help-content.json`
- Changed dropdown label from "Temporal Loadings Pattern" (25 chars) to "Temporal Loadings" (17 chars) in `cmd/gopca-desktop/frontend/src/App.tsx`

## Label Length Comparison
- Current: "Temporal Loadings Pattern" (25 characters)
- New: "Temporal Loadings" (17 characters)
- For comparison:
  - "Circle of Correlations" (22 characters)
  - "Eigencorrelation Plot" (21 characters)
  - "Kernel Matrix Heatmap" (21 characters)
  - "Sample Contributions" (20 characters)

The shorter label maintains the same semantic meaning while being consistent with other visualization labels.

## Testing
- Frontend builds successfully with no errors
- Pre-commit checks pass

Closes #497