### PR TITLE
chore: update copyright year to 2025-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rune Mathisen
+Copyright (c) 2025-2026 Rune Mathisen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/app_test.go
+++ b/cmd/gocsv/app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/commands.go
+++ b/cmd/gocsv/commands.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/commands_test.go
+++ b/cmd/gocsv/commands_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/AboutDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/AboutDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/CSVGrid.tsx
+++ b/cmd/gocsv/frontend/src/components/CSVGrid.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/ColumnIcons.tsx
+++ b/cmd/gocsv/frontend/src/components/ColumnIcons.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/CorrelationMatrix.tsx
+++ b/cmd/gocsv/frontend/src/components/CorrelationMatrix.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/DataPreview.tsx
+++ b/cmd/gocsv/frontend/src/components/DataPreview.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/DataQualityDashboard.tsx
+++ b/cmd/gocsv/frontend/src/components/DataQualityDashboard.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/DataTransformDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/DataTransformDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/DocumentationViewer.tsx
+++ b/cmd/gocsv/frontend/src/components/DocumentationViewer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/FileSelector.tsx
+++ b/cmd/gocsv/frontend/src/components/FileSelector.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/FormatOptions.tsx
+++ b/cmd/gocsv/frontend/src/components/FormatOptions.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/ImportProgress.tsx
+++ b/cmd/gocsv/frontend/src/components/ImportProgress.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/ImportWizard.tsx
+++ b/cmd/gocsv/frontend/src/components/ImportWizard.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/MissingValueDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/MissingValueDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/MissingValueSummary.tsx
+++ b/cmd/gocsv/frontend/src/components/MissingValueSummary.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/PlotlyDistributionChart.tsx
+++ b/cmd/gocsv/frontend/src/components/PlotlyDistributionChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/QualityScoreCard.tsx
+++ b/cmd/gocsv/frontend/src/components/QualityScoreCard.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/RenameDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/RenameDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/UndoRedoControls.tsx
+++ b/cmd/gocsv/frontend/src/components/UndoRedoControls.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/ValidationResults.tsx
+++ b/cmd/gocsv/frontend/src/components/ValidationResults.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/components/index.ts
+++ b/cmd/gocsv/frontend/src/components/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/hooks/useFileOperations.ts
+++ b/cmd/gocsv/frontend/src/hooks/useFileOperations.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/main.tsx
+++ b/cmd/gocsv/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/src/vite-env.d.ts
+++ b/cmd/gocsv/frontend/src/vite-env.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/frontend/vite.config.ts
+++ b/cmd/gocsv/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/json_utils.go
+++ b/cmd/gocsv/json_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/main.go
+++ b/cmd/gocsv/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gocsv/utils.go
+++ b/cmd/gocsv/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-cli/main.go
+++ b/cmd/gopca-cli/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/app_test.go
+++ b/cmd/gopca-desktop/app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/App.tsx
+++ b/cmd/gopca-desktop/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/__mocks__/@gopca/ui-components.tsx
+++ b/cmd/gopca-desktop/frontend/src/__mocks__/@gopca/ui-components.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Mock for @gopca/ui-components — used in Vitest.
 import React from 'react';
 import { vi } from 'vitest';

--- a/cmd/gopca-desktop/frontend/src/components/AboutDialog.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/AboutDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/ChartContainer.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/ChartContainer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/DataTable.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/DocumentationViewer.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/DocumentationViewer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/ExportButton.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/ExportButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/FontSizeControl.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/FontSizeControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/HelpDisplay.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/HelpDisplay.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/HelpWrapper.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/HelpWrapper.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/MatrixIllustration.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/MatrixIllustration.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/ModelOverview.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/ModelOverview.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/PaletteSelector.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/PlotControls.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/PlotControls.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/SelectionTable.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/SelectionTable.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/index.ts
+++ b/cmd/gopca-desktop/frontend/src/components/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/sections/DataLoadSection.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/sections/DataLoadSection.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/sections/PCAConfigSection.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/sections/PCAConfigSection.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/sections/ResultsSection.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/sections/ResultsSection.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based PCA Biplot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot3D.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Biplot3D.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based 3D PCA Biplot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/CircleOfCorrelations.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based Circle of Correlations
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/DiagnosticScatterPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based PCA Diagnostic Plot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/EigencorrelationPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/EigencorrelationPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based Eigencorrelation Plot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/KernelMatrixHeatmap.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/KernelMatrixHeatmap.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Kernel Matrix Heatmap - Visualizes pairwise similarities in kernel space
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/LoadingsPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based PCA Loadings Plot
 
 import React, { useMemo } from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/SampleContributionPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/SampleContributionPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Sample Contribution Plot - Shows which samples contribute most to each PC
 
 import React, { useState, useMemo } from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/Scores3DPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/Scores3DPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScoresPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based PCA Scores Plot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/ScreePlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/ScreePlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based PCA Scree Plot
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/TemporalLoadingsPlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/TemporalLoadingsPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based Temporal Loadings (U matrix) Visualization
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/TemporalVariableImportancePlot.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/TemporalVariableImportancePlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly-based Temporal Variable Importance Visualization
 
 import React from 'react';

