### PR TITLE
docs: add v1.1.8 CHANGELOG entry and improve release guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2025-11-09
+
+### Added
+- **Bundled MSIX Package** for Microsoft Store (#608, #567)
+  - Single installation package containing both GoPCA Desktop and GoCSV
+  - Both apps installed in same directory enabling tight integration
+  - Enables "Open in GoPCA" and "Open GoCSV" cross-app features
+  - Includes comprehensive MSIX packaging documentation
+  - Suitable for Microsoft Store submission and enterprise sideloading
+
+### Fixed
+- CustomSelect component keyboard navigation with type-to-search filtering (#607)
+- Preprocessor state now used for PreprocessingApplied metadata field (#606)
+- Non-comma delimiter handling in mixed parsing and CLI validation (#605, #599, #600)
+- --target-columns CLI flag now parsed and applied correctly (#604)
+- Missing-strategy zero implementation for imputation (#603)
+
 ## [1.1.7] - 2025-11-07
 
 ### Fixed

--- a/docs/devel/release-guide.md
+++ b/docs/devel/release-guide.md
@@ -116,6 +116,21 @@ For major releases with many features accumulated in develop:
 
 When using Claude Code or another AI assistant to create a release, the assistant can automate most steps:
 
+**What requires MANUAL action FIRST:**
+- ❌ **Update CHANGELOG.md** - MUST be done before running prepare-release.sh
+  ```bash
+  # List PRs merged since last release
+  gh pr list --state merged --base develop --limit 30 \
+    --json number,title,mergedAt --jq '.[] | "\(.number): \(.title) (\(.mergedAt[:10]))"'
+
+  # Identify which PRs belong to this release (merged after previous release date)
+  # Edit CHANGELOG.md with:
+  # - Version and date header: ## [X.X.X] - YYYY-MM-DD
+  # - Organized sections: Added, Fixed, Changed, Documentation, etc.
+  # - PR numbers for each change
+  # - Commit the updated CHANGELOG.md
+  ```
+
 **What the AI CAN do automatically:**
 1. ✅ Check current version and determine next version
 2. ✅ Verify main branch and clean working directory
@@ -128,11 +143,15 @@ When using Claude Code or another AI assistant to create a release, the assistan
 9. ✅ Monitor release workflow progress
 
 **What requires MANUAL action:**
+- ❌ **Update CHANGELOG.md FIRST** - See above (CRITICAL - do not skip!)
 - ❌ **Merge the PR** - Must be done via GitHub web interface due to branch protection rules
 
 **AI Assistant Instructions:**
 ```bash
-# The AI will execute these automatically:
+# FIRST: Update CHANGELOG.md manually (see above)
+# Commit the CHANGELOG.md changes before proceeding
+
+# Then the AI will execute these automatically:
 ./scripts/prepare-release.sh vX.X.X
 git push -u origin release-vX.X.X
 gh pr create --title "Release vX.X.X" --body "Preparing release vX.X.X"


### PR DESCRIPTION
## Purpose

Backport the CHANGELOG.md and release-guide.md updates to main branch.

The v1.1.8 release was created from main, but the CHANGELOG.md entry for v1.1.8 was missing at the time. This PR adds the missing documentation to main.

## Changes

### CHANGELOG.md
Adds the v1.1.8 entry that was missing when the release was created:
- **Added**: Bundled MSIX Package for Microsoft Store (#608, #567)
- **Fixed**: 5 bug fixes (#607, #606, #605, #604, #603)

### release-guide.md
Improves the release process documentation:
- Emphasizes CHANGELOG.md must be updated BEFORE prepare-release.sh
- Adds it as first item under "What requires MANUAL action FIRST"
- Provides example commands for identifying PRs to include
- Adds troubleshooting section for variable substitution issues

## Context

This is a backport of PR #612 which was already merged to develop. These documentation improvements need to be in main so that:
1. The CHANGELOG.md on main reflects what's actually in the v1.1.8 release
2. Future releases from main have proper documentation
3. The release guide improvements are available for reference

## Related

- PR #612: Original PR merged to develop
- Release v1.1.8: https://github.com/bitjungle/gopca/releases/tag/v1.1.8
- PR #611: Related fix for variable substitution in release workflow

---
**This is a documentation-only change - no code changes included**