### PR TITLE
fix: track unsaved changes and warn on GoCSV close (#477)

### DIFF
--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -30,9 +30,10 @@ import (
 
 // App struct
 type App struct {
-	ctx         context.Context
-	history     *CommandHistory
-	currentData *FileData
+	ctx               context.Context
+	history           *CommandHistory
+	currentData       *FileData
+	hasUnsavedChanges bool
 }
 
 // NewApp creates a new App application struct
@@ -46,6 +47,34 @@ func NewApp() *App {
 // so we can call the runtime methods
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+}
+
+// markDirty marks the app as having unsaved changes and notifies the frontend.
+// Only emits an event on the first transition to dirty to avoid noise.
+func (a *App) markDirty() {
+	if !a.hasUnsavedChanges {
+		a.hasUnsavedChanges = true
+		if a.ctx != nil {
+			wailsruntime.EventsEmit(a.ctx, "unsaved-state-changed", true)
+		}
+	}
+}
+
+// markClean marks the app as having no unsaved changes and notifies the frontend.
+// Called after a successful save or when a new file is loaded.
+func (a *App) markClean() {
+	if a.hasUnsavedChanges {
+		a.hasUnsavedChanges = false
+		if a.ctx != nil {
+			wailsruntime.EventsEmit(a.ctx, "unsaved-state-changed", false)
+		}
+	}
+}
+
+// HasUnsavedChanges returns true if there are unsaved data changes.
+// Used by OnBeforeClose to determine whether to prompt the user.
+func (a *App) HasUnsavedChanges() bool {
+	return a.hasUnsavedChanges
 }
 
 // ValidationResult represents the result of GoPCA validation
@@ -134,6 +163,7 @@ func (a *App) LoadCSV(filePath string) (*FileData, error) {
 	a.currentData = fileData
 	// Clear history when loading new file
 	a.history.Clear()
+	a.markClean()
 	if a.ctx != nil {
 		wailsruntime.EventsEmit(a.ctx, "undo-redo-state-changed", a.GetUndoRedoState())
 	}
@@ -561,6 +591,7 @@ func (a *App) SaveCSV(data *FileData) error {
 	}
 
 	wailsruntime.EventsEmit(a.ctx, "file-saved", filepath.Base(selection))
+	a.markClean()
 	return nil
 }
 
@@ -701,6 +732,7 @@ func (a *App) SaveExcel(data *FileData) error {
 	}
 
 	wailsruntime.EventsEmit(a.ctx, "file-saved", filepath.Base(selection))
+	a.markClean()
 	return nil
 }
 
@@ -938,6 +970,7 @@ func (a *App) FillMissingValues(data *FileData, request FillMissingValuesRequest
 		}
 	}
 
+	a.markDirty()
 	return result, nil
 }
 
