### PR TITLE
fix: use preprocessor state for PreprocessingApplied metadata

### DIFF
--- a/internal/core/kernel_pca.go
+++ b/internal/core/kernel_pca.go
@@ -390,7 +390,7 @@ func (kpca *KernelPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*type
 		ComponentLabels:      componentLabels,
 		ComponentsComputed:   config.Components,
 		Method:               "kernel",
-		PreprocessingApplied: config.ScaleOnly || config.SNV || config.VectorNorm,
+		PreprocessingApplied: kpca.preprocessor != nil,
 		AllEigenvalues:       allEigvals,
 		KernelType:           string(kpca.kernelType),
 		KernelParams:         kernelParams,

--- a/internal/core/pca.go
+++ b/internal/core/pca.go
@@ -206,7 +206,7 @@ func (p *PCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types.PCAResu
 		ComponentLabels:      componentLabels,
 		ComponentsComputed:   actualComponents,
 		Method:               config.Method,
-		PreprocessingApplied: config.MeanCenter || config.StandardScale || config.RobustScale,
+		PreprocessingApplied: p.preprocessor != nil,
 		Means:                means,
 		StdDevs:              stddevs,
 		AllEigenvalues:       allEigenvalues,

--- a/internal/core/pca_preprocessing_test.go
+++ b/internal/core/pca_preprocessing_test.go
@@ -113,6 +113,45 @@ func TestPCAWithDifferentPreprocessing(t *testing.T) {
 				// The preprocessor should have been applied
 			},
 		},
+		{
+			name: "Scale only (variance scaling without centering)",
+			config: types.PCAConfig{
+				Components: 2,
+				ScaleOnly:  true,
+				Method:     "svd",
+			},
+			checkFunction: func(t *testing.T, result *types.PCAResult) {
+				if !result.PreprocessingApplied {
+					t.Error("PreprocessingApplied should be true with ScaleOnly")
+				}
+			},
+		},
+		{
+			name: "SNV (Standard Normal Variate)",
+			config: types.PCAConfig{
+				Components: 2,
+				SNV:        true,
+				Method:     "svd",
+			},
+			checkFunction: func(t *testing.T, result *types.PCAResult) {
+				if !result.PreprocessingApplied {
+					t.Error("PreprocessingApplied should be true with SNV")
+				}
+			},
+		},
+		{
+			name: "VectorNorm (L2 normalization)",
+			config: types.PCAConfig{
+				Components: 2,
+				VectorNorm: true,
+				Method:     "svd",
+			},
+			checkFunction: func(t *testing.T, result *types.PCAResult) {
+				if !result.PreprocessingApplied {
+					t.Error("PreprocessingApplied should be true with VectorNorm")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/temporal_pca.go
+++ b/internal/core/temporal_pca.go
@@ -362,7 +362,7 @@ func (t *TemporalPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types
 			StdDevs:                    nil, // Not applicable for temporal PCA with SSA approach
 			ComponentsComputed:         1,
 			Config:                     config,
-			PreprocessingApplied:       config.MeanCenter || config.StandardScale || config.RobustScale || config.ScaleOnly,
+			PreprocessingApplied:       t.preprocessor != nil,
 			TemporalEigenvectors:       utils.MatrixToSlice(temporalEigenvectors), // Add trivial U matrix for single sample case
 			TemporalVariableImportance: types.Matrix(variableImportance),          // Add variable importance for single sample case
 		}, nil
@@ -497,7 +497,7 @@ func (t *TemporalPCAImpl) Fit(data types.Matrix, config types.PCAConfig) (*types
 		ComponentsComputed:         t.nComponents,
 		Config:                     config,
 		AllEigenvalues:             allEigenvalues, // Store all eigenvalues for diagnostic purposes
-		PreprocessingApplied:       config.MeanCenter || config.StandardScale || config.RobustScale || config.ScaleOnly,
+		PreprocessingApplied:       t.preprocessor != nil,
 		TemporalEigenvectors:       utils.MatrixToSlice(temporalEigenvectors), // Add U matrix for temporal loadings visualization
 		TemporalVariableImportance: types.Matrix(variableImportance),          // Add variable importance for temporal PCA
 	}


### PR DESCRIPTION
## Summary

Fixes #601 

The `PreprocessingApplied` field in PCA results was incorrectly set due to incomplete flag checks, causing it to be false even when preprocessing methods like ScaleOnly, SNV, or VectorNorm were applied.

## Problem

Previously, `PreprocessingApplied` was set by manually checking specific preprocessing flags, but the checks were incomplete and inconsistent across different PCA implementations:

- **pca.go**: Only checked `MeanCenter || StandardScale || RobustScale`
- **kernel_pca.go**: Only checked `ScaleOnly || SNV || VectorNorm`  
- **temporal_pca.go**: Only checked `MeanCenter || StandardScale || RobustScale || ScaleOnly`

This caused:
- Incorrect metadata when ScaleOnly, SNV, or VectorNorm was used
- Broken provenance tracking for exported models
- Inconsistent behavior across PCA implementations

## Solution

Changed all three PCA implementations to use `p.preprocessor != nil` instead of manual flag checks. This approach:

- ✅ **Single source of truth**: Relies on whether preprocessor was actually created
- ✅ **Future-proof**: Automatically works with any new preprocessing methods
- ✅ **Maintainable**: No need to update multiple locations when adding features
- ✅ **Consistent**: Same logic across all PCA implementations

## Changes

### Code Changes
- `internal/core/pca.go`: Changed line 209 to use `p.preprocessor != nil`
- `internal/core/kernel_pca.go`: Changed line 393 to use `kpca.preprocessor != nil`
- `internal/core/temporal_pca.go`: Changed lines 365 and 500 to use `t.preprocessor != nil`

### Test Changes
- Added test cases for `ScaleOnly`, `SNV`, and `VectorNorm` in `pca_preprocessing_test.go`
- All existing tests still pass
- New tests verify `PreprocessingApplied` is correctly set for all preprocessing methods

## Testing

- ✅ All unit tests pass
- ✅ All integration tests pass  
- ✅ Full CI test suite passes locally
- ✅ Pre-commit hooks pass (formatting, linting, tests)

## Verification

```bash
# Verify ScaleOnly sets PreprocessingApplied
pca analyze data.csv --scale-only  # PreprocessingApplied will now be true

# Verify SNV sets PreprocessingApplied
pca analyze data.csv --snv  # PreprocessingApplied will now be true

# Verify VectorNorm sets PreprocessingApplied
pca analyze data.csv --vector-norm  # PreprocessingApplied will now be true
```