### PR TITLE
fix: Add Z-axis component selector for 3D Biplot visualization

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1517,7 +1517,7 @@ return;
                                                         className="min-w-[150px]"
                                                     />
                                                 </div>
-                                                {selectedPlot === 'scores3d' && pcaResponse.result.scores[0]?.length > 2 && (
+                                                {(selectedPlot === 'scores3d' || selectedPlot === 'biplot3d') && pcaResponse.result.scores[0]?.length > 2 && (
                                                     <div className="flex items-center gap-2">
                                                         <label className="text-sm text-gray-600 dark:text-gray-400">Z:</label>
                                                         <CustomSelect


### PR DESCRIPTION
## Summary
Fixes the missing Z-axis component selector dropdown when using 3D Biplot visualization.

## Problem
When selecting "3D Biplot" from the visualization dropdown in GoPCA Desktop, only the X and Y component selectors were displayed, making it impossible to choose which component to display on the Z-axis.

## Solution
Updated the conditional rendering at line 1520 in `App.tsx` to include both `scores3d` and `biplot3d` plot types:

```typescript
// Before:
{selectedPlot === 'scores3d' && ...}

// After:
{(selectedPlot === 'scores3d' || selectedPlot === 'biplot3d') && ...}
```

This follows the existing pattern used elsewhere in the codebase where both 3D plot types are checked together.

## Testing
- Built and ran GoPCA Desktop in dev mode
- Loaded a CSV file and ran PCA with preprocessing enabled
- Verified that selecting "3D Biplot" now shows all three component selectors (X, Y, Z)
- Confirmed TypeScript compilation passes

Closes #533