@@ -2164,6 +2197,7 @@ func (a *App) Undo(data *FileData) (*FileData, error) {
 	if err := a.history.Undo(data); err != nil {
 		return nil, err
 	}
+	a.markDirty()
 	// Emit event to update UI
 	wailsruntime.EventsEmit(a.ctx, "undo-redo-state-changed", a.GetUndoRedoState())
 	// Return the modified data
@@ -2175,6 +2209,7 @@ func (a *App) Redo(data *FileData) (*FileData, error) {
 	if err := a.history.Redo(data); err != nil {
 		return nil, err
 	}
+	a.markDirty()
 	// Emit event to update UI
 	wailsruntime.EventsEmit(a.ctx, "undo-redo-state-changed", a.GetUndoRedoState())
 	// Return the modified data
@@ -2206,6 +2241,7 @@ func (a *App) executeCommand(cmd Command, data *FileData, operation string) (*Fi
 		return nil, fmt.Errorf("%s: %w", operation, err)
 	}
 	a.currentData = data // Store the current data
+	a.markDirty()
 
 	if a.ctx != nil {
 		wailsruntime.EventsEmit(a.ctx, "undo-redo-state-changed", a.GetUndoRedoState())
@@ -2978,6 +3014,7 @@ func (a *App) ApplyTransformation(data *FileData, options TransformOptions) (*Tr
 		return nil, fmt.Errorf("apply transformation: %w", err)
 	}
 	a.currentData = data // Store the current data
+	a.markDirty()
 	if a.ctx != nil {
 		wailsruntime.EventsEmit(a.ctx, "undo-redo-state-changed", a.GetUndoRedoState())
 	}

--- a/cmd/gocsv/app_test.go
+++ b/cmd/gocsv/app_test.go
@@ -135,6 +135,82 @@ func TestAppMultiStepUndoRedo(t *testing.T) {
 	}
 }
 
+// TestUnsavedChanges verifies that HasUnsavedChanges, markDirty, and markClean
+// track state transitions correctly without requiring a Wails context.
+// Note: ctx is nil here so EventsEmit is not called; this is intentional.
+func TestUnsavedChanges(t *testing.T) {
+	t.Run("InitialStateIsClean", func(t *testing.T) {
+		app := NewApp()
+		if app.HasUnsavedChanges() {
+			t.Error("expected clean on fresh app")
+		}
+	})
+
+	t.Run("MarkDirtySetsDirty", func(t *testing.T) {
+		app := NewApp()
+		app.markDirty()
+		if !app.HasUnsavedChanges() {
+			t.Error("expected dirty after markDirty")
+		}
+	})
+
+	t.Run("MarkCleanClearsDirty", func(t *testing.T) {
+		app := NewApp()
+		app.markDirty()
+		app.markClean()
+		if app.HasUnsavedChanges() {
+			t.Error("expected clean after markClean")
+		}
+	})
+
+	t.Run("ExecuteCellEditMarksDirty", func(t *testing.T) {
+		app := NewApp()
+		data := &FileData{
+			Headers: []string{"A"},
+			Data:    [][]string{{"1"}},
+			Rows:    1, Columns: 1,
+		}
+		app.currentData = data
+		_, err := app.executeCommand(NewCellEditCommand(0, 0, "1", "2"), data, "edit")
+		if err != nil {
+			t.Fatalf("executeCommand failed: %v", err)
+		}
+		if !app.HasUnsavedChanges() {
+			t.Error("expected dirty after executeCommand")
+		}
+	})
+
+	t.Run("MarkCleanAfterEditResetsFlag", func(t *testing.T) {
+		app := NewApp()
+		data := &FileData{
+			Headers: []string{"A"},
+			Data:    [][]string{{"1"}},
+			Rows:    1, Columns: 1,
+		}
+		app.currentData = data
+		_, _ = app.executeCommand(NewCellEditCommand(0, 0, "1", "2"), data, "edit")
+		app.markClean()
+		if app.HasUnsavedChanges() {
+			t.Error("expected clean after markClean following edit")
+		}
+	})
+
+	t.Run("SimulatedLoadResetsFlag", func(t *testing.T) {
+		app := NewApp()
+		app.markDirty()
+
+		// Simulate what LoadCSV does internally
+		data := &FileData{Headers: []string{"X"}, Data: [][]string{{"1"}}, Rows: 1, Columns: 1}
+		app.currentData = data
+		app.history.Clear()
+		app.markClean()
+
+		if app.HasUnsavedChanges() {
+			t.Error("expected clean after simulated LoadCSV")
+		}
+	})
+}
+
 func TestCommandHistoryWithMultipleOperations(t *testing.T) {
 	// Create app
 	app := NewApp()

--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './App.css';
 import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, AboutDialog } from './components';
-import { ConfirmDialog, ErrorBoundary } from '@gopca/ui-components';
+import { ConfirmDialog, ErrorBoundary, ErrorAlert } from '@gopca/ui-components';
 import { ThemeProvider, ThemeToggle } from '@gopca/ui-components';
 import logo from './assets/images/GoCSV-logo-1024-transp.png';
 import { LoadCSV, SaveCSV, SaveExcel, ValidateForGoPCA, AnalyzeMissingValues, FillMissingValues, AnalyzeDataQuality, CheckGoPCAStatus, OpenInGoPCA, DownloadGoPCA, ExecuteCellEdit, ExecuteHeaderEdit, ClearHistory, GetVersion } from '../wailsjs/go/main/App';
@@ -37,6 +37,8 @@ function AppContent() {
     const [showAboutDialog, setShowAboutDialog] = useState(false);
     const [showDownloadConfirm, setShowDownloadConfirm] = useState(false);
     const [version, setVersion] = useState<string>('');
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     // Ref for scrolling to Step 2
     const step2Ref = useRef<HTMLDivElement>(null);
@@ -47,6 +49,9 @@ function AppContent() {
     useEffect(() => {
         const unsubscribe = EventsOn('file-loaded', (filename: string) => {
             setFileName(filename);
+        });
+        const unsubscribeUnsaved = EventsOn('unsaved-state-changed', (dirty: boolean) => {
+            setHasUnsavedChanges(dirty);
         });
 
         // Check GoPCA status on startup
@@ -67,13 +72,14 @@ function AppContent() {
                 if (filePath.match(/\.(csv|tsv|xlsx|xls)$/i)) {
                     await handleDroppedFile(filePath);
                 } else {
-                    alert('Please drop a supported file type: CSV, TSV, or Excel files');
+                    setErrorMessage('Unsupported file type. Please drop a CSV, TSV, or Excel file.');
                 }
             }
         }, false);
 
         return () => {
             unsubscribe();
+            unsubscribeUnsaved();
             OnFileDropOff();
         };
     }, []);
@@ -131,7 +137,7 @@ function AppContent() {
                 setDataQualityReport(null);
                 setValidationResult(null);
             } else {
-                alert('Failed to load file or file is empty');
+                setErrorMessage('Could not load file — the file appears to be empty or invalid. Is it a valid CSV, TSV, or Excel file?');
             }
         } catch (error) {
             console.error('Error loading dropped file:', error);
@@ -158,7 +164,7 @@ function AppContent() {
         } catch (error: any) {
             console.error('Error loading file:', error);
             const errorMsg = error?.message || error?.toString() || 'Unknown error';
-            alert('Error loading file: ' + errorMsg);
+            setErrorMessage('Could not load file — ' + errorMsg);
             setFileLoaded(false);
             setFileName(null);
         } finally {
@@ -233,7 +239,7 @@ return;
             setShowMissingValueSummary(true);
         } catch (error) {
             console.error('Error analyzing missing values:', error);
-            alert('Error analyzing missing values: ' + error);
+            setErrorMessage('Could not analyze missing values — ' + (error instanceof Error ? error.message : String(error)));
         }
     };
 
@@ -259,7 +265,7 @@ return;
             }
         } catch (error) {
             console.error('Error filling missing values:', error);
-            alert('Error filling missing values: ' + error);
+            setErrorMessage('Could not fill missing values — ' + (error instanceof Error ? error.message : String(error)));
         }
     };
 
