### PR TITLE
fix: Import ui-components CSS to fix LaTeX math duplication

### DIFF
--- a/cmd/gocsv/frontend/src/main.tsx
+++ b/cmd/gocsv/frontend/src/main.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './style.css';
+import '@gopca/ui-components/dist/ui-components.css';
 import App from './App';
 
 const container = document.getElementById('root');

--- a/cmd/gopca-desktop/frontend/src/main.tsx
+++ b/cmd/gopca-desktop/frontend/src/main.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './style.css';
+import '@gopca/ui-components/dist/ui-components.css';
 import App from './App';
 
 const container = document.getElementById('root');

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -43,6 +43,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.esjs",
       "require": "./dist/index.js"
-    }
+    },
+    "./dist/ui-components.css": "./dist/ui-components.css"
   }
 }

--- a/packages/ui-components/src/components/MarkdownRenderer.tsx
+++ b/packages/ui-components/src/components/MarkdownRenderer.tsx
@@ -27,21 +27,6 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className = ''
 }) => {
-  // Preprocess markdown to fix display math blocks with $$ on separate lines
-  // This converts multiline display math blocks into single-line format to prevent duplication
-  const preprocessedContent = React.useMemo(() => {
-    // Pattern: $$ on its own line, followed by content, followed by $$ on its own line
-    // Replace with: $$content$$ on a single line
-    return content.replace(
-      /^\$\$\s*\n([\s\S]*?)\n\$\$\s*$/gm,
-      (_match, formula) => {
-        // Trim the formula and put it on a single line with $$
-        const trimmedFormula = formula.trim();
-        return `$$${trimmedFormula}$$`;
-      }
-    );
-  }, [content]);
-
   return (
     <div className={`prose prose-lg dark:prose-invert max-w-none text-left
       prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-headings:text-left
@@ -163,7 +148,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           }
         }}
       >
-        {preprocessedContent}
+        {content}
       </ReactMarkdown>
     </div>
   );

--- a/packages/ui-components/src/components/MarkdownRenderer.tsx
+++ b/packages/ui-components/src/components/MarkdownRenderer.tsx
@@ -27,6 +27,21 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className = ''
 }) => {
+  // Preprocess markdown to fix display math blocks with $$ on separate lines
+  // This converts multiline display math blocks into single-line format to prevent duplication
+  const preprocessedContent = React.useMemo(() => {
+    // Pattern: $$ on its own line, followed by content, followed by $$ on its own line
+    // Replace with: $$content$$ on a single line
+    return content.replace(
+      /^\$\$\s*\n([\s\S]*?)\n\$\$\s*$/gm,
+      (_match, formula) => {
+        // Trim the formula and put it on a single line with $$
+        const trimmedFormula = formula.trim();
+        return `$$${trimmedFormula}$$`;
+      }
+    );
+  }, [content]);
+
   return (
     <div className={`prose prose-lg dark:prose-invert max-w-none text-left
       prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-headings:text-left
@@ -133,7 +148,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
             </td>
           ),
           // Custom image component to handle relative paths
-          img: ({ node, src, alt, ...props }) => {
+          img: ({ src, alt, ...props }) => {
             // If the src is a relative path starting with 'images/', prepend the docs path
             const imageSrc = src?.startsWith('images/') ? `/docs/${src}` : src;
             return (
@@ -148,7 +163,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           }
         }}
       >
-        {content}
+        {preprocessedContent}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes the LaTeX math formula duplication issue by ensuring KaTeX CSS is properly loaded in both GoPCA Desktop and GoCSV Desktop.

## Root Cause
The math formulas were appearing twice because:
1. KaTeX renders math twice by design - once as HTML for display and once as MathML for accessibility
2. The MathML version should be hidden by KaTeX CSS
3. The CSS from ui-components (including KaTeX CSS) was never imported in the consuming applications
4. Without the CSS, both renderings were visible

## Solution
Added CSS import from ui-components package to both desktop applications. This ensures all component styles, including the critical KaTeX CSS, are properly loaded.

## Changes
- ✅ Add `@gopca/ui-components/dist/ui-components.css` import to GoPCA Desktop main.tsx
- ✅ Add same CSS import to GoCSV Desktop main.tsx
- ✅ Update ui-components package.json to export the CSS file
- ✅ Remove unnecessary markdown preprocessing from MarkdownRenderer (wasn't the issue)

## Testing
- Built and tested GoPCA Desktop - math formulas now render correctly without duplication
- Built and tested GoCSV Desktop - same fix applies
- All existing functionality preserved

## Why This Approach
- **Simplest**: Single line addition to each app's main.tsx
- **Maintainable**: CSS stays bundled with components
- **DRY**: All shared component styles managed in one place
- **Complete**: Includes all styles from shared components, not just KaTeX

Closes #532