### PR TITLE
fix: preserve unselected rows in table after plot selection

### DIFF
--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -497,52 +497,9 @@ return;
                 // Clear any previous errors
                 setPcaError(null);
 
-                // If we had excluded rows, update fileData to reflect the filtered dataset
-                if (excludedRows.length > 0) {
-                    setPcaHasExclusions(true);  // Mark that this PCA was run with exclusions
-                    const includedIndices = fileData.data
-                        .map((_, i) => i)
-                        .filter(i => !excludedRows.includes(i));
-
-                    const filteredData = includedIndices.map(i => fileData.data[i]);
-                    const filteredRowNames = includedIndices.map(i => fileData.rowNames[i]);
-
-                    // Update categorical and numeric columns if they exist
-                    const filteredCategorical: Record<string, string[]> = {};
-                    const filteredNumeric: Record<string, number[]> = {};
-
-                    if (fileData.categoricalColumns) {
-                        Object.keys(fileData.categoricalColumns).forEach(col => {
-                            filteredCategorical[col] = includedIndices.map(i =>
-                                fileData.categoricalColumns![col][i]
-                            );
-                        });
-                    }
-
-                    if (fileData.numericTargetColumns) {
-                        Object.keys(fileData.numericTargetColumns).forEach(col => {
-                            filteredNumeric[col] = includedIndices.map(i =>
-                                fileData.numericTargetColumns![col][i]
-                            );
-                        });
-                    }
-
-                    // Clear excluded rows before updating fileData
-                    setExcludedRows([]);
-
-                    // Then update fileData with filtered dataset
-                    setFileData({
-                        ...fileData,
-                        data: filteredData,
-                        rowNames: filteredRowNames,
-                        categoricalColumns: Object.keys(filteredCategorical).length > 0 ? filteredCategorical : undefined,
-                        numericTargetColumns: Object.keys(filteredNumeric).length > 0 ? filteredNumeric : undefined
-                    });
-                    // Force table components to reset their selection state for the new dataset
-                    setDatasetId(prev => prev + 1);
-                } else {
-                    setPcaHasExclusions(false);  // No exclusions in this PCA
-                }
+                // Track whether this PCA was run with exclusions (for UI feedback)
+                // Note: We keep the original fileData intact - the backend handles exclusions
+                setPcaHasExclusions(excludedRows.length > 0);
 
                 // Check if Kernel PCA is selected with unsupported visualization
                 if (config.method === 'kernel' &&


### PR DESCRIPTION
## Summary
Fixes #543 - Preserves unselected rows in the table view after plot selection by removing destructive data filtering.

## Problem
Previously, when users selected points in plots via lasso tool:
1. Plot selection toggled checkboxes in table (expected)
2. Running PCA with exclusions **permanently removed** excluded rows from fileData
3. Users had to reload the entire dataset to recover excluded rows
4. This created a destructive UX where exploratory plot interactions had permanent consequences

## Solution
Remove the destructive filtering code (lines 501-542) that modified fileData after PCA runs. The backend already handles row exclusions correctly via the `excludedRows` parameter, so this filtering was unnecessary and harmful.

## Changes
- **Removed**: 43 lines of destructive data filtering code
- **Added**: Simple 3-line solution that tracks exclusions for UI feedback
- **Result**: Original fileData stays intact, exclusions handled by backend

## Benefits
✅ **Non-destructive**: Excluded rows remain visible in table view  
✅ **Reversible**: Users can toggle exclusions on/off without reloading  
✅ **Simpler code**: Removed 43 lines of complex filtering logic  
✅ **Follows SoC**: Data storage (fileData) decoupled from filtering (backend)  
✅ **KISS principle**: Leverage existing backend functionality  

## Testing
- ✅ TypeScript compilation passes
- ✅ Backend tests pass
- ✅ No new linting errors introduced

## How to Test
1. Load a dataset in GoPCA Desktop
2. Use lasso tool to select/unselect points in plots
3. Verify checkboxes update correctly
4. Run PCA with some rows excluded
5. ✅ Verify excluded rows still visible in table (previously they disappeared)
6. Toggle exclusions back on via checkboxes
7. Run PCA again
8. ✅ Verify all rows included in analysis

## Code Review Notes
This is a clean simplification that removes unnecessary complexity. The backend was already handling exclusions correctly - we were just duplicating and destructively modifying the frontend state.

**Before**: Frontend filtered data → backend analyzed filtered data  
**After**: Frontend keeps all data → backend filters during analysis  

The separation of concerns is now clearer and matches the KISS principle.