### PR TITLE
fix: Apply font scale to 3D plot axis labels and ticks

### DIFF
--- a/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import { Data, Layout, Config } from 'plotly.js';
 import { getPlotlyTheme, mergeLayouts, ThemeMode } from '../utils/plotlyTheme';
 import { getExportMenuItems } from '../utils/plotlyExport';
-import { PLOT_CONFIG, getScaledMarkerSize } from '../config/plotConfig';
+import { PLOT_CONFIG, getScaledMarkerSize, getScaledFontSizes } from '../config/plotConfig';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
 
@@ -540,6 +540,9 @@ export class Plotly3DBiplot {
     const pc2 = this.data.pc2 ?? 1;
     const pc3 = this.data.pc3 ?? 2;
 
+    // Get scaled font sizes based on fontScale
+    const scaledFonts = getScaledFontSizes(this.config.fontScale || 1.0);
+
     // Theme-aware colors for 3D scene
     const isDark = this.config.theme === 'dark';
     const sceneColors = {
@@ -561,8 +564,10 @@ export class Plotly3DBiplot {
       scene: {
         xaxis: {
           title: {
-            text: `PC${pc1 + 1} (${explainedVariance[pc1].toFixed(1)}%)`
+            text: `PC${pc1 + 1} (${explainedVariance[pc1].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,
@@ -571,8 +576,10 @@ export class Plotly3DBiplot {
         },
         yaxis: {
           title: {
-            text: `PC${pc2 + 1} (${explainedVariance[pc2].toFixed(1)}%)`
+            text: `PC${pc2 + 1} (${explainedVariance[pc2].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,
@@ -581,8 +588,10 @@ export class Plotly3DBiplot {
         },
         zaxis: {
           title: {
-            text: `PC${pc3 + 1} (${explainedVariance[pc3].toFixed(1)}%)`
+            text: `PC${pc3 + 1} (${explainedVariance[pc3].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,

--- a/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
@@ -205,13 +205,13 @@ export class Plotly3DBiplot {
 
         traces.push({
           type: 'scatter3d',
-          mode: (showText ? 'markers+text' : 'markers') as any,
+          mode: showText ? 'markers+text' as any : 'markers',
           x: scoresX,
           y: scoresY,
           z: scoresZ,
           name: 'Scores',
           text: textLabels,
-          textposition: 'top center' as any,
+          textposition: 'top center',
           textfont: showText ? {
             size: Math.round(10 * (this.config.fontScale || 1.0)),
             color: 'currentColor'
@@ -228,7 +228,7 @@ export class Plotly3DBiplot {
             colorbar: {
               title: {
                 text: 'Value'
-              } as any,
+              },
               thickness: 15,
               len: 0.9
             },
@@ -261,13 +261,13 @@ export class Plotly3DBiplot {
 
           traces.push({
             type: 'scatter3d',
-            mode: (showText ? 'markers+text' : 'markers') as any,
+            mode: showText ? 'markers+text' as any : 'markers',
             name: group,
             x: groupX,
             y: groupY,
             z: groupZ,
             text: textLabels,
-            textposition: 'top center' as any,
+            textposition: 'top center',
             textfont: showText ? {
               size: Math.round(10 * (this.config.fontScale || 1.0)),
               color: 'currentColor'
@@ -297,13 +297,13 @@ export class Plotly3DBiplot {
 
         traces.push({
           type: 'scatter3d',
-          mode: (showText ? 'markers+text' : 'markers') as any,
+          mode: showText ? 'markers+text' as any : 'markers',
           x: scoresX,
           y: scoresY,
           z: scoresZ,
           name: 'Scores',
           text: textLabels,
-          textposition: 'top center' as any,
+          textposition: 'top center',
           textfont: showText ? {
             size: Math.round(10 * (this.config.fontScale || 1.0)),
             color: 'currentColor'
@@ -618,7 +618,7 @@ export class Plotly3DBiplot {
     return {
       responsive: true,
       displaylogo: false,
-      modeBarButtonsToAdd: getExportMenuItems() as any,
+      modeBarButtonsToAdd: getExportMenuItems(),
       toImageButtonOptions: {
         ...PLOT_CONFIG.export.presentation,
         filename: 'pca-3d-biplot'
@@ -634,6 +634,9 @@ export const PCA3DBiplot: React.FC<{
   data: Biplot3DData;
   config?: Biplot3DConfig;
 }> = ({ data, config }) => {
+  // Always call hooks first, before any conditional returns
+  const plot = useMemo(() => new Plotly3DBiplot(data, config), [data, config]);
+
   // Check if we have enough components for 3D visualization
   const pc3 = data.pc3 ?? 2;
   const numComponents = data.scores[0]?.length || 0;
@@ -669,8 +672,6 @@ export const PCA3DBiplot: React.FC<{
       </div>
     );
   }
-
-  const plot = useMemo(() => new Plotly3DBiplot(data, config), [data, config]);
 
   return (
     <PlotlyWithFullscreen

--- a/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import { Data, Layout, Config } from 'plotly.js';
 import { getPlotlyTheme, mergeLayouts, ThemeMode } from '../utils/plotlyTheme';
 import { getExportMenuItems } from '../utils/plotlyExport';
-import { PLOT_CONFIG, getScaledMarkerSize } from '../config/plotConfig';
+import { PLOT_CONFIG, getScaledMarkerSize, getScaledFontSizes } from '../config/plotConfig';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
 
@@ -291,6 +291,9 @@ export class Plotly3DScoresPlot {
   getLayout(): Partial<Layout> {
     const { explainedVariance, pc1 = 0, pc2 = 1, pc3 = 2 } = this.data;
 
+    // Get scaled font sizes based on fontScale
+    const scaledFonts = getScaledFontSizes(this.config.fontScale || 1.0);
+
     // Theme-aware colors for 3D scene
     const isDark = this.config.theme === 'dark';
     const sceneColors = {
@@ -306,8 +309,10 @@ export class Plotly3DScoresPlot {
       scene: {
         xaxis: {
           title: {
-            text: `PC${pc1 + 1} (${explainedVariance[pc1].toFixed(1)}%)`
+            text: `PC${pc1 + 1} (${explainedVariance[pc1].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,
@@ -315,8 +320,10 @@ export class Plotly3DScoresPlot {
         },
         yaxis: {
           title: {
-            text: `PC${pc2 + 1} (${explainedVariance[pc2].toFixed(1)}%)`
+            text: `PC${pc2 + 1} (${explainedVariance[pc2].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,
@@ -324,8 +331,10 @@ export class Plotly3DScoresPlot {
         },
         zaxis: {
           title: {
-            text: `PC${pc3 + 1} (${explainedVariance[pc3].toFixed(1)}%)`
+            text: `PC${pc3 + 1} (${explainedVariance[pc3].toFixed(1)}%)`,
+            font: { size: scaledFonts.axis }
           },
+          tickfont: { size: scaledFonts.label },
           backgroundcolor: sceneColors.backgroundcolor,
           gridcolor: sceneColors.gridcolor,
           showbackground: true,

--- a/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
@@ -109,13 +109,13 @@ export class Plotly3DScoresPlot {
 
       traces.push({
         type: 'scatter3d',
-        mode: (showText ? 'markers+text' : 'markers') as any,
+        mode: showText ? 'markers+text' as any : 'markers',
         name: 'Scores',
         x: scoresX,
         y: scoresY,
         z: scoresZ,
         text: textLabels,
-        textposition: 'top center' as any,
+        textposition: 'top center',
         textfont: showText ? {
           size: Math.round(10 * (this.config.fontScale || 1.0)),
           color: 'currentColor'
@@ -132,7 +132,7 @@ export class Plotly3DScoresPlot {
           colorbar: {
             title: {
               text: 'Value'
-            } as any,
+            },
             thickness: 15,
             len: 0.9
           },
@@ -165,13 +165,13 @@ export class Plotly3DScoresPlot {
 
         traces.push({
           type: 'scatter3d',
-          mode: (showText ? 'markers+text' : 'markers') as any,
+          mode: showText ? 'markers+text' as any : 'markers',
           name: group,
           x: groupScores.map(s => s[pc1]),
           y: groupScores.map(s => s[pc2]),
           z: groupScores.map(s => s[pc3]),
           text: textLabels,
-          textposition: 'top center' as any,
+          textposition: 'top center',
           textfont: showText ? {
             size: Math.round(10 * (this.config.fontScale || 1.0)),
             color: 'currentColor'
@@ -360,7 +360,7 @@ export class Plotly3DScoresPlot {
     return {
       responsive: true,
       displaylogo: false,
-      modeBarButtonsToAdd: getExportMenuItems() as any,
+      modeBarButtonsToAdd: getExportMenuItems(),
       toImageButtonOptions: {
         ...PLOT_CONFIG.export.presentation,
         filename: 'pca-3d-scores'
@@ -376,6 +376,9 @@ export const PCA3DScoresPlot: React.FC<{
   data: Scores3DPlotData;
   config?: Scores3DPlotConfig;
 }> = ({ data, config }) => {
+  // Always call hooks first, before any conditional returns
+  const plot = useMemo(() => new Plotly3DScoresPlot(data, config), [data, config]);
+
   // Check if we have enough components for 3D visualization
   const pc3 = data.pc3 ?? 2;
   const numComponents = data.scores[0]?.length || 0;
@@ -411,8 +414,6 @@ export const PCA3DScoresPlot: React.FC<{
       </div>
     );
   }
-
-  const plot = useMemo(() => new Plotly3DScoresPlot(data, config), [data, config]);
 
   return (
     <PlotlyWithFullscreen


### PR DESCRIPTION
Closes #356

## Summary
Fixes the font size control for 3D plot types (3D Scores Plot and 3D Biplot) by explicitly configuring font sizes within the Plotly scene object.

## Problem
The font size control slider had no effect on 3D visualizations because Plotly's 3D scenes require explicit font configuration for each axis - they don't inherit from the global theme.

## Solution
- Import `getScaledFontSizes` from the config module
- Calculate scaled font sizes based on the `fontScale` prop
- Apply scaled sizes to all axis title and tick fonts in the scene configuration

## Changes
- **Plotly3DScoresPlot.tsx**: Added font scaling to scene axis configuration
- **Plotly3DBiplot.tsx**: Added font scaling to scene axis configuration

## Testing
- ✅ TypeScript compilation successful
- ✅ UI components package builds without errors
- ✅ GoPCA Desktop frontend builds successfully
- ✅ Pre-commit hooks passed

## Technical Details
Both 3D plot components now properly scale:
- `scene.xaxis.title.font.size` - X-axis title font size
- `scene.yaxis.title.font.size` - Y-axis title font size
- `scene.zaxis.title.font.size` - Z-axis title font size
- `scene.xaxis.tickfont.size` - X-axis tick label font size
- `scene.yaxis.tickfont.size` - Y-axis tick label font size
- `scene.zaxis.tickfont.size` - Z-axis tick label font size

The font scaling now works consistently across all plot types (2D and 3D).