### PR TITLE
fix: handle non-comma delimiters in mixed parsing and CLI validation (#599, #600)

### DIFF
--- a/internal/cobra/analyze.go
+++ b/internal/cobra/analyze.go
@@ -196,13 +196,49 @@ EXAMPLES:
 	return cmd
 }
 
+// parseDelimiter converts a delimiter string to a rune, handling escape sequences
+// and validating the input according to CSV standards.
+// Common escape sequences like \t (tab), \n (newline), and \r (carriage return)
+// are automatically converted to their respective rune values.
+// Returns an error if the delimiter is empty or contains more than one character.
+func parseDelimiter(delimStr string) (rune, error) {
+	if delimStr == "" {
+		return 0, fmt.Errorf("delimiter cannot be empty")
+	}
+
+	// Handle common escape sequences
+	switch delimStr {
+	case "\\t":
+		return '\t', nil
+	case "\\n":
+		return '\n', nil
+	case "\\r":
+		return '\r', nil
+	}
+
+	// Convert to rune and validate single character
+	runes := []rune(delimStr)
+	if len(runes) != 1 {
+		return 0, fmt.Errorf("delimiter must be a single character, got %d characters", len(runes))
+	}
+
+	return runes[0], nil
+}
+
 // runAnalyze executes the analyze command
 func runAnalyze(opts *AnalyzeOptions, inputFile string) error {
 	// Parse CSV options
 	parseOpts := pkgcsv.DefaultOptions()
 	parseOpts.HasHeaders = !opts.NoHeaders
 	parseOpts.HasRowNames = !opts.NoIndex
-	parseOpts.Delimiter = rune(opts.Delimiter[0])
+
+	// Parse delimiter with validation and escape sequence handling
+	var err error
+	parseOpts.Delimiter, err = parseDelimiter(opts.Delimiter)
+	if err != nil {
+		return fmt.Errorf("invalid delimiter: %w", err)
+	}
+
 	parseOpts.ParseMode = pkgcsv.ParseMixedWithTargets
 
 	// Parse NA values

--- a/internal/cobra/analyze_test.go
+++ b/internal/cobra/analyze_test.go
@@ -315,3 +315,94 @@ func TestParseExcludeColumns(t *testing.T) {
 		})
 	}
 }