@@ -292,8 +298,17 @@ return;
                             className="h-12 cursor-pointer hover:opacity-90 transition-opacity flex-shrink-0"
                             onClick={handleLogoClick}
                         />
-                        <div>
+                        <div className="flex items-center gap-3">
                             <p className="text-sm text-gray-600 dark:text-gray-400">Data Editor for GoPCA</p>
+                            {hasUnsavedChanges && (
+                                <span
+                                    title="Unsaved changes"
+                                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                                >
+                                    <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                                    Unsaved
+                                </span>
+                            )}
                         </div>
                     </div>
                     <div className="flex items-center gap-4">
@@ -326,6 +341,15 @@ return;
             {/* Main content area */}
             <main className="flex-1 overflow-y-auto p-4 md:p-6 max-w-7xl mx-auto w-full">
                 <div className="space-y-6">
+                    {/* Error display */}
+                    {errorMessage && (
+                        <ErrorAlert
+                            title="Error"
+                            message={errorMessage}
+                            onDismiss={() => setErrorMessage(null)}
+                        />
+                    )}
+
                     {/* Step 1: Load Data - matching GoPCA's card style */}
                     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 animate-fadeIn">
                         <h2 className="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-200">
@@ -427,7 +451,7 @@ return;
                                                 setShowDataQualityReport(true);
                                             } catch (error) {
                                                 console.error('Error analyzing data quality:', error);
-                                                alert('Error analyzing data quality: ' + error);
+                                                setErrorMessage('Could not analyze data quality — ' + (error instanceof Error ? error.message : String(error)));
                                             } finally {
                                                 setIsAnalyzingQuality(false);
                                             }
@@ -558,7 +582,7 @@ return;
                                                 await OpenInGoPCA(fileData);
                                             } catch (error) {
                                                 console.error('Error opening in GoPCA:', error);
-                                                alert('Error opening in GoPCA: ' + error);
+                                                setErrorMessage('Could not open in GoPCA — ' + (error instanceof Error ? error.message : String(error)));
                                             }
                                         }}
                                         disabled={!gopcaStatus || isCheckingGoPCA}
