### PR TITLE
fix: check scores nil before calling Dims() in CalculateGroupEllipses (#571)

### DIFF
--- a/internal/core/statistics.go
+++ b/internal/core/statistics.go
@@ -106,12 +106,12 @@ func chiSquareValue(confidenceLevel float64, df int) float64 {
 // groups is a slice indicating the group membership of each observation.
 // pcX and pcY are the indices of the principal components to use (0-based).
 func CalculateGroupEllipses(scores mat.Matrix, groups []string, pcX, pcY int, confidenceLevel float64) (map[string]EllipseParams, error) {
-	rows, cols := scores.Dims()
-
 	// Validate inputs
 	if scores == nil {
 		return nil, fmt.Errorf("scores matrix is nil")
 	}
+
+	rows, cols := scores.Dims()
 	if len(groups) == 0 {
 		return nil, fmt.Errorf("groups slice is empty")
 	}

--- a/internal/core/statistics_test.go
+++ b/internal/core/statistics_test.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"gonum.org/v1/gonum/mat"
@@ -190,6 +191,13 @@ func TestCalculateGroupEllipsesEdgeCases(t *testing.T) {
 			pcX:    2, // Out of bounds
 			pcY:    0,
 		},
+		{
+			name:   "nil scores matrix",
+			scores: nil,
+			groups: []string{"A", "B"},
+			pcX:    0,
+			pcY:    1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -197,6 +205,13 @@ func TestCalculateGroupEllipsesEdgeCases(t *testing.T) {
 			ellipses, err := CalculateGroupEllipses(tt.scores, tt.groups, tt.pcX, tt.pcY, 0.95)
 
 			switch tt.name {
+			case "nil scores matrix":
+				if err == nil {
+					t.Error("Expected error for nil scores matrix")
+				}
+				if err != nil && !strings.Contains(err.Error(), "scores matrix is nil") {
+					t.Errorf("Expected 'scores matrix is nil' error, got: %v", err)
+				}
 			case "PC indices out of bounds":
 				if err == nil {
 					t.Error("Expected error for out of bounds PC indices")


### PR DESCRIPTION
## Problem

`CalculateGroupEllipses` called `scores.Dims()` at line 109 before checking `if scores == nil` at line 112, causing a **panic on nil input** instead of returning a clean error message.

## Root Cause

The nil check validation was placed AFTER the Dims() method call, making the guard unreachable for nil inputs:

```go
func CalculateGroupEllipses(scores mat.Matrix, ...) (map[string]EllipseParams, error) {
    rows, cols := scores.Dims()  // Line 109 - PANICS if scores == nil
    
    // Validate inputs
    if scores == nil {            // Line 112 - UNREACHABLE for nil input
        return nil, fmt.Errorf("scores matrix is nil")
    }
    // ...
}
```

The program would panic with a nil pointer dereference before the error handling code could run.

## Solution

### 1. Reorder Validation (statistics.go)

Move the nil check to happen BEFORE the Dims() call:

```go
func CalculateGroupEllipses(scores mat.Matrix, ...) (map[string]EllipseParams, error) {
    // Validate inputs - CHECK NIL FIRST
    if scores == nil {
        return nil, fmt.Errorf("scores matrix is nil")
    }
    
    rows, cols := scores.Dims()  // Now safe to call
    // ...
}
```

This follows Go defensive programming best practices.

### 2. Add Regression Test (statistics_test.go)

Added new test case "nil scores matrix" to `TestCalculateGroupEllipsesEdgeCases`:
- Verifies function returns error (not panic)
- Checks error message contains "scores matrix is nil"
- Prevents future regression

## Impact

**Before Fix**: `CalculateGroupEllipses(nil, ...) → PANIC`

**After Fix**: `CalculateGroupEllipses(nil, ...) → error: "scores matrix is nil"`

## Changes

### Files Modified
- `internal/core/statistics.go`: Reordered nil check (lines 109-114)
- `internal/core/statistics_test.go`: Added test case + `strings` import

## Testing

✅ New test "nil scores matrix" passes  
✅ All existing `CalculateGroupEllipses` tests pass  
✅ No behavioral changes to valid inputs  
✅ Function now gracefully handles nil input with clear error message  

## Risk Assessment

**Risk Level**: Very Low

- Only changes error handling path (no logic changes)
- Simple reordering (no complex refactoring)
- Isolated to single function
- Comprehensive test coverage added

Fixes #571