### PR TITLE
feat: change default coef0 value for polynomial kernel from 0 to 1

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -111,7 +111,7 @@ function AppContent() {
         kernelType: 'rbf',
         kernelGamma: 1.0,
         kernelDegree: 3,
-        kernelCoef0: 0.0,
+        kernelCoef0: 1.0,
         // Temporal PCA parameters
         temporalLags: 10,
         varianceExplained: 0.0
@@ -1012,7 +1012,7 @@ return;
                                                                 step="0.1"
                                                                 onChange={(e) => {
                                                                     const value = parseFloat(e.target.value);
-                                                                    setConfig({ ...config, kernelCoef0: isNaN(value) ? 0.0 : value });
+                                                                    setConfig({ ...config, kernelCoef0: isNaN(value) ? 1.0 : value });
                                                                 }}
                                                                 className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                                                             />

--- a/cmd/gopca-desktop/frontend/src/help/help-content.json
+++ b/cmd/gopca-desktop/frontend/src/help/help-content.json
@@ -72,7 +72,7 @@
     },
     "kernel-coef0": {
       "title": "Polynomial Coefficient",
-      "text": "Independent term in polynomial kernel. Usually 0 or 1.",
+      "text": "Independent term in polynomial kernel. Default is 1 for numerical stability. Set to 0 for traditional polynomial kernel.",
       "category": "configuration"
     },
     "temporal-lags": {

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -96,7 +96,7 @@ pca analyze [OPTIONS] <input.csv>
 - `--kernel-type <type>` - Kernel type: `rbf`, `linear`, or `poly`
 - `--kernel-gamma <value>` - Gamma parameter for RBF and polynomial kernels (default: 0.01)
 - `--kernel-degree <n>` - Degree for polynomial kernel (default: 3)
-- `--kernel-coef0 <value>` - Coef0 for polynomial kernel (default: 0)
+- `--kernel-coef0 <value>` - Coef0 for polynomial kernel (default: 1)
 
 ##### Data Format Options
 - `--no-headers` - First row contains data, not column names

--- a/internal/cobra/analyze.go
+++ b/internal/cobra/analyze.go
@@ -125,7 +125,7 @@ EXAMPLES:
 		"Gamma parameter for RBF/poly kernels")
 	cmd.Flags().IntVar(&opts.KernelDegree, "kernel-degree", 3,
 		"Degree for polynomial kernel")
-	cmd.Flags().Float64Var(&opts.KernelCoef0, "kernel-coef0", 0.0,
+	cmd.Flags().Float64Var(&opts.KernelCoef0, "kernel-coef0", 1.0,
 		"Coef0 for polynomial kernel")
 
 	// Temporal PCA parameters


### PR DESCRIPTION
## Summary
This PR changes the default value of the coef0 parameter in kernel PCA when using polynomial kernel from 0 to 1 for improved numerical stability and flexibility.

## Changes
- Update CLI default in `internal/cobra/analyze.go` from 0.0 to 1.0
- Update GUI default in `cmd/gopca-desktop/frontend/src/App.tsx` from 0.0 to 1.0
- Update documentation in `docs/cli_reference.md` to reflect new default
- Update help text in `help-content.json` explaining the new default

## Rationale
The current default value of `coef0 = 0` in the polynomial kernel can cause numerical instabilities, especially when:
- Working with standardized data or data with small values
- The kernel outputs very small numbers, weakening the learning process
- Inputs are near zero, causing the kernel to be unresponsive

Setting `coef0 = 1` provides several benefits:
1. **Numerical Stability**: Ensures the kernel responds reliably even when inputs are small or near zero
2. **Flexibility**: Allows the kernel to capture both simple linear relationships and complex polynomial interactions
3. **Robustness**: Works more consistently across different types of data and preprocessing methods
4. **Industry Standard**: Many machine learning libraries (e.g., scikit-learn) use coef0=1 as default for similar reasons

## Testing
- ✅ Polynomial kernel works with new default coef0=1
- ✅ Users can explicitly set coef0=0 if needed
- ✅ All kernel PCA tests pass
- ✅ Tested with iris dataset using both values

## Backward Compatibility
Users who specifically need `coef0 = 0` can still explicitly set it via:
- CLI: `--kernel-coef0 0`
- GUI: Manual configuration in the interface

## References
- Schölkopf, B., & Smola, A. J. (2002). Learning with Kernels. MIT Press.
- scikit-learn polynomial kernel documentation

Closes #541