### PR TITLE
fix: add RFC 4180 compliant CSV field escaping (#588)

### DIFF
--- a/packages/ui-components/src/charts/utils/plotlyExport.ts
+++ b/packages/ui-components/src/charts/utils/plotlyExport.ts
@@ -87,6 +87,33 @@ export async function downloadPlot(
 }
 
 /**
+ * Escapes a CSV field value according to RFC 4180
+ *
+ * Fields containing commas, quotes, newlines, or carriage returns must be quoted.
+ * Internal quotes must be escaped by doubling them.
+ *
+ * @param field - The field value to escape
+ * @returns RFC 4180 compliant escaped field
+ */
+function escapeCSVField(field: any): string {
+  // Convert to string, handle null/undefined
+  const value = field == null ? '' : String(field);
+
+  // Check if field needs quoting (comma, quote, newline, or carriage return)
+  const needsQuoting = value.includes(',') ||
+                      value.includes('"') ||
+                      value.includes('\n') ||
+                      value.includes('\r');
+
+  if (needsQuoting) {
+    // Escape quotes by doubling them, then wrap in quotes
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  return value;
+}
+
+/**
  * Export plot data to CSV
  *
  * @param data - Plot data
@@ -120,7 +147,7 @@ headers.add('group');
 
   // Build CSV content
   const rows: string[] = [];
-  rows.push(Array.from(headers).join(','));
+  rows.push(Array.from(headers).map(escapeCSVField).join(','));
 
   // Combine all traces
   data.forEach(trace => {
@@ -128,19 +155,19 @@ headers.add('group');
     for (let i = 0; i < length; i++) {
       const row: string[] = [];
       if (headers.has('x')) {
-row.push(trace.x?.[i] ?? '');
+row.push(escapeCSVField(trace.x?.[i] ?? ''));
 }
       if (headers.has('y')) {
-row.push(trace.y?.[i] ?? '');
+row.push(escapeCSVField(trace.y?.[i] ?? ''));
 }
       if (headers.has('z')) {
-row.push(trace.z?.[i] ?? '');
+row.push(escapeCSVField(trace.z?.[i] ?? ''));
 }
       if (headers.has('label')) {
-row.push(trace.text?.[i] ?? '');
+row.push(escapeCSVField(trace.text?.[i] ?? ''));
 }
       if (headers.has('group')) {
-row.push(trace.name ?? '');
+row.push(escapeCSVField(trace.name ?? ''));
 }
       rows.push(row.join(','));
     }


### PR DESCRIPTION
## Summary
Fixed CSV export function to properly quote and escape field values according to RFC 4180 standard, preventing data corruption when exporting plot data containing special characters.

## Changes
- Added `escapeCSVField()` helper function implementing RFC 4180 compliance
- Applied escaping to both header row and all data fields  
- Fields containing commas, quotes, newlines, or carriage returns are now properly quoted
- Internal quotes are escaped by doubling them (`"` → `""`)

## Test Cases Handled
- **Commas**: `"Sample, Control"` → `"Sample, Control"` (quoted)
- **Quotes**: `Sample "A"` → `"Sample ""A"""` (escaped and quoted)
- **Newlines**: `"Line1\nLine2"` → `"Line1\nLine2"` (quoted)
- **Normal values**: `Sample1` → `Sample1` (unchanged)

## Impact
- Fixes data integrity issue in plot CSV exports
- Ensures exported CSVs can be reliably re-imported
- Follows RFC 4180 standard for CSV formatting
- Maintains backward compatibility for values without special characters

## Testing
- ✅ TypeScript compilation passed
- ✅ Pre-commit hooks passed
- Manual testing with GoPCA Desktop plot exports recommended

## Adherence to Development Principles
- **KISS**: Simple, focused function following RFC 4180 standard
- **DRY**: Single `escapeCSVField()` function used throughout
- **SoC**: CSV escaping logic separated from data extraction
- **Readability**: Clear function name and comprehensive documentation

Closes #588