### PR TITLE
fix: correct VERSION_NO_V variable substitution in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1322,6 +1322,7 @@ jobs:
       run: |
         # Extract the changelog content for this version
         VERSION="${GITHUB_REF#refs/tags/}"
+        VERSION_NO_V="${VERSION#v}"
         echo "Extracting changelog for version: $VERSION"
 
         # Use the extraction script
@@ -1374,7 +1375,7 @@ jobs:
 
         | Package | Download | Description |
         |---------|----------|-------------|
-        | **MSIX Package** | [\`GoPCA_{VERSION_NO_V}.0_x64.msix\`](../../releases/download/${VERSION}/GoPCA_*.msix) | Microsoft Store package for sideloading or Store submission<br>• Modern Windows app package format<br>• Sandboxed installation<br>• Suitable for enterprise deployment<br>• **Coming to Microsoft Store soon!** |
+        | **MSIX Package** | [\`GoPCA_${VERSION_NO_V}.0_x64.msix\`](../../releases/download/${VERSION}/GoPCA_${VERSION_NO_V}.0_x64.msix) | Microsoft Store package for sideloading or Store submission<br>• Modern Windows app package format<br>• Sandboxed installation<br>• Suitable for enterprise deployment<br>• **Coming to Microsoft Store soon!** |
 
         **Note**: The MSIX package is primarily for sideloading in enterprise environments or for submission to Microsoft Store. Most users should use the traditional installer above.
 

--- a/docs/devel/release-guide.md
+++ b/docs/devel/release-guide.md
@@ -563,6 +563,30 @@ If self-hosted runner is offline:
 - Check runner status: Settings → Actions → Runners
 - The workflow will wait for runner to come online
 
+### Release Notes Variable Substitution Issues
+
+If release notes contain literal `{VERSION_NO_V}` text or wildcard links like `GoPCA_*.msix`:
+
+**Root Cause**: The `VERSION_NO_V` variable wasn't defined in the "Generate release body with changelog" step of `.github/workflows/release.yml`.
+
+**Fix**:
+1. Ensure `VERSION_NO_V="${VERSION#v}"` is defined early in the step (after VERSION is set)
+2. Use bash variable syntax `${VERSION_NO_V}` not `{VERSION_NO_V}` in heredoc templates
+3. Replace wildcards in links with actual filenames using `${VERSION_NO_V}`
+
+**To Fix a Released Version**:
+```bash
+# Download current release notes
+gh release view vX.X.X --json body --jq '.body' > /tmp/release_notes.md
+
+# Fix the text (replace X.X.X with actual version)
+sed -i '' 's/GoPCA_{VERSION_NO_V}\.0_x64\.msix/GoPCA_X.X.X.0_x64.msix/g' /tmp/release_notes.md
+sed -i '' 's|releases/download/vX\.X\.X/GoPCA_\*\.msix|releases/download/vX.X.X/GoPCA_X.X.X.0_x64.msix|g' /tmp/release_notes.md
+
+# Update the release
+gh release edit vX.X.X --notes-file /tmp/release_notes.md
+```
+
 ## Windows Code Signing (Manual Process)
 
 After the automated release workflow completes, the Windows installer needs to be manually signed to avoid security warnings.


### PR DESCRIPTION
## Purpose

Backport PR #611 to main branch to fix the variable substitution issue in release notes.

## Problem

In the release workflow, the MSIX package download link shows:
- Filename: `{VERSION_NO_V}` (literal text, not substituted)  
- Link: `GoPCA_*.msix` (wildcard doesn't work)

This makes the MSIX download link non-functional in release notes.

## Solution

### .github/workflows/release.yml
1. Added `VERSION_NO_V="${VERSION#v}"` definition in "Generate release body" step
2. Changed `{VERSION_NO_V}` to `${VERSION_NO_V}` (proper bash variable syntax)
3. Replaced wildcard `GoPCA_*.msix` with `GoPCA_${VERSION_NO_V}.0_x64.msix`

### docs/devel/release-guide.md
Added troubleshooting section documenting:
- Root cause of the issue
- How to fix in the workflow
- How to manually fix already-released versions

## Impact

Future releases from main will have correct MSIX download links that work properly.

## Context

This is a backport of PR #611 which was already merged to develop. The fix is needed in main so that:
1. Future releases created from main have working download links
2. The troubleshooting documentation is available on main
3. Next release won't repeat the same issue

## Related

- PR #611: Original PR merged to develop
- Release v1.1.8: Already manually fixed with `gh release edit`
- PR #613: CHANGELOG backport (companion PR)

---
**Fixes the variable substitution issue for all future releases**