--- a/cmd/gopca-desktop/frontend/src/components/visualizations/index.ts
+++ b/cmd/gopca-desktop/frontend/src/components/visualizations/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/FileDataContext.test.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/FileDataContext.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';

--- a/cmd/gopca-desktop/frontend/src/contexts/FileDataContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/FileDataContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/GoCSVContext.test.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/GoCSVContext.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';

--- a/cmd/gopca-desktop/frontend/src/contexts/GoCSVContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/GoCSVContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/HelpContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/HelpContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/PCAContext.test.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/PCAContext.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';

--- a/cmd/gopca-desktop/frontend/src/contexts/PCAContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/PCAContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/PaletteContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/PaletteContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/UIContext.test.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/UIContext.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';

--- a/cmd/gopca-desktop/frontend/src/contexts/UIContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/UIContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/contexts/VisualizationContext.test.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/VisualizationContext.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';

--- a/cmd/gopca-desktop/frontend/src/contexts/VisualizationContext.tsx
+++ b/cmd/gopca-desktop/frontend/src/contexts/VisualizationContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useAppInit.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useAppInit.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useChartCommon.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useChartCommon.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useChartTheme.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useChartTheme.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useEllipses.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useEllipses.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useFileData.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useFileData.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useGoCSVIntegration.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useGoCSVIntegration.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useHelpHover.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useHelpHover.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/usePCAConfig.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/usePCAConfig.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/usePCARunner.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/usePCARunner.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useUIState.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useUIState.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/hooks/useVisualization.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useVisualization.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/main.tsx
+++ b/cmd/gopca-desktop/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/test/setup.ts
+++ b/cmd/gopca-desktop/frontend/src/test/setup.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Test setup: extends expect with jest-dom matchers.
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';

--- a/cmd/gopca-desktop/frontend/src/types/global.d.ts
+++ b/cmd/gopca-desktop/frontend/src/types/global.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/types/index.ts
+++ b/cmd/gopca-desktop/frontend/src/types/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/chartDataHelpers.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/chartDataHelpers.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/cliCommandGenerator.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // CLI command generation for GoPCA Desktop
 
 import { optimizeToRanges } from './rangeOptimizer';

