### PR TITLE
refactor: centralize NIPALS and KernelPCA algorithm constants (#484)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,56 @@ type AnalysisConfig struct {
 	PreviewMaxRows int `json:"preview_max_rows"`
 }
 
+// AlgorithmConfig holds tunable parameters for PCA algorithms.
+// These values affect the accuracy/performance trade-off of iterative methods.
+type AlgorithmConfig struct {
+	// NIPALS algorithm parameters
+	NIPALS NIPALSConfig `json:"nipals"`
+
+	// Kernel PCA algorithm parameters
+	KernelPCA KernelPCAConfig `json:"kernel_pca"`
+}
+
+// NIPALSConfig holds parameters for the NIPALS (Nonlinear Iterative Partial Least Squares)
+// power-iteration algorithm used for standard and missing-value PCA.
+//
+// Reference: Wold (1966), "Estimation of principal components and related models
+// by iterative least squares", in Multivariate Analysis, pp. 391-420.
+type NIPALSConfig struct {
+	// Convergence tolerance: iteration stops when the change in the score vector
+	// (Euclidean norm of t_new - t_old) falls below this threshold.
+	// Smaller values give more precise components at the cost of more iterations.
+	Tolerance float64 `json:"tolerance"`
+
+	// Maximum number of power iterations per component.
+	// For well-conditioned data, convergence typically occurs in <50 iterations.
+	// Increase only if you see "did not converge" warnings on ill-conditioned data.
+	MaxIterations int `json:"max_iterations"`
+}
+
+// KernelPCAConfig holds parameters for the Kernel PCA algorithm.
+type KernelPCAConfig struct {
+	// Minimum eigenvalue: eigenvalues below this threshold are clamped to it
+	// to avoid division-by-zero when normalizing eigenvectors.
+	// This is a numerical stability guard, not a truncation criterion.
+	MinEigenvalue float64 `json:"min_eigenvalue"`
+}
+
+// DefaultAlgorithmConfig returns algorithm parameters suitable for typical
+// well-conditioned datasets. Override these only when working with
+// ill-conditioned data or when tighter numerical precision is required.
+func DefaultAlgorithmConfig() AlgorithmConfig {
+	return AlgorithmConfig{
+		NIPALS: NIPALSConfig{
+			Tolerance:     1e-8,
+			MaxIterations: 1000,
+		},
+		KernelPCA: KernelPCAConfig{
+			MinEigenvalue: 1e-10,
+		},
+	}
+}
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() *CLIConfig {
 	return &CLIConfig{

--- a/internal/core/kernel_pca.go
+++ b/internal/core/kernel_pca.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/bitjungle/gopca/internal/config"
 	"github.com/bitjungle/gopca/pkg/security"
 	"github.com/bitjungle/gopca/pkg/types"
 	"gonum.org/v1/gonum/mat"
@@ -177,13 +178,15 @@ func (kpca *KernelPCAImpl) eigenDecomposition(K *mat.Dense, k int) ([]float64, [
 		return vals[idx[i]] > vals[idx[j]]
 	})
 
-	// Store all eigenvalues in sorted order for variance calculation
+	// Store all eigenvalues in sorted order for variance calculation.
+	// Near-zero or negative eigenvalues (numerical noise) are clamped to the
+	// minimum threshold to prevent division-by-zero during eigenvector normalization.
+	minEig := config.DefaultAlgorithmConfig().KernelPCA.MinEigenvalue
 	allSortedVals := make([]float64, nVals)
 	for i := 0; i < nVals; i++ {
 		allSortedVals[i] = vals[idx[i]]
-		// Handle near-zero or negative eigenvalues
-		if allSortedVals[i] < 1e-10 {
-			allSortedVals[i] = 1e-10
+		if allSortedVals[i] < minEig {
+			allSortedVals[i] = minEig
 		}
 	}
 

--- a/internal/core/pca.go
+++ b/internal/core/pca.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/bitjungle/gopca/internal/config"
 	"github.com/bitjungle/gopca/internal/utils"
 	"github.com/bitjungle/gopca/pkg/types"
 	"gonum.org/v1/gonum/mat"
@@ -262,9 +263,11 @@ func (p *PCAImpl) nipalsAlgorithm(X *mat.Dense, nComponents int) (*mat.Dense, *m
 	// Working copy of X for deflation
 	Xwork := CreateWorkingCopy(X)
 
-	// Tolerance for convergence
-	const tolerance = 1e-8
-	const maxIter = 1000
+	// Convergence parameters from centralized algorithm config.
+	// See internal/config/config.go for documentation and rationale.
+	algConfig := config.DefaultAlgorithmConfig()
+	tolerance := algConfig.NIPALS.Tolerance
+	maxIter := algConfig.NIPALS.MaxIterations
 
 	for k := 0; k < nComponents; k++ {
 		// Find column with maximum variance for initialization
@@ -395,9 +398,11 @@ func (p *PCAImpl) nipalsAlgorithmWithMissing(X *mat.Dense, nComponents int) (*ma
 		centerMatrixWithMissing(Xwork, columnMeans)
 	}
 
-	// Tolerance for convergence
-	const tolerance = 1e-8
-	const maxIter = 1000
+	// Convergence parameters from centralized algorithm config.
+	// See internal/config/config.go for documentation and rationale.
+	algConfig := config.DefaultAlgorithmConfig()
+	tolerance := algConfig.NIPALS.Tolerance
+	maxIter := algConfig.NIPALS.MaxIterations
 
 	for k := 0; k < nComponents; k++ {
 		// Find column with maximum variance (considering only non-missing values)


### PR DESCRIPTION
## Summary

- Adds `AlgorithmConfig` to `internal/config/config.go` with two sub-structs:
  - `NIPALSConfig` — convergence `Tolerance` (1e-8) and `MaxIterations` (1000), with documentation explaining the trade-off
  - `KernelPCAConfig` — `MinEigenvalue` (1e-10) clamping threshold for numerical stability
- Replaces the two duplicated `const tolerance / maxIter` blocks in `pca.go` with `config.DefaultAlgorithmConfig()`
- Replaces the hardcoded `1e-10` threshold in `kernel_pca.go` with the same

No behaviour change — values are identical to before. The constants are now in one documented place instead of scattered across algorithm files.

## Scope (what was NOT changed)

The issue also lists frontend hard-coded values and security limits. Those are left as-is:
- Security limits in `pkg/security/input_validation.go` are intentionally hard-coded for safety
- Frontend values (`plotConfig.ts`, `gui_config.go`) already have appropriate homes or are minor UI details
- `DefaultColumnTypeDetectionSampleSize` in `pkg/types/csv_detector.go` is already surfaced through `config.go`'s `TypeDetectionSampleSize`

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/core/ ./internal/config/ ./pkg/types/` — all pass
- [x] Pre-commit hooks (fmt, vet, full test suite) — all pass

Fixes #484