### PR TITLE
Release v1.1.5

### DIFF
--- a/cmd/gocsv/wails.json
+++ b/cmd/gocsv/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoCSV - GoPCA CSV Editor",
-    "productVersion": "1.1.4",
+    "productVersion": "1.1.5",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Data Editor for GoPCA"
   },

--- a/cmd/gopca-desktop/wails.json
+++ b/cmd/gopca-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "bitjungle",
     "productName": "GoPCA Desktop",
-    "productVersion": "1.1.4",
+    "productVersion": "1.1.5",
     "copyright": "Copyright © 2025 bitjungle",
     "comments": "Professional PCA Analysis Tool"
   },


### PR DESCRIPTION
## Release v1.1.5 - MSIX Identity Fix

This is a **patch release** to fix the MSIX package identity mismatch that prevented Microsoft Store submission.

### What Changed
- Corrected MSIX package identity name from `BitjungleGoPCA` to `bitjungle.GoPCA`
- This matches the reserved app name in Microsoft Partner Center
- Fixes Partner Center validation error: "Invalid package identity name"

### Files Changed
- `cmd/gopca-desktop/AppxManifest.template.xml` - Corrected identity name
- Version bumped to 1.1.5 in wails.json files

### Why This Release
v1.1.4 MSIX package cannot be uploaded to Partner Center due to identity mismatch. This patch release generates a correctly formatted MSIX package that Partner Center will accept.

### Post-Merge
After merging, run:
```bash
git checkout main && git pull
./scripts/release.sh v1.1.5
```

The automated workflow will build a corrected MSIX package: `GoPCA_1.1.5.0_x64.msix`