--- a/cmd/gopca-desktop/frontend/src/utils/colorPalettes.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/colorPalettes.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/ellipseUtils.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/ellipseUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/exportHelpers.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/exportHelpers.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/labelUtils.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/labelUtils.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/logger.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/logger.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/plotlyDataTransform.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/plotlyDataTransform.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/src/utils/rangeOptimizer.ts
+++ b/cmd/gopca-desktop/frontend/src/utils/rangeOptimizer.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Utility for optimizing arrays of indices to range notation
 
 /**

--- a/cmd/gopca-desktop/frontend/src/vite-env.d.ts
+++ b/cmd/gopca-desktop/frontend/src/vite-env.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/frontend/vite.config.ts
+++ b/cmd/gopca-desktop/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/json_helpers.go
+++ b/cmd/gopca-desktop/json_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/json_helpers_test.go
+++ b/cmd/gopca-desktop/json_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/main.go
+++ b/cmd/gopca-desktop/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/cmd/gopca-desktop/parse_csv.go
+++ b/cmd/gopca-desktop/parse_csv.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cli/cli_cobra.go
+++ b/internal/cli/cli_cobra.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/analyze.go
+++ b/internal/cobra/analyze.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/analyze_test.go
+++ b/internal/cobra/analyze_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/completion.go
+++ b/internal/cobra/completion.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/helpers.go
+++ b/internal/cobra/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/output.go
+++ b/internal/cobra/output.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/root.go
+++ b/internal/cobra/root.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/transform.go
+++ b/internal/cobra/transform.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/validate.go
+++ b/internal/cobra/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/cobra/version.go
+++ b/internal/cobra/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/config/gui_config.go
+++ b/internal/config/gui_config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/benchmark_test.go
+++ b/internal/core/benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/consistency_test.go
+++ b/internal/core/consistency_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/correlation.go
+++ b/internal/core/correlation.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/correlation_test.go
+++ b/internal/core/correlation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/crossmethod_validation_test.go
+++ b/internal/core/crossmethod_validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/edgecase_test.go
+++ b/internal/core/edgecase_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/kernel_pca.go
+++ b/internal/core/kernel_pca.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/kernel_pca_gamma_test.go
+++ b/internal/core/kernel_pca_gamma_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/kernel_pca_memory_test.go
+++ b/internal/core/kernel_pca_memory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/kernel_pca_scaling_test.go
+++ b/internal/core/kernel_pca_scaling_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/kernel_pca_test.go
+++ b/internal/core/kernel_pca_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/kernel_pca_visualization_test.go
+++ b/internal/core/kernel_pca_visualization_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/matrix_helpers.go
+++ b/internal/core/matrix_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/memory_test.go
+++ b/internal/core/memory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/method_comparison_test.go
+++ b/internal/core/method_comparison_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/missing_handler.go
+++ b/internal/core/missing_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/missing_handler_test.go
+++ b/internal/core/missing_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/nipals_helpers.go
+++ b/internal/core/nipals_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/nipals_helpers_test.go
+++ b/internal/core/nipals_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/nipals_missing_test.go
+++ b/internal/core/nipals_missing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/pca.go
+++ b/internal/core/pca.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/pca_preprocessing_test.go
+++ b/internal/core/pca_preprocessing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/pca_test.go
+++ b/internal/core/pca_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/performance_test.go
+++ b/internal/core/performance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/preprocessing.go
+++ b/internal/core/preprocessing.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/preprocessing_scaleonly_test.go
+++ b/internal/core/preprocessing_scaleonly_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/preprocessing_test.go
+++ b/internal/core/preprocessing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/stability_test.go
+++ b/internal/core/stability_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/statistics.go
+++ b/internal/core/statistics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/statistics_test.go
+++ b/internal/core/statistics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/temporal_pca.go
+++ b/internal/core/temporal_pca.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/temporal_pca_cumulative_test.go
+++ b/internal/core/temporal_pca_cumulative_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/temporal_pca_test.go
+++ b/internal/core/temporal_pca_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/core/transform_validation_test.go
+++ b/internal/core/transform_validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/core/validation.go
+++ b/internal/core/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/datasets/embedded.go
+++ b/internal/datasets/embedded.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/integration/exclusion_test.go
+++ b/internal/integration/exclusion_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/internal/utils/matrix.go
+++ b/internal/utils/matrix.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/utils/path_validator.go
+++ b/internal/utils/path_validator.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/utils/path_validator_test.go
+++ b/internal/utils/path_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/utils/range_parser.go
+++ b/internal/utils/range_parser.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/utils/range_parser_test.go
+++ b/internal/utils/range_parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/PlotlyBarChart.tsx
+++ b/packages/ui-components/src/charts/PlotlyBarChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/PlotlyComposedChart.tsx
+++ b/packages/ui-components/src/charts/PlotlyComposedChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/PlotlyLineChart.tsx
+++ b/packages/ui-components/src/charts/PlotlyLineChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/PlotlyScatterChart.tsx
+++ b/packages/ui-components/src/charts/PlotlyScatterChart.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/assets/watermark.ts
+++ b/packages/ui-components/src/charts/assets/watermark.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/config/plotConfig.ts
+++ b/packages/ui-components/src/charts/config/plotConfig.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/core/PlotlyVisualization.tsx
+++ b/packages/ui-components/src/charts/core/PlotlyVisualization.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/index.ts
+++ b/packages/ui-components/src/charts/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DBiplot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/Plotly3DScoresPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyBiplot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyBiplot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyCircleOfCorrelations.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyDiagnosticPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyEigencorrelationPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyLoadingsPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyLoadingsPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyScoresPlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyScreePlot.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyScreePlot.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyTemporalLoadings.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyTemporalLoadings.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/PlotlyTemporalVariableImportance.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyTemporalVariableImportance.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/pca/index.ts
+++ b/packages/ui-components/src/charts/pca/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/plotly-bundle.ts
+++ b/packages/ui-components/src/charts/plotly-bundle.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Plotly bundle for PCA visualizations
 // Using the full minified distribution to ensure all features work correctly
 

--- a/packages/ui-components/src/charts/types.ts
+++ b/packages/ui-components/src/charts/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/utils/index.ts
+++ b/packages/ui-components/src/charts/utils/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/packages/ui-components/src/charts/utils/plotlyExport.ts
+++ b/packages/ui-components/src/charts/utils/plotlyExport.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Export utilities for high-quality Plotly visualizations
 
 import { PlotlyHTMLElement } from 'plotly.js';

--- a/packages/ui-components/src/charts/utils/plotlyFullscreen.tsx
+++ b/packages/ui-components/src/charts/utils/plotlyFullscreen.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/charts/utils/plotlyHelpers.ts
+++ b/packages/ui-components/src/charts/utils/plotlyHelpers.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/packages/ui-components/src/charts/utils/plotlyMath.ts
+++ b/packages/ui-components/src/charts/utils/plotlyMath.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Mathematical utilities for Plotly visualizations with academic references
 
 export interface Point2D {

--- a/packages/ui-components/src/charts/utils/plotlyPerformance.ts
+++ b/packages/ui-components/src/charts/utils/plotlyPerformance.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Performance optimization utilities for Plotly visualizations
 
 import { Data } from 'plotly.js';

--- a/packages/ui-components/src/charts/utils/plotlyTheme.ts
+++ b/packages/ui-components/src/charts/utils/plotlyTheme.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/packages/ui-components/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/packages/ui-components/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ConfirmDialog/index.ts
+++ b/packages/ui-components/src/components/ConfirmDialog/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/CustomSelect.tsx
+++ b/packages/ui-components/src/components/CustomSelect.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/packages/ui-components/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-components/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/Dialog/index.ts
+++ b/packages/ui-components/src/components/Dialog/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/DocumentationViewer.tsx
+++ b/packages/ui-components/src/components/DocumentationViewer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/packages/ui-components/src/components/ErrorAlert/ErrorAlert.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/ui-components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ErrorPage/ErrorPage.tsx
+++ b/packages/ui-components/src/components/ErrorPage/ErrorPage.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ErrorToast/ErrorToast.tsx
+++ b/packages/ui-components/src/components/ErrorToast/ErrorToast.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ExportButton/ExportButton.tsx
+++ b/packages/ui-components/src/components/ExportButton/ExportButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ExportButton/index.ts
+++ b/packages/ui-components/src/components/ExportButton/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/FileSelector/FileSelector.tsx
+++ b/packages/ui-components/src/components/FileSelector/FileSelector.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/FileSelector/index.ts
+++ b/packages/ui-components/src/components/FileSelector/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/FontSizeControl/FontSizeControl.tsx
+++ b/packages/ui-components/src/components/FontSizeControl/FontSizeControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/InputDialog/InputDialog.tsx
+++ b/packages/ui-components/src/components/InputDialog/InputDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/InputDialog/index.ts
+++ b/packages/ui-components/src/components/InputDialog/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/ui-components/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/MarkdownRenderer.tsx
+++ b/packages/ui-components/src/components/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/ui-components/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ProgressIndicator/index.ts
+++ b/packages/ui-components/src/components/ProgressIndicator/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ThemeToggle/index.ts
+++ b/packages/ui-components/src/components/ThemeToggle/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/components/ValidationError/ValidationError.tsx
+++ b/packages/ui-components/src/components/ValidationError/ValidationError.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/contexts/ThemeContext/ThemeContext.tsx
+++ b/packages/ui-components/src/contexts/ThemeContext/ThemeContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/contexts/ThemeContext/index.ts
+++ b/packages/ui-components/src/contexts/ThemeContext/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/dialogs/AboutDialog.tsx
+++ b/packages/ui-components/src/dialogs/AboutDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/dialogs/AboutDialog.tsx
+++ b/packages/ui-components/src/dialogs/AboutDialog.tsx
@@ -60,7 +60,7 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
 
                     <div className="border-t border-gray-200 dark:border-gray-700 pt-4 w-full">
                         <p className="text-sm text-gray-700 dark:text-gray-300">
-                            © 2025 bitjungle - Rune Mathisen
+                            © 2025-2026 bitjungle - Rune Mathisen
                         </p>
                         <p className="text-sm text-gray-700 dark:text-gray-300">
                             All rights reserved.

--- a/packages/ui-components/src/hooks/useChartTheme.ts
+++ b/packages/ui-components/src/hooks/useChartTheme.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/hooks/useLoadingState.ts
+++ b/packages/ui-components/src/hooks/useLoadingState.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/types/images.d.ts
+++ b/packages/ui-components/src/types/images.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/utils/chartTheme.ts
+++ b/packages/ui-components/src/utils/chartTheme.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/utils/errorHandling.ts
+++ b/packages/ui-components/src/utils/errorHandling.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/src/utils/errorTemplates.ts
+++ b/packages/ui-components/src/utils/errorTemplates.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/packages/ui-components/vite.config.ts
+++ b/packages/ui-components/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/doc.go
+++ b/pkg/csv/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/csv/output.go
+++ b/pkg/csv/output.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/reader.go
+++ b/pkg/csv/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/reader_test.go
+++ b/pkg/csv/reader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/types.go
+++ b/pkg/csv/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/validation.go
+++ b/pkg/csv/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/validation_test.go
+++ b/pkg/csv/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/csv/writer_test.go
+++ b/pkg/csv/writer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/app_integration.go
+++ b/pkg/integration/app_integration.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/app_integration_test.go
+++ b/pkg/integration/app_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/integration/event_bus.go
+++ b/pkg/integration/event_bus.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/event_bus_test.go
+++ b/pkg/integration/event_bus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/integration_phase4_test.go
+++ b/pkg/integration/integration_phase4_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/json_consistency.go
+++ b/pkg/integration/json_consistency.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/integration/temp_file_manager.go
+++ b/pkg/integration/temp_file_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/profiling/leak_detector.go
+++ b/pkg/profiling/leak_detector.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/profiling/memory_profiler.go
+++ b/pkg/profiling/memory_profiler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/command_security.go
+++ b/pkg/security/command_security.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/command_security_test.go
+++ b/pkg/security/command_security_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/doc.go
+++ b/pkg/security/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/security/input_validation.go
+++ b/pkg/security/input_validation.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/input_validation_test.go
+++ b/pkg/security/input_validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/path_security.go
+++ b/pkg/security/path_security.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/path_security_test.go
+++ b/pkg/security/path_security_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/testutil/helpers.go
+++ b/pkg/testutil/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv.go
+++ b/pkg/types/csv.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_detector.go
+++ b/pkg/types/csv_detector.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_detector_test.go
+++ b/pkg/types/csv_detector_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_mixed.go
+++ b/pkg/types/csv_mixed.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_mixed_target_test.go
+++ b/pkg/types/csv_mixed_target_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_mixed_test.go
+++ b/pkg/types/csv_mixed_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/csv_test.go
+++ b/pkg/types/csv_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/doc.go
+++ b/pkg/types/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/types/errors.go
+++ b/pkg/types/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/json.go
+++ b/pkg/types/json.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/json_helpers.go
+++ b/pkg/types/json_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/json_helpers_test.go
+++ b/pkg/types/json_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/types/json_test.go
+++ b/pkg/types/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/pca.go
+++ b/pkg/types/pca.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/types/preprocessing.go
+++ b/pkg/types/preprocessing.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 

--- a/pkg/utils/missing.go
+++ b/pkg/utils/missing.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/utils/missing_test.go
+++ b/pkg/utils/missing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/utils/parsing.go
+++ b/pkg/utils/parsing.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/utils/parsing_test.go
+++ b/pkg/utils/parsing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/validation/schema.go
+++ b/pkg/validation/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for

--- a/pkg/validation/schema_test.go
+++ b/pkg/validation/schema_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 bitjungle - Rune Mathisen. All rights reserved.
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 // The author respectfully requests that it not be used for


### PR DESCRIPTION
## Summary

- Updates `LICENSE` file copyright from `2025` to `2025-2026`
- Updates all source file headers (`*.go`, `*.ts`, `*.tsx`) from `Copyright 2025 bitjungle` to `Copyright 2025-2026 bitjungle` (282 files)

Using a year range is the standard practice for active projects — it records the year work began while indicating continued activity, and won't need touching again until v2.0 or a similar major new effort.