### PR TITLE
fix: replace alert() calls with ErrorAlert component in GoCSV (#495)

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './App.css';
 import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, AboutDialog } from './components';
-import { ConfirmDialog, ErrorBoundary } from '@gopca/ui-components';
+import { ConfirmDialog, ErrorBoundary, ErrorAlert } from '@gopca/ui-components';
 import { ThemeProvider, ThemeToggle } from '@gopca/ui-components';
 import logo from './assets/images/GoCSV-logo-1024-transp.png';
 import { LoadCSV, SaveCSV, SaveExcel, ValidateForGoPCA, AnalyzeMissingValues, FillMissingValues, AnalyzeDataQuality, CheckGoPCAStatus, OpenInGoPCA, DownloadGoPCA, ExecuteCellEdit, ExecuteHeaderEdit, ClearHistory, GetVersion } from '../wailsjs/go/main/App';
@@ -37,6 +37,7 @@ function AppContent() {
     const [showAboutDialog, setShowAboutDialog] = useState(false);
     const [showDownloadConfirm, setShowDownloadConfirm] = useState(false);
     const [version, setVersion] = useState<string>('');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     // Ref for scrolling to Step 2
     const step2Ref = useRef<HTMLDivElement>(null);
@@ -67,7 +68,7 @@ function AppContent() {
                 if (filePath.match(/\.(csv|tsv|xlsx|xls)$/i)) {
                     await handleDroppedFile(filePath);
                 } else {
-                    alert('Please drop a supported file type: CSV, TSV, or Excel files');
+                    setErrorMessage('Unsupported file type. Please drop a CSV, TSV, or Excel file.');
                 }
             }
         }, false);
@@ -131,7 +132,7 @@ function AppContent() {
                 setDataQualityReport(null);
                 setValidationResult(null);
             } else {
-                alert('Failed to load file or file is empty');
+                setErrorMessage('Could not load file — the file appears to be empty or invalid. Is it a valid CSV, TSV, or Excel file?');
             }
         } catch (error) {
             console.error('Error loading dropped file:', error);
@@ -158,7 +159,7 @@ function AppContent() {
         } catch (error: any) {
             console.error('Error loading file:', error);
             const errorMsg = error?.message || error?.toString() || 'Unknown error';
-            alert('Error loading file: ' + errorMsg);
+            setErrorMessage('Could not load file — ' + errorMsg);
             setFileLoaded(false);
             setFileName(null);
         } finally {
@@ -233,7 +234,7 @@ return;
             setShowMissingValueSummary(true);
         } catch (error) {
             console.error('Error analyzing missing values:', error);
-            alert('Error analyzing missing values: ' + error);
+            setErrorMessage('Could not analyze missing values — ' + (error instanceof Error ? error.message : String(error)));
         }
     };
 
@@ -259,7 +260,7 @@ return;
             }
         } catch (error) {
             console.error('Error filling missing values:', error);
-            alert('Error filling missing values: ' + error);
+            setErrorMessage('Could not fill missing values — ' + (error instanceof Error ? error.message : String(error)));
         }
     };
 
@@ -326,6 +327,15 @@ return;
             {/* Main content area */}
             <main className="flex-1 overflow-y-auto p-4 md:p-6 max-w-7xl mx-auto w-full">
                 <div className="space-y-6">
+                    {/* Error display */}
+                    {errorMessage && (
+                        <ErrorAlert
+                            title="Error"
+                            message={errorMessage}
+                            onDismiss={() => setErrorMessage(null)}
+                        />
+                    )}
+
                     {/* Step 1: Load Data - matching GoPCA's card style */}
                     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 animate-fadeIn">
                         <h2 className="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-200">
@@ -427,7 +437,7 @@ return;
                                                 setShowDataQualityReport(true);
                                             } catch (error) {
                                                 console.error('Error analyzing data quality:', error);
-                                                alert('Error analyzing data quality: ' + error);
+                                                setErrorMessage('Could not analyze data quality — ' + (error instanceof Error ? error.message : String(error)));
                                             } finally {
                                                 setIsAnalyzingQuality(false);
                                             }
@@ -558,7 +568,7 @@ return;
                                                 await OpenInGoPCA(fileData);
                                             } catch (error) {
                                                 console.error('Error opening in GoPCA:', error);
-                                                alert('Error opening in GoPCA: ' + error);
+                                                setErrorMessage('Could not open in GoPCA — ' + (error instanceof Error ? error.message : String(error)));
                                             }
                                         }}
                                         disabled={!gopcaStatus || isCheckingGoPCA}
@@ -590,7 +600,7 @@ return;
                                                         await SaveCSV(fileData);
                                                     } catch (error) {
                                                         console.error('Error saving file:', error);
-                                                        alert('Error saving file: ' + error);
+                                                        setErrorMessage('Could not save file — ' + (error instanceof Error ? error.message : String(error)));
                                                     }
                                                 }
                                             }}
@@ -605,7 +615,7 @@ return;
                                                         await SaveExcel(fileData);
                                                     } catch (error) {
                                                         console.error('Error saving Excel file:', error);
-                                                        alert('Error saving Excel file: ' + error);
+                                                        setErrorMessage('Could not save Excel file — ' + (error instanceof Error ? error.message : String(error)));
                                                     }
                                                 }
                                             }}


### PR DESCRIPTION
## Summary

- Replaces all 9 native `alert()` calls in `cmd/gocsv/frontend/src/App.tsx` with dismissible `ErrorAlert` components from `@gopca/ui-components`
- Error messages use actionable language ("Could not load file — ...") instead of raw exception strings
- Uses the standard `err instanceof Error ? err.message : String(err)` extraction pattern consistently

## Test plan

- [ ] Load a valid CSV — no change in behavior
- [ ] Drop an unsupported file type (e.g. `.pdf`) — error banner appears, no browser alert
- [ ] Drop an empty or corrupted CSV — error banner appears with descriptive message
- [ ] Load a file via dialog, then cancel — no error shown
- [ ] Load a file via dialog with an invalid file — error banner appears, is dismissible
- [ ] Trigger "Analyze Missing Values" error (e.g. with empty data) — error banner appears
- [ ] Save CSV/Excel with no file path — error banner appears
- [ ] Confirm error banners are dismissible (✕ button)
- [ ] Test in both light and dark themes

Fixes #495