+
+// TestParseDelimiter verifies delimiter parsing with validation and escape sequences.
+// This is a regression test for issue #600.
+func TestParseDelimiter(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    rune
+		expectError bool
+	}{
+		{
+			name:        "comma delimiter",
+			input:       ",",
+			expected:    ',',
+			expectError: false,
+		},
+		{
+			name:        "semicolon delimiter",
+			input:       ";",
+			expected:    ';',
+			expectError: false,
+		},
+		{
+			name:        "pipe delimiter",
+			input:       "|",
+			expected:    '|',
+			expectError: false,
+		},
+		{
+			name:        "tab escape sequence",
+			input:       "\\t",
+			expected:    '\t',
+			expectError: false,
+		},
+		{
+			name:        "newline escape sequence",
+			input:       "\\n",
+			expected:    '\n',
+			expectError: false,
+		},
+		{
+			name:        "carriage return escape sequence",
+			input:       "\\r",
+			expected:    '\r',
+			expectError: false,
+		},
+		{
+			name:        "empty delimiter - should error",
+			input:       "",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "multi-character delimiter - should error",
+			input:       "ab",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "multi-character delimiter - should error",
+			input:       "|||",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "unicode character",
+			input:       "→",
+			expected:    '→',
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseDelimiter(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("parseDelimiter(%q) expected error, got nil", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("parseDelimiter(%q) unexpected error: %v", tt.input, err)
+				}
+				if result != tt.expected {
+					t.Errorf("parseDelimiter(%q) = %q, want %q", tt.input, result, tt.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/csv/reader.go
+++ b/pkg/csv/reader.go
@@ -7,6 +7,7 @@
 package csv
 
 import (
+	"bytes"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -364,7 +365,7 @@ func (r *Reader) parseAsMixed(records [][]string, nullMap map[string]bool) (*Dat
 
 	// Use existing mixed parser
 	csvData, categoricalData, err := types.ParseCSVMixed(
-		strings.NewReader(recordsToString(records)),
+		strings.NewReader(r.recordsToString(records)),
 		format,
 	)
 	if err != nil {
@@ -398,7 +399,7 @@ func (r *Reader) parseAsMixedWithTargets(records [][]string, nullMap map[string]
 
 	// Use existing parser with target detection
 	csvData, categoricalData, targetData, err := types.ParseCSVMixedWithTargets(
-		strings.NewReader(recordsToString(records)),
+		strings.NewReader(r.recordsToString(records)),
 		format,
 		r.opts.TargetCols, // Use provided target columns
 	)
@@ -449,26 +450,21 @@ func (r *Reader) getSelectedColumns(totalCols int) []int {
 	return selected
 }
 
-// recordsToString converts records back to CSV string for compatibility
-func recordsToString(records [][]string) string {
-	var sb strings.Builder
-	for _, record := range records {
-		for i, field := range record {
-			if i > 0 {
-				sb.WriteRune(',')
-			}
-			// Simple CSV escaping
-			if strings.ContainsAny(field, ",\"\n") {
-				sb.WriteRune('"')
-				sb.WriteString(strings.ReplaceAll(field, "\"", "\"\""))
-				sb.WriteRune('"')
-			} else {
-				sb.WriteString(field)
-			}
-		}
-		sb.WriteRune('\n')
+// recordsToString converts records back to CSV string using RFC 4180 compliant encoding.
+// Uses the standard library's csv.Writer to ensure proper escaping and delimiter handling.
+// This method respects the configured delimiter from r.opts and handles all special characters
+// (quotes, delimiters, newlines, carriage returns) according to RFC 4180.
+func (r *Reader) recordsToString(records [][]string) string {
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+	writer.Comma = r.opts.Delimiter
+
+	if err := writer.WriteAll(records); err != nil {
+		// This should never happen with a bytes.Buffer
+		return ""
 	}
-	return sb.String()
+
+	return buf.String()
 }
 
 // ParseFile is a convenience function for simple CSV parsing

--- a/pkg/csv/reader_test.go
+++ b/pkg/csv/reader_test.go
@@ -469,3 +469,233 @@ row2,4,5,6`,
 		})
 	}
 }
+
+// TestSemicolonDelimiterMixed verifies that semicolon-delimited files work correctly
+// in ParseMixed mode with proper RFC 4180 escaping.
+// This is a regression test for issue #599.
+func TestSemicolonDelimiterMixed(t *testing.T) {
+	input := `A;B;C
+1;2;3
+4;5;6`
+
+	opts := DefaultOptions()
+	opts.Delimiter = ';'
+	opts.ParseMode = ParseMixed
+	opts.HasRowNames = false
+
+	reader := NewReader(opts)
+	data, err := reader.Read(strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All columns are numeric in this test
+	if len(data.Headers) != 3 {
+		t.Errorf("expected 3 numeric headers, got %d (headers: %v)", len(data.Headers), data.Headers)
+	}
+
+	if data.Rows != 2 {
+		t.Errorf("expected 2 rows, got %d", data.Rows)
+	}
+
+	// Verify there are no categorical columns (all numeric)
+	if len(data.CategoricalColumns) != 0 {
+		t.Errorf("expected 0 categorical columns, got %d", len(data.CategoricalColumns))
+	}
+}
+
+// TestSemicolonDelimiterWithTargets verifies that semicolon-delimited files work correctly
+// in ParseMixedWithTargets mode with proper RFC 4180 escaping.
+// This is a regression test for issues #599 and #600.
+func TestSemicolonDelimiterWithTargets(t *testing.T) {
+	input := `"";A;B;C;Target
+row1;1;2;3;100
+row2;4;5;6;200`
+
+	opts := DefaultOptions()
+	opts.Delimiter = ';'
+	opts.TargetCols = []string{"Target"}
+	opts.ParseMode = ParseMixedWithTargets
+
+	reader := NewReader(opts)
+	data, err := reader.Read(strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Feature columns should be A, B, C (not Target)
+	if len(data.Headers) != 3 {
+		t.Errorf("feature columns = %d, want 3 (got: %v)", len(data.Headers), data.Headers)
+	}
+
+	// Target columns should contain Target
+	if len(data.NumericTargetColumns) != 1 {
+		t.Errorf("target columns = %d, want 1", len(data.NumericTargetColumns))
+	}
+
+	if _, exists := data.NumericTargetColumns["Target"]; !exists {
+		t.Error("Target column not found in NumericTargetColumns")
+	}
+}
+
+// TestTabDelimiterMixed verifies that tab-delimited files work correctly
+// in ParseMixed mode with proper RFC 4180 escaping.
+// This is a regression test for issue #599.
+func TestTabDelimiterMixed(t *testing.T) {
+	input := "A\tB\tC\n1\t2\t3\n4\t5\t6"
+
+	opts := DefaultOptions()
+	opts.Delimiter = '\t'
+	opts.ParseMode = ParseMixed
+	opts.HasRowNames = false
+
+	reader := NewReader(opts)
+	data, err := reader.Read(strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All columns are numeric in this test
+	if len(data.Headers) != 3 {
+		t.Errorf("expected 3 numeric headers, got %d (headers: %v)", len(data.Headers), data.Headers)
+	}
+
+	if data.Rows != 2 {
+		t.Errorf("expected 2 rows, got %d", data.Rows)
+	}
+
+	// Verify there are no categorical columns (all numeric)
+	if len(data.CategoricalColumns) != 0 {
+		t.Errorf("expected 0 categorical columns, got %d", len(data.CategoricalColumns))
+	}
+}
+
+// TestTabDelimiterWithTargets verifies that tab-delimited files work correctly
+// in ParseMixedWithTargets mode.
+// This is a regression test for issues #599 and #600.
+func TestTabDelimiterWithTargets(t *testing.T) {
+	input := "A\tB\tC\tTarget\n1\t2\t3\t100\n4\t5\t6\t200"
+
+	opts := DefaultOptions()
+	opts.Delimiter = '\t'
+	opts.HasRowNames = false // No row names in this simplified test
+	opts.TargetCols = []string{"Target"}
+	opts.ParseMode = ParseMixedWithTargets
+
+	reader := NewReader(opts)
+	data, err := reader.Read(strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Feature columns should be A, B, C (not Target)
+	if len(data.Headers) != 3 {
+		t.Errorf("feature columns = %d, want 3 (got: %v)", len(data.Headers), data.Headers)
+	}
+
+	// Target columns should contain Target
+	if len(data.NumericTargetColumns) != 1 {
+		t.Errorf("target columns = %d, want 1", len(data.NumericTargetColumns))
+	}
+
+	// Verify we have 2 rows of data
+	if data.Rows != 2 {
+		t.Errorf("expected 2 rows, got %d", data.Rows)
+	}
+}
+
+// TestRFC4180EscapingWithDelimiters verifies that the recordsToString method
+// properly escapes fields containing the delimiter character according to RFC 4180.
+// This ensures that fields with semicolons in semicolon-delimited files are quoted.
+func TestRFC4180EscapingWithDelimiters(t *testing.T) {
+	tests := []struct {
+		name      string
+		delimiter rune
+		input     string
+		wantRows  int
+	}{
+		{
+			name:      "semicolon delimiter with semicolon in field",
+			delimiter: ';',
+			input: `Name;Description
+Alice;"Developer; Team Lead"
+Bob;"Manager; Director"`,
+			wantRows: 2,
+		},
+		{
+			name:      "tab delimiter with tab in field - should be quoted",
+			delimiter: '\t',
+			input:     "Name\tDescription\nAlice\t\"Developer\tSenior\"\nBob\t\"Manager\tExecutive\"",
+			wantRows:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.Delimiter = tt.delimiter
+			opts.ParseMode = ParseMixed
+			opts.HasRowNames = false
+
+			reader := NewReader(opts)
+			data, err := reader.Read(strings.NewReader(tt.input))
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if data.Rows != tt.wantRows {
+				t.Errorf("expected %d rows, got %d", tt.wantRows, data.Rows)
+			}
+		})
+	}
+}
+
+// TestPollOfPollsCSV is a regression test for the bug where semicolon-delimited
+// European format files (pollofpolls.csv) failed to load in GoPCA Desktop.
+// The file uses semicolons as delimiters and commas as decimal separators.
+// This test verifies issues #599 and #600 are fixed.
+func TestPollOfPollsCSV(t *testing.T) {
+	// Test with actual pollofpolls.csv file
+	opts := EuropeanOptions() // Semicolon delimiter, comma decimal separator
+	opts.ParseMode = ParseMixed
+
+	reader := NewReader(opts)
+	data, err := reader.ReadFile("../../testdata/pollofpolls/pollofpolls.csv")
+
+	if err != nil {
+		t.Fatalf("failed to read pollofpolls.csv: %v", err)
+	}
+
+	// Verify basic structure
+	if data.Rows <= 0 {
+		t.Errorf("expected rows > 0, got %d", data.Rows)
+	}
+
+	if len(data.Headers) <= 0 {
+		t.Errorf("expected headers, got %d", len(data.Headers))
+	}
+
+	// The file should have row names (poll dates)
+	if len(data.RowNames) != data.Rows {
+		t.Errorf("expected %d row names, got %d", data.Rows, len(data.RowNames))
+	}
+
+	// Verify we can parse numeric columns (parties)
+	if data.Columns <= 0 {
+		t.Errorf("expected columns > 0, got %d", data.Columns)
+	}
+
+	// Spot check: verify we have some numeric data
+	if len(data.Matrix) > 0 && len(data.Matrix[0]) > 0 {
+		// First value should be a reasonable number (percentage)
+		firstVal := data.Matrix[0][0]
+		if math.IsNaN(firstVal) || firstVal < 0 || firstVal > 100 {
+			t.Errorf("first data value seems invalid: %f (expected 0-100)", firstVal)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes multiple related issues with CSV delimiter handling that prevented non-comma delimiters (semicolon, tab) from working correctly in mixed parsing modes and caused the CLI to crash on invalid delimiter input.

## Issues Fixed

- Fixes #599 - CSV parsing fails with non-comma delimiters in mixed mode
- Fixes #600 - CLI panics on empty `--delimiter` and doesn't handle escape sequences
- Fixes bug where `testdata/pollofpolls/pollofpolls.csv` failed in GoPCA Desktop but worked in GoCSV

## Root Cause

The `recordsToString()` function in `pkg/csv/reader.go` hard-coded comma delimiters when serializing CSV records for re-parsing by mixed mode parsers (`ParseCSVMixed` and `ParseCSVMixedWithTargets`). This broke any CSV file using semicolons, tabs, or other delimiters.

Additionally, the CLI directly indexed `opts.Delimiter[0]` without validation or escape sequence handling, causing panics on empty input.

## Solution

### Backend Changes (pkg/csv/reader.go)

Replaced manual CSV serialization with Go's standard library `encoding/csv.Writer`:

- **Before**: 20 lines of hand-rolled CSV escaping with hard-coded comma delimiter
- **After**: 8 lines using stdlib that respects configured delimiter and is RFC 4180 compliant

This aligns with the RFC 4180 escaping work done in PR #593 for the frontend. The stdlib approach is more robust, maintainable, and handles all edge cases (quotes, delimiters, newlines, carriage returns).

### CLI Changes (internal/cobra/analyze.go)

Added `parseDelimiter()` helper function that:
- Validates delimiter is non-empty (prevents panic)
- Converts escape sequences (`\t` → tab, `\n` → newline, `\r` → carriage return)
- Validates single-character constraint
- Returns descriptive error messages

## Testing

### New Tests Added

**pkg/csv/reader_test.go:**
- `TestSemicolonDelimiterMixed`: Verify semicolon works in ParseMixed mode
- `TestSemicolonDelimiterWithTargets`: Verify semicolon with target column exclusion
- `TestTabDelimiterMixed`: Verify tab delimiter in ParseMixed mode
- `TestTabDelimiterWithTargets`: Verify tab with target columns
- `TestRFC4180EscapingWithDelimiters`: Verify RFC 4180 field escaping
- `TestPollOfPollsCSV`: Regression test for actual pollofpolls.csv file

**internal/cobra/analyze_test.go:**
- `TestParseDelimiter`: Comprehensive validation covering:
  - Common delimiters (comma, semicolon, pipe)
  - Escape sequences (\t, \n, \r)
  - Empty string error handling
  - Multi-character error handling
  - Unicode character support

### Test Results

All tests pass with maintained code coverage:
- Unit tests: ✅ All passed
- CI tests: ✅ All passed
- Linters: ✅ 0 issues
- Pre-commit hooks: ✅ All passed

## Technical Details

### RFC 4180 Compliance

By using `encoding/csv.Writer`, we ensure:
- Proper escaping of fields containing delimiters
- Automatic quote doubling
- Correct handling of newlines and carriage returns
- Consistent behavior across all delimiter types

### Example Fix Impact

**pollofpolls.csv** (semicolon-delimited European format):
```csv
;Ap;Høyre;Frp;SV;Sp;KrF;Venstre;MDG;Rødt;Andre
November '25;23,7;16,6;25,7;5,3;5,8;4,5;3,6;4,2;6,6;4,0
```

- **Before**: Failed with "wrong number of fields" error
- **After**: Loads successfully with proper column separation

### CLI Usage

Users can now use escape sequences:
```bash
pca analyze --delimiter '\t' input.tsv    # Tab-delimited
pca analyze --delimiter ';' data.csv      # Semicolon-delimited
pca analyze --delimiter '|' data.txt      # Pipe-delimited
```

Empty or multi-character delimiters now produce helpful error messages instead of panics.

## Files Changed

- `pkg/csv/reader.go`: Convert recordsToString to RFC 4180 compliant version
- `internal/cobra/analyze.go`: Add parseDelimiter helper with validation
- `pkg/csv/reader_test.go`: Add comprehensive delimiter tests
- `internal/cobra/analyze_test.go`: Add parseDelimiter validation tests

## Checklist

- [x] Tests added and passing
- [x] Linters passing
- [x] Pre-commit hooks passing
- [x] Documentation updated (via code comments)
- [x] Issue numbers referenced
- [x] Changes follow existing code patterns
- [x] RFC 4180 compliance verified