### PR TITLE
fix: add await to ClearHistory() calls in GoCSV App.tsx (#587)

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -125,7 +125,7 @@ function AppContent() {
                 setFileData(result);
                 setFileLoaded(true);
                 // Clear history when loading new file
-                ClearHistory();
+                await ClearHistory();
                 // Clear any previous analysis
                 setMissingValueStats(null);
                 setDataQualityReport(null);
@@ -150,7 +150,7 @@ function AppContent() {
                 setFileLoaded(true);
                 // Filename will be set by the event from backend
                 // Clear history when loading new file
-                ClearHistory();
+                await ClearHistory();
             } else {
                 console.error('Invalid file data received:', result);
                 throw new Error('No data found in file');


### PR DESCRIPTION
## Summary
- Added missing `await` keywords to two `ClearHistory()` calls in GoCSV App.tsx
- Ensures proper promise handling and prevents potential race conditions
- Both calls already within try-catch blocks in async functions

## Changes
- Line 128: `handleDroppedFile` - Added await to ClearHistory()
- Line 153: `handleLoadFromDialog` - Added await to ClearHistory()

## Testing
- TypeScript compilation: ✅ Passed
- CI tests: ✅ All tests passed
- Pre-commit hooks: ✅ Passed

Fixes #587