### PR TITLE
test: fix race conditions in EventBus tests (#580)

### DIFF
--- a/pkg/integration/event_bus_test.go
+++ b/pkg/integration/event_bus_test.go
@@ -22,51 +22,58 @@ func TestEventBus_NewEventBus(t *testing.T) {
 
 func TestEventBus_SubscribeAndPublish(t *testing.T) {
 	bus := NewEventBus()
-	received := false
+	received := make(chan bool, 1)
 
 	bus.Subscribe(EventDataLoaded, func(event Event) {
-		received = true
 		if event.Type != EventDataLoaded {
 			t.Errorf("expected type %v, got %v", EventDataLoaded, event.Type)
 		}
+		received <- true
 	})
 
 	bus.Publish(Event{Type: EventDataLoaded, Data: map[string]interface{}{"test": "data"}})
 
-	time.Sleep(50 * time.Millisecond)
-
-	if !received {
-		t.Error("event was not received by subscriber")
+	select {
+	case <-received:
+		// Success - event was received
+	case <-time.After(time.Second):
+		t.Error("timeout: event was not received by subscriber")
 	}
 }
 
 func TestEventBus_MultipleSubscribers(t *testing.T) {
 	bus := NewEventBus()
-	count := 0
+	received := make(chan struct{}, 2)
 
 	bus.Subscribe(EventDataLoaded, func(event Event) {
-		count++
+		received <- struct{}{}
 	})
 
 	bus.Subscribe(EventDataLoaded, func(event Event) {
-		count++
+		received <- struct{}{}
 	})
 
 	bus.Publish(Event{Type: EventDataLoaded})
 
-	time.Sleep(50 * time.Millisecond)
-
-	if count != 2 {
-		t.Errorf("expected 2 callbacks, got %d", count)
+	// Wait for both subscribers to receive the event
+	timeout := time.After(time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-received:
+			// Success - subscriber received event
+		case <-timeout:
+			t.Errorf("timeout: only %d of 2 subscribers received event", i)
+			return
+		}
 	}
 }
 
 func TestEventBus_Unsubscribe(t *testing.T) {
 	bus := NewEventBus()
-	received := false
+	received := make(chan bool, 1)
 
 	handler := func(event Event) {
-		received = true
+		received <- true
 	}
 
 	unsubscribe := bus.Subscribe(EventDataLoaded, handler)
@@ -74,29 +81,32 @@ func TestEventBus_Unsubscribe(t *testing.T) {
 
 	bus.Publish(Event{Type: EventDataLoaded})
 
-	time.Sleep(50 * time.Millisecond)
-
-	if received {
+	// Should timeout since handler was unsubscribed
+	select {
+	case <-received:
 		t.Error("unsubscribed handler should not receive events")
+	case <-time.After(100 * time.Millisecond):
+		// Success - handler did not receive event (timeout expected)
 	}
 }
 
 func TestEventBus_PublishAsync(t *testing.T) {
 	bus := NewEventBus()
-	received := false
+	received := make(chan bool, 1)
 
 	bus.Subscribe(EventPCAStarted, func(event Event) {
 		time.Sleep(10 * time.Millisecond)
-		received = true
+		received <- true
 	})
 
 	ctx := context.Background()
 	bus.PublishAsync(ctx, Event{Type: EventPCAStarted})
 
-	time.Sleep(100 * time.Millisecond)
-
-	if !received {
-		t.Error("async event was not received")
+	select {
+	case <-received:
+		// Success - async event was received
+	case <-time.After(time.Second):
+		t.Error("timeout: async event was not received")
 	}
 }
 
@@ -144,17 +154,18 @@ func TestProgressTracker_Update(t *testing.T) {
 	bus := NewEventBus()
 	tracker := NewProgressTracker(bus, "test-task", 10)
 
-	received := false
+	received := make(chan bool, 1)
 	bus.Subscribe(EventProgressUpdate, func(event Event) {
-		received = true
+		received <- true
 	})
 
 	tracker.Update(5)
 
-	time.Sleep(50 * time.Millisecond)
-
-	if !received {
-		t.Error("progress update event not received")
+	select {
+	case <-received:
+		// Success - progress update event received
+	case <-time.After(time.Second):
+		t.Error("timeout: progress update event not received")
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes data race conditions in `pkg/integration/event_bus_test.go` that were preventing successful pre-commit hooks with race detection enabled.

## Problem
Five tests had unsafe concurrent access to shared variables:
- `TestEventBus_SubscribeAndPublish` - race on `bool` flag
- `TestEventBus_MultipleSubscribers` - race on `int` counter  
- `TestEventBus_Unsubscribe` - race on `bool` flag
- `TestEventBus_PublishAsync` - race on `bool` flag
- `TestProgressTracker_Update` - race on `bool` flag

**Root Cause:** EventBus calls handlers in goroutines (`go handler(event)` at line 110), but tests used unsynchronized variables and `time.Sleep()` for coordination.

## Solution
Replaced unsafe shared variables with **channels** for proper synchronization:

**Before (unsafe):**
```go
received := false
bus.Subscribe(EventDataLoaded, func(event Event) {
    received = true  // ⚠️ Write in goroutine
})
bus.Publish(Event{Type: EventDataLoaded})
time.Sleep(50 * time.Millisecond)  // ⚠️ Unreliable
if !received {  // ⚠️ Read in main goroutine - RACE!
    t.Error("...")
}
```

**After (safe):**
```go
received := make(chan bool, 1)
bus.Subscribe(EventDataLoaded, func(event Event) {
    received <- true  // ✅ Safe channel send
})
bus.Publish(Event{Type: EventDataLoaded})
select {
case <-received:
    // Success
case <-time.After(time.Second):
    t.Error("timeout waiting for event")
}
```

## Testing
```bash
# All race tests pass
go test -race ./pkg/integration/...
# ✅ ok  	github.com/bitjungle/gopca/pkg/integration	1.799s

# Full test suite with race detection
go test -race ./internal/... ./pkg/... ./cmd/gopca-cli/...
# ✅ All tests pass, no races detected

# Pre-commit hooks (with race detection)
git commit
# ✅ All checks passed
```

## Benefits
- ✅ Eliminates all data races in EventBus tests
- ✅ Tests run faster (no unnecessary `time.Sleep()`)
- ✅ More reliable (proper synchronization with timeouts)
- ✅ Pre-commit hooks with `-race` now work
- ✅ Follows Go concurrency best practices
- ✅ Consistent with patterns in codebase (e.g., `internal/core/performance_test.go`)

## Impact
- No changes to production code
- Only test synchronization improvements
- No breaking changes

Fixes #580