### PR TITLE
fix: CLI command generator uses actual file paths (#585)

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1056,8 +1056,14 @@ func (a *App) LoadIrisDataset() (*FileDataJSON, error) {
 	return a.ParseCSV(modifiedContent)
 }
 
-// SelectCSVFile opens a native file dialog for selecting CSV files and returns parsed data
-func (a *App) SelectCSVFile() (*FileDataJSON, error) {
+// FileSelectionResult contains both parsed data and the file path
+type FileSelectionResult struct {
+	Data     *FileDataJSON `json:"data"`
+	FilePath string        `json:"filePath"`
+}
+
+// SelectCSVFile opens a native file dialog for selecting CSV files and returns parsed data with file path
+func (a *App) SelectCSVFile() (*FileSelectionResult, error) {
 	dialogOptions := runtime.OpenDialogOptions{
 		Title: "Select CSV File",
 		Filters: []runtime.FileFilter{
@@ -1088,8 +1094,17 @@ func (a *App) SelectCSVFile() (*FileDataJSON, error) {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	// Parse the CSV content and return the result
-	return a.ParseCSV(string(content))
+	// Parse the CSV content
+	data, err := a.ParseCSV(string(content))
+	if err != nil {
+		return nil, err
+	}
+
+	// Return both parsed data and file path
+	return &FileSelectionResult{
+		Data:     data,
+		FilePath: filePath,
+	}, nil
 }
 
 // LoadDatasetFile loads a CSV file from the embedded data

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -64,6 +64,7 @@ function AppContent() {
     const { setMode } = usePalette();
     const [fileData, setFileData] = useState<FileData | null>(null);
     const [fileName, setFileName] = useState<string>('');
+    const [filePath, setFilePath] = useState<string>(''); // Actual file path for CLI commands
     const [pcaResponse, setPcaResponse] = useState<PCAResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [fileError, setFileError] = useState<string | null>(null);
@@ -284,6 +285,7 @@ function AppContent() {
             const result = await LoadDatasetFile(filename);
             setFileData(result);
             setFileName(filename); // Store the sample dataset filename
+            setFilePath(''); // Built-in datasets don't have real file paths
             setPcaResponse(null);
             setExcludedRows([]);
             setExcludedColumns([]);
@@ -327,17 +329,26 @@ function AppContent() {
         setPcaError(null); // Clear any previous PCA errors
 
         try {
-            const parseResult = await SelectCSVFile();
+            const result = await SelectCSVFile();
 
             // User cancelled
-            if (!parseResult) {
+            if (!result) {
                 setLoading(false);
                 return;
             }
 
-            // Set a generic filename for display purposes
+            // Extract data and file path from result
+            const { data, filePath: selectedFilePath } = result;
+
+            // Ensure data is present
+            if (!data) {
+                throw new Error('No data returned from file selection');
+            }
+
+            // Set display name and actual file path
             setFileName('Selected File');
-            setFileData(parseResult);
+            setFilePath(selectedFilePath); // Store actual path for CLI commands
+            setFileData(data);
             setPcaResponse(null);
             // Reset exclusions and selections when loading new data
             setExcludedRows([]);
@@ -347,7 +358,7 @@ function AppContent() {
             setDatasetId(prev => prev + 1); // Force DataTable re-render
 
             // Calculate and set default gamma for kernel PCA
-            updateGammaForData(parseResult);
+            updateGammaForData(data);
         } catch (err) {
             console.error('File selection failed:', err);
             setFileError(`Failed to load file: ${err}`);
@@ -430,6 +441,7 @@ function AppContent() {
     const generateCLICommand = (): string => {
         return generateCLICommandUtil({
             fileName,
+            filePath,
             components: config.components,
             method: config.method,
             kernelType: config.kernelType,

--- a/cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts
@@ -5,6 +5,7 @@ import { optimizeToRanges } from './rangeOptimizer';
 
 export interface CLIConfig {
     fileName?: string;
+    filePath?: string;
     components: number;
     method: string;
     kernelType?: string;
@@ -32,12 +33,16 @@ export interface CLIConfig {
 export function generateCLICommand(config: CLIConfig): string {
     let cmd = 'pca analyze';
 
+    // Use filePath if available (user file), otherwise fileName (built-in dataset)
+    // For built-in datasets, fileName is just for illustration
+    const pathToUse = config.filePath || config.fileName;
+
     // Add file path (with quotes if it contains spaces)
-    if (config.fileName) {
-        if (config.fileName.includes(' ')) {
-            cmd += ` "${config.fileName}"`;
+    if (pathToUse) {
+        if (pathToUse.includes(' ')) {
+            cmd += ` "${pathToUse}"`;
         } else {
-            cmd += ` ${config.fileName}`;
+            cmd += ` ${pathToUse}`;
         }
     }
 


### PR DESCRIPTION
## Fixes
#585 

## Summary
The CLI command generator in GoPCA Desktop now uses actual file paths instead of display names, making generated commands runnable for user-selected files while keeping illustrative examples for built-in datasets.

## Changes

### Backend (`cmd/gopca-desktop/app.go`)
- Added `FileSelectionResult` struct containing both parsed data and file path
- Modified `SelectCSVFile()` to return the new type with full absolute path

### Frontend (`cmd/gopca-desktop/frontend/src/App.tsx`)
- Added `filePath` state variable to track actual file paths separately from display names
- Updated `handleNativeFileSelect()` to extract and store file path from backend
- Updated `loadDataset()` to set `filePath` to empty string for built-in datasets

### CLI Generator (`cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts`)
- Added `filePath` parameter to `CLIConfig` interface
- Updated logic to prefer `filePath` (user files) over `fileName` (built-in datasets)

## Behavior

**Built-in Datasets:**
- CLI command shows: `pca analyze iris.csv`
- Purpose: Illustrative - helps users understand CLI syntax

**User-Selected Files:**
- CLI command shows: `pca analyze /full/path/to/file.csv`
- Purpose: Actually runnable command with copy-paste capability

## Testing
- ✅ Pre-commit hooks passed (go fmt, go vet, tests)
- ✅ CI tests passed (`make ci-test`)
- ✅ Application compiles and runs successfully
- ✅ Wails TypeScript bindings auto-regenerated

## Files Modified
- `cmd/gopca-desktop/app.go`
- `cmd/gopca-desktop/frontend/src/App.tsx`
- `cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts`

## Note
The Wails-generated TypeScript bindings (`frontend/wailsjs/`) are not committed as they're auto-generated and in `.gitignore`.