### PR TITLE
fix: arrow colors in Circle of Correlations now follow palette (Fixes #513)

### DIFF
--- a/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
@@ -322,23 +322,33 @@ export class PlotlyCircleOfCorrelations {
 
     // Add arrow annotations for vectors
     const { correlationsX, correlationsY, magnitudes } = this.prepareData();
-    const arrowAnnotations = correlationsX.map((_x, i) => ({
-      x: correlationsX[i],
-      y: correlationsY[i],
-      ax: 0,
-      ay: 0,
-      xref: 'x' as any,
-      yref: 'y' as any,
-      axref: 'x' as any,
-      ayref: 'y' as any,
-      showarrow: true,
-      arrowhead: 2,
-      arrowsize: 1,
-      arrowwidth: this.config.arrowWidth,
-      arrowcolor: this.config.colorByMagnitude
-        ? `hsl(${240 - magnitudes[i] * 240}, 70%, 50%)`
-        : '#3b82f6'
-    }));
+    const arrowAnnotations = correlationsX.map((_x, i) => {
+      let arrowColor: string;
+      if (this.config.colorByMagnitude) {
+        arrowColor = `hsl(${240 - magnitudes[i] * 240}, 70%, 50%)`;
+      } else if (this.config.colorScheme && this.config.colorScheme.length > 0) {
+        // Use the same palette index as the line trace for this variable so
+        // arrowhead and line always share the same color.
+        arrowColor = this.config.colorScheme[i % this.config.colorScheme.length];
+      } else {
+        arrowColor = '#3b82f6';
+      }
+      return {
+        x: correlationsX[i],
+        y: correlationsY[i],
+        ax: 0,
+        ay: 0,
+        xref: 'x' as any,
+        yref: 'y' as any,
+        axref: 'x' as any,
+        ayref: 'y' as any,
+        showarrow: true,
+        arrowhead: 2,
+        arrowsize: 1,
+        arrowwidth: this.config.arrowWidth,
+        arrowcolor: arrowColor
+      };
+    });
 
     layout.annotations = [...(layout.annotations || []), ...arrowAnnotations];
 
@@ -367,12 +377,8 @@ export const PCACircleOfCorrelations: React.FC<{
 }> = ({ data, config }) => {
   const plot = useMemo(() => new PlotlyCircleOfCorrelations(data, config), [data, config]);
 
-  // Create a key based on the colorScheme to force re-render when palette changes
-  const colorSchemeKey = config?.colorScheme ? JSON.stringify(config.colorScheme) : 'default';
-
   return (
     <PlotlyWithFullscreen
-      key={`circle-correlations-${colorSchemeKey}`}
       data={plot.getTraces()}
       layout={plot.getEnhancedLayout()}
       config={plot.getConfig()}


### PR DESCRIPTION
## Summary

- Arrow annotations in `getLayout()` had a hardcoded `arrowcolor` (`#3b82f6`) instead of reading from `colorScheme`, while the line traces for the same vectors already used `colorScheme` correctly
- Fix: use the same `colorScheme[i % colorScheme.length]` palette index for `arrowcolor` as for the line trace, keeping line, dot, and arrowhead visually consistent per variable
- Remove the `key={colorSchemeKey}` forced re-render workaround from `PCACircleOfCorrelations` — now that the layout data is correct, `react-plotly.js` diffs naturally; this also preserves zoom/pan state on palette changes

## Files changed

- `packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx`

## Test plan

- [ ] Run GoPCA Desktop, load a dataset with preprocessing applied, navigate to Circle of Correlations
- [ ] Change color palette — verify arrow lines, dots, and arrowheads all update to the new palette colors
- [ ] Verify each variable gets its own color from the palette (cycling if more variables than palette colors)
- [ ] Zoom in on the plot, then change palette — verify zoom state is preserved (no full re-render)
- [ ] Verify `colorByMagnitude` mode still works (HSL gradient arrowheads)