@@ -590,7 +614,7 @@ return;
                                                         await SaveCSV(fileData);
                                                     } catch (error) {
                                                         console.error('Error saving file:', error);
-                                                        alert('Error saving file: ' + error);
+                                                        setErrorMessage('Could not save file — ' + (error instanceof Error ? error.message : String(error)));
                                                     }
                                                 }
                                             }}
@@ -605,7 +629,7 @@ return;
                                                         await SaveExcel(fileData);
                                                     } catch (error) {
                                                         console.error('Error saving Excel file:', error);
-                                                        alert('Error saving Excel file: ' + error);
+                                                        setErrorMessage('Could not save Excel file — ' + (error instanceof Error ? error.message : String(error)));
                                                     }
                                                 }
                                             }}

--- a/cmd/gocsv/main.go
+++ b/cmd/gocsv/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 
 	"github.com/wailsapp/wails/v2"
@@ -14,6 +15,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 //go:embed all:frontend/dist
@@ -36,7 +38,25 @@ func main() {
 			Assets: assets,
 		},
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
-		OnStartup:        app.startup,
+		OnStartup: app.startup,
+		OnBeforeClose: func(ctx context.Context) bool {
+			if !app.HasUnsavedChanges() {
+				return false // allow close
+			}
+			result, err := wailsruntime.MessageDialog(ctx, wailsruntime.MessageDialogOptions{
+				Type:          wailsruntime.QuestionDialog,
+				Title:         "Unsaved Changes",
+				Message:       "You have unsaved changes. Close anyway?",
+				Buttons:       []string{"Close anyway", "Cancel"},
+				DefaultButton: "Cancel",
+				CancelButton:  "Cancel",
+			})
+			if err != nil {
+				return false // if dialog fails, allow close
+			}
+			// Block close if user chose Cancel
+			return result == "Cancel"
+		},
 		Bind: []interface{}{
 			app,
 		},

--- a/scripts/ci/test-core.sh
+++ b/scripts/ci/test-core.sh
@@ -54,7 +54,7 @@ cd cmd/gocsv
 mkdir -p frontend/dist
 echo '<!DOCTYPE html><html><body>Test</body></html>' > frontend/dist/index.html
 
-if ! go test -v -cover -run "TestMultiStepUndoRedo|TestUndoRedoState" .; then
+if ! go test -v -cover -run "TestMultiStepUndoRedo|TestUndoRedoState|TestUnsavedChanges" .; then
     echo "✗ GoCSV tests failed"
     cd ../..
     exit 1


### PR DESCRIPTION
## Summary

- Adds `hasUnsavedChanges` tracking to GoCSV's Go backend
- Shows a native dialog when closing with unsaved changes
- Displays an amber "Unsaved" badge in the header when data is modified

**Backend changes (`app.go`):**
- `hasUnsavedChanges bool` field on `App` struct
- `markDirty()` / `markClean()` helpers emit `unsaved-state-changed` event to frontend
- `HasUnsavedChanges() bool` exported Wails binding
- `markDirty()` called from all mutation paths: `executeCommand`, `Undo`, `Redo`, `FillMissingValues`, `ApplyTransformation`
- `markClean()` called on `LoadCSV`, `SaveCSV`, `SaveExcel`

**Backend changes (`main.go`):**
- `OnBeforeClose` hook shows a native `QuestionDialog` if there are unsaved changes; blocks the close if user chooses Cancel

**Frontend changes (`App.tsx`):**
- Listens for `unsaved-state-changed` event
- Amber "Unsaved" badge visible in header when dirty, hidden when clean
- Also includes the `alert()` → `ErrorAlert` replacements from #495 (this branch is independent)

**Tests:**
- `TestUnsavedChanges` with 6 sub-tests (initial state, markDirty, markClean, executeCommand, save reset, load reset)
- Added to CI test pattern in `scripts/ci/test-core.sh`

## Test plan

- [ ] Load a CSV file — no "Unsaved" badge in header
- [ ] Edit a cell — amber "Unsaved" badge appears
- [ ] Save (Export as CSV) — badge disappears
- [ ] Edit a cell, try to close — native dialog appears: "You have unsaved changes. Close anyway?"
- [ ] In dialog, choose "Cancel" — window stays open
- [ ] In dialog, choose "Close anyway" — app closes
- [ ] Load a file after editing (without saving) — badge disappears on load
- [ ] Undo/Redo operations — badge appears
- [ ] Fill missing values — badge appears
- [ ] Apply transformation — badge appears
- [ ] Test in both light and dark themes

Fixes #477