### PR TITLE
feat(transform): extract pkg/transform from cmd/gocsv/app.go (#640)

### DIFF
--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -10,11 +10,9 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -24,6 +22,7 @@ import (
 	"github.com/bitjungle/gopca/internal/version"
 	"github.com/bitjungle/gopca/pkg/dataquality"
 	"github.com/bitjungle/gopca/pkg/integration"
+	"github.com/bitjungle/gopca/pkg/transform"
 	"github.com/bitjungle/gopca/pkg/types"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 	"github.com/xuri/excelize/v2"
@@ -1811,544 +1810,71 @@ func (a *App) ApplyTransformation(data *FileData, options TransformOptions) (*Tr
 	return cmd.result, nil
 }
 
-// applyTransformationInternal is the internal implementation of transformation
+// applyTransformationInternal delegates to pkg/transform and maps the result
+// back into the FileData-based TransformationResult expected by the Wails layer.
 func (a *App) applyTransformationInternal(data *FileData, options TransformOptions) (*TransformationResult, error) {
 	if data == nil || len(data.Data) == 0 {
 		return nil, fmt.Errorf("no data to transform")
 	}
 
-	result := &TransformationResult{
-		Success:            true,
-		TransformedColumns: []string{},
-		Messages:           []string{},
+	in := transform.Input{
+		Data:               data.Data,
+		Headers:            data.Headers,
+		ColumnTypes:        data.ColumnTypes,
+		CategoricalColumns: data.CategoricalColumns,
+		Rows:               data.Rows,
+		Columns:            data.Columns,
+	}
+	opts := transform.Options{
+		Type:     transform.Type(options.Type),
+		Columns:  options.Columns,
+		BinCount: options.BinCount,
+		MinValue: options.MinValue,
+		MaxValue: options.MaxValue,
 	}
 
-	// Create a copy of the data
+	res, err := transform.Apply(in, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	newData := &FileData{
-		Headers:              make([]string, len(data.Headers)),
-		Data:                 make([][]string, len(data.Data)),
+		Headers:              res.Headers,
+		Data:                 res.Data,
 		Rows:                 data.Rows,
-		Columns:              data.Columns,
-		CategoricalColumns:   make(map[string][]string),
+		Columns:              res.Columns,
+		CategoricalColumns:   res.CategoricalColumns,
 		NumericTargetColumns: make(map[string][]types.JSONFloat64),
-		ColumnTypes:          make(map[string]string),
+		ColumnTypes:          res.ColumnTypes,
 	}
-
-	// Copy headers
-	copy(newData.Headers, data.Headers)
-
-	// Copy data
-	for i := range data.Data {
-		newData.Data[i] = make([]string, len(data.Data[i]))
-		copy(newData.Data[i], data.Data[i])
-	}
-
-	// Copy row names if present
 	if data.RowNames != nil {
 		newData.RowNames = make([]string, len(data.RowNames))
 		copy(newData.RowNames, data.RowNames)
 	}
-
-	// Copy column types
-	for k, v := range data.ColumnTypes {
-		newData.ColumnTypes[k] = v
+	// Carry over any numeric target columns untouched.
+	for k, v := range data.NumericTargetColumns {
+		newData.NumericTargetColumns[k] = v
 	}
 
-	// Apply transformation based on type
-	switch options.Type {
-	case TransformLog, TransformSqrt, TransformSquare:
-		err := a.applyMathTransformation(newData, options, result)
-		if err != nil {
-			return nil, err
-		}
-	case TransformStandardize:
-		err := a.applyStandardization(newData, options, result)
-		if err != nil {
-			return nil, err
-		}
-	case TransformMinMax:
-		err := a.applyMinMaxScaling(newData, options, result)
-		if err != nil {
-			return nil, err
-		}
-	case TransformBin:
-		err := a.applyBinning(newData, options, result)
-		if err != nil {
-			return nil, err
-		}
-	case TransformOneHot:
-		err := a.applyOneHotEncoding(newData, options, result)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unsupported transformation type: %s", options.Type)
-	}
-
-	result.Data = newData
-	return result, nil
+	return &TransformationResult{
+		Success:            true,
+		TransformedColumns: res.TransformedColumns,
+		NewColumns:         res.NewColumns,
+		Messages:           res.Messages,
+		Data:               newData,
+	}, nil
 }
 
-// applyMathTransformation applies mathematical transformations (log, sqrt, square)
-func (a *App) applyMathTransformation(data *FileData, options TransformOptions, result *TransformationResult) error {
-	for _, colName := range options.Columns {
-		// Find column index
-		colIndex := -1
-		for i, header := range data.Headers {
-			if header == colName {
-				colIndex = i
-				break
-			}
-		}
-
-		if colIndex == -1 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
-			continue
-		}
-
-		// Check if column is numeric
-		if data.ColumnTypes[colName] != "numeric" {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
-			continue
-		}
-
-		// Apply transformation
-		transformedCount := 0
-		for i := range data.Data {
-			if colIndex >= len(data.Data[i]) {
-				continue
-			}
-
-			value := strings.TrimSpace(data.Data[i][colIndex])
-			if value == "" {
-				continue
-			}
-
-			num, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				continue
-			}
-
-			var transformed float64
-			switch options.Type {
-			case TransformLog:
-				if num <= 0 {
-					result.Messages = append(result.Messages, fmt.Sprintf("Warning: Non-positive value in row %d, column '%s' - cannot apply log", i+1, colName))
-					continue
-				}
-				transformed = math.Log(num)
-			case TransformSqrt:
-				if num < 0 {
-					result.Messages = append(result.Messages, fmt.Sprintf("Warning: Negative value in row %d, column '%s' - cannot apply sqrt", i+1, colName))
-					continue
-				}
-				transformed = math.Sqrt(num)
-			case TransformSquare:
-				transformed = num * num
-			}
-
-			data.Data[i][colIndex] = fmt.Sprintf("%.6g", transformed)
-			transformedCount++
-		}
-
-		result.TransformedColumns = append(result.TransformedColumns, colName)
-		result.Messages = append(result.Messages, fmt.Sprintf("Transformed %d values in column '%s'", transformedCount, colName))
-	}
-
-	return nil
-}
-
-// applyStandardization applies z-score standardization
-func (a *App) applyStandardization(data *FileData, options TransformOptions, result *TransformationResult) error {
-	for _, colName := range options.Columns {
-		// Find column index
-		colIndex := -1
-		for i, header := range data.Headers {
-			if header == colName {
-				colIndex = i
-				break
-			}
-		}
-
-		if colIndex == -1 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
-			continue
-		}
-
-		// Check if column is numeric
-		if data.ColumnTypes[colName] != "numeric" {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
-			continue
-		}
-
-		// Collect values
-		values := []float64{}
-		indices := []int{}
-		for i := range data.Data {
-			if colIndex >= len(data.Data[i]) {
-				continue
-			}
-
-			value := strings.TrimSpace(data.Data[i][colIndex])
-			if value == "" {
-				continue
-			}
-
-			num, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				continue
-			}
-
-			values = append(values, num)
-			indices = append(indices, i)
-		}
-
-		if len(values) < 2 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has insufficient numeric values for standardization", colName))
-			continue
-		}
-
-		// Calculate mean and std dev
-		mean := 0.0
-		for _, v := range values {
-			mean += v
-		}
-		mean /= float64(len(values))
-
-		variance := 0.0
-		for _, v := range values {
-			variance += (v - mean) * (v - mean)
-		}
-		variance /= float64(len(values))
-		stdDev := math.Sqrt(variance)
-
-		if stdDev < 1e-10 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has zero variance, cannot standardize", colName))
-			continue
-		}
-
-		// Apply standardization
-		for i, idx := range indices {
-			standardized := (values[i] - mean) / stdDev
-			data.Data[idx][colIndex] = fmt.Sprintf("%.6g", standardized)
-		}
-
-		result.TransformedColumns = append(result.TransformedColumns, colName)
-		result.Messages = append(result.Messages, fmt.Sprintf("Standardized %d values in column '%s' (mean=%.3f, std=%.3f)", len(values), colName, mean, stdDev))
-	}
-
-	return nil
-}
-
-// applyMinMaxScaling applies min-max scaling
-func (a *App) applyMinMaxScaling(data *FileData, options TransformOptions, result *TransformationResult) error {
-	targetMin := options.MinValue
-	targetMax := options.MaxValue
-	if targetMax <= targetMin {
-		targetMin = 0.0
-		targetMax = 1.0
-	}
-
-	for _, colName := range options.Columns {
-		// Find column index
-		colIndex := -1
-		for i, header := range data.Headers {
-			if header == colName {
-				colIndex = i
-				break
-			}
-		}
-
-		if colIndex == -1 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
-			continue
-		}
-
-		// Check if column is numeric
-		if data.ColumnTypes[colName] != "numeric" {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
-			continue
-		}
-
-		// Collect values and find min/max
-		values := []float64{}
-		indices := []int{}
-		minVal := math.Inf(1)
-		maxVal := math.Inf(-1)
-
-		for i := range data.Data {
-			if colIndex >= len(data.Data[i]) {
-				continue
-			}
-
-			value := strings.TrimSpace(data.Data[i][colIndex])
-			if value == "" {
-				continue
-			}
-
-			num, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				continue
-			}
-
-			values = append(values, num)
-			indices = append(indices, i)
-
-			if num < minVal {
-				minVal = num
-			}
-			if num > maxVal {
-				maxVal = num
-			}
-		}
-
-		if len(values) == 0 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no numeric values", colName))
-			continue
-		}
-
-		if maxVal <= minVal {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has constant values, cannot scale", colName))
-			continue
-		}
-
-		// Apply min-max scaling
-		for i, idx := range indices {
-			scaled := (values[i]-minVal)/(maxVal-minVal)*(targetMax-targetMin) + targetMin
-			data.Data[idx][colIndex] = fmt.Sprintf("%.6g", scaled)
-		}
-
-		result.TransformedColumns = append(result.TransformedColumns, colName)
-		result.Messages = append(result.Messages, fmt.Sprintf("Scaled %d values in column '%s' to range [%.2f, %.2f]", len(values), colName, targetMin, targetMax))
-	}
-
-	return nil
-}
-
-// applyBinning applies binning to numeric columns
-func (a *App) applyBinning(data *FileData, options TransformOptions, result *TransformationResult) error {
-	binCount := options.BinCount
-	if binCount <= 0 {
-		binCount = 5 // Default to 5 bins
-	}
-
-	for _, colName := range options.Columns {
-		// Find column index
-		colIndex := -1
-		for i, header := range data.Headers {
-			if header == colName {
-				colIndex = i
-				break
-			}
-		}
-
-		if colIndex == -1 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
-			continue
-		}
-
-		// Check if column is numeric
-		if data.ColumnTypes[colName] != "numeric" {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
-			continue
-		}
-
-		// Collect values and find min/max
-		values := []float64{}
-		indices := []int{}
-		minVal := math.Inf(1)
-		maxVal := math.Inf(-1)
-
-		for i := range data.Data {
-			if colIndex >= len(data.Data[i]) {
-				continue
-			}
-
-			value := strings.TrimSpace(data.Data[i][colIndex])
-			if value == "" {
-				continue
-			}
-
-			num, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				continue
-			}
-
-			values = append(values, num)
-			indices = append(indices, i)
-
-			if num < minVal {
-				minVal = num
-			}
-			if num > maxVal {
-				maxVal = num
-			}
-		}
-
-		if len(values) == 0 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no numeric values", colName))
-			continue
-		}
-
-		// Create bins
-		binWidth := (maxVal - minVal) / float64(binCount)
-
-		// Apply binning
-		for i, idx := range indices {
-			binIndex := int((values[i] - minVal) / binWidth)
-			if binIndex >= binCount {
-				binIndex = binCount - 1
-			}
-
-			binLabel := fmt.Sprintf("Bin_%d", binIndex+1)
-			data.Data[idx][colIndex] = binLabel
-		}
-
-		// Update column type to categorical
-		data.ColumnTypes[colName] = "categorical"
-
-		// Update categorical columns
-		catValues := make([]string, len(data.Data))
-		for i := range data.Data {
-			if colIndex < len(data.Data[i]) {
-				catValues[i] = data.Data[i][colIndex]
-			}
-		}
-		data.CategoricalColumns[colName] = catValues
-
-		result.TransformedColumns = append(result.TransformedColumns, colName)
-		result.Messages = append(result.Messages, fmt.Sprintf("Binned %d values in column '%s' into %d bins", len(values), colName, binCount))
-	}
-
-	return nil
-}
-
-// applyOneHotEncoding applies one-hot encoding to categorical columns
-func (a *App) applyOneHotEncoding(data *FileData, options TransformOptions, result *TransformationResult) error {
-	for _, colName := range options.Columns {
-		// Find column index
-		colIndex := -1
-		for i, header := range data.Headers {
-			if header == colName {
-				colIndex = i
-				break
-			}
-		}
-
-		if colIndex == -1 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
-			continue
-		}
-
-		// Check if column is categorical
-		if data.ColumnTypes[colName] != "categorical" {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not categorical, skipping", colName))
-			continue
-		}
-
-		// Get unique values
-		uniqueValues := make(map[string]bool)
-		for i := range data.Data {
-			if colIndex >= len(data.Data[i]) {
-				continue
-			}
-			value := strings.TrimSpace(data.Data[i][colIndex])
-			if value != "" {
-				uniqueValues[value] = true
-			}
-		}
-
-		if len(uniqueValues) == 0 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no values", colName))
-			continue
-		}
-
-		if len(uniqueValues) > 20 {
-			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has too many unique values (%d), skipping one-hot encoding", colName, len(uniqueValues)))
-			continue
-		}
-
-		// Create sorted list of unique values
-		sortedValues := make([]string, 0, len(uniqueValues))
-		for val := range uniqueValues {
-			sortedValues = append(sortedValues, val)
-		}
-		sort.Strings(sortedValues)
-
-		// Add new columns for each unique value
-		newColumns := []string{}
-		for _, val := range sortedValues {
-			newColName := fmt.Sprintf("%s_%s", colName, val)
-			data.Headers = append(data.Headers, newColName)
-			data.ColumnTypes[newColName] = "numeric"
-			newColumns = append(newColumns, newColName)
-
-			// Add the encoded values
-			for i := range data.Data {
-				if colIndex < len(data.Data[i]) && strings.TrimSpace(data.Data[i][colIndex]) == val {
-					data.Data[i] = append(data.Data[i], "1")
-				} else {
-					data.Data[i] = append(data.Data[i], "0")
-				}
-			}
-		}
-
-		// Remove original column
-		data.Headers = append(data.Headers[:colIndex], data.Headers[colIndex+1:]...)
-		delete(data.ColumnTypes, colName)
-		delete(data.CategoricalColumns, colName)
-
-		for i := range data.Data {
-			if colIndex < len(data.Data[i]) {
-				data.Data[i] = append(data.Data[i][:colIndex], data.Data[i][colIndex+1:]...)
-			}
-		}
-
-		data.Columns = len(data.Headers)
-
-		result.TransformedColumns = append(result.TransformedColumns, colName)
-		result.NewColumns = append(result.NewColumns, newColumns...)
-		result.Messages = append(result.Messages, fmt.Sprintf("One-hot encoded column '%s' into %d new columns", colName, len(newColumns)))
-
-		// Adjust indices for remaining columns
-		for j := range options.Columns {
-			if j > 0 && options.Columns[j] != colName {
-				// Need to find and update column index if it was after the removed column
-				for _, h := range data.Headers {
-					if h == options.Columns[j] {
-						// Update for next iteration
-						break
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// GetTransformableColumns returns columns that can be transformed
+// GetTransformableColumns returns columns eligible for the given transformation type.
 func (a *App) GetTransformableColumns(data *FileData, transformType TransformationType) []string {
-	columns := []string{}
-
-	for _, header := range data.Headers {
-		colType := data.ColumnTypes[header]
-
-		switch transformType {
-		case TransformLog, TransformSqrt, TransformSquare, TransformStandardize, TransformMinMax, TransformBin:
-			// These transformations require numeric columns
-			if colType == "numeric" && !strings.HasSuffix(header, "#target") {
-				columns = append(columns, header)
-			}
-		case TransformOneHot:
-			// One-hot encoding requires categorical columns
-			if colType == "categorical" {
-				columns = append(columns, header)
-			}
-		}
+	in := transform.Input{
+		Data:        data.Data,
+		Headers:     data.Headers,
+		ColumnTypes: data.ColumnTypes,
+		Rows:        data.Rows,
+		Columns:     data.Columns,
 	}
-
-	return columns
+	return transform.GetTransformableColumns(in, transform.Type(transformType))
 }
 
 // ExecuteDeleteRows deletes multiple rows with undo support

--- a/pkg/transform/binning.go
+++ b/pkg/transform/binning.go
@@ -67,6 +67,11 @@ func applyBin(data [][]string, columnTypes map[string]string, catCols map[string
 			continue
 		}
 
+		if maxVal <= minVal {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has constant values, cannot bin", colName))
+			continue
+		}
+
 		binWidth := (maxVal - minVal) / float64(binCount)
 
 		for i, idx := range indices {

--- a/pkg/transform/binning.go
+++ b/pkg/transform/binning.go
@@ -1,0 +1,96 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// applyBin discretizes the specified numeric columns into equal-width bins.
+// Each value is replaced with a label "Bin_N" (1-indexed). The column type is
+// updated to "categorical" and the binned values are registered in catCols.
+func applyBin(data [][]string, columnTypes map[string]string, catCols map[string][]string, headers []string, opts Options, result *Result) error {
+	binCount := opts.BinCount
+	if binCount <= 0 {
+		binCount = 5 // default number of bins
+	}
+
+	for _, colName := range opts.Columns {
+		colIndex := findColumn(headers, colName)
+		if colIndex == -1 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
+			continue
+		}
+
+		if columnTypes[colName] != "numeric" {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
+			continue
+		}
+
+		// Collect numeric values and their row positions.
+		values := make([]float64, 0)
+		indices := make([]int, 0)
+		minVal := math.Inf(1)
+		maxVal := math.Inf(-1)
+
+		for i := range data {
+			if colIndex >= len(data[i]) {
+				continue
+			}
+			v := strings.TrimSpace(data[i][colIndex])
+			if v == "" {
+				continue
+			}
+			num, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				continue
+			}
+			values = append(values, num)
+			indices = append(indices, i)
+			if num < minVal {
+				minVal = num
+			}
+			if num > maxVal {
+				maxVal = num
+			}
+		}
+
+		if len(values) == 0 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no numeric values", colName))
+			continue
+		}
+
+		binWidth := (maxVal - minVal) / float64(binCount)
+
+		for i, idx := range indices {
+			binIndex := int((values[i] - minVal) / binWidth)
+			if binIndex >= binCount {
+				binIndex = binCount - 1
+			}
+			data[idx][colIndex] = fmt.Sprintf("Bin_%d", binIndex+1)
+		}
+
+		// Update metadata.
+		columnTypes[colName] = "categorical"
+
+		catValues := make([]string, len(data))
+		for i := range data {
+			if colIndex < len(data[i]) {
+				catValues[i] = data[i][colIndex]
+			}
+		}
+		catCols[colName] = catValues
+
+		result.TransformedColumns = append(result.TransformedColumns, colName)
+		result.Messages = append(result.Messages, fmt.Sprintf("Binned %d values in column '%s' into %d bins", len(values), colName, binCount))
+	}
+
+	return nil
+}

--- a/pkg/transform/binning_test.go
+++ b/pkg/transform/binning_test.go
@@ -152,6 +152,30 @@ func TestApply_Bin_NonNumericColumn(t *testing.T) {
 	}
 }
 
+func TestApply_Bin_ConstantColumn(t *testing.T) {
+	// All values identical — binWidth would be 0 → must be handled gracefully.
+	in := Input{
+		Data:               [][]string{{"5"}, {"5"}, {"5"}},
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               3,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns for constant-value column")
+	}
+	if len(res.Messages) == 0 {
+		t.Error("expected message explaining why binning was skipped")
+	}
+}
+
 func TestApply_Bin_NoNumericValues(t *testing.T) {
 	in := Input{
 		Data:               [][]string{{""}},

--- a/pkg/transform/binning_test.go
+++ b/pkg/transform/binning_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ─── Binning ──────────────────────────────────────────────────────────────────
+
+func TestApply_Bin_DefaultBinCount(t *testing.T) {
+	// 10 values uniformly spaced → 5 bins (default).
+	data := make([][]string, 10)
+	for i := range data {
+		data[i] = []string{fmt.Sprintf("%d", i+1)} // 1..10
+	}
+	in := Input{
+		Data:               data,
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               10,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply bin: %v", err)
+	}
+
+	// Count distinct bin labels produced.
+	bins := map[string]int{}
+	for _, row := range res.Data {
+		bins[row[0]]++
+	}
+	if len(bins) != 5 {
+		t.Errorf("expected 5 distinct bins, got %d: %v", len(bins), bins)
+	}
+
+	// Column type should now be categorical.
+	if res.ColumnTypes["X"] != "categorical" {
+		t.Errorf("expected column type 'categorical' after binning, got %q", res.ColumnTypes["X"])
+	}
+
+	// CategoricalColumns should contain "X".
+	if _, ok := res.CategoricalColumns["X"]; !ok {
+		t.Error("expected 'X' to be registered in CategoricalColumns after binning")
+	}
+}
+
+func TestApply_Bin_CustomBinCount(t *testing.T) {
+	// 9 values 1..9 → 3 bins.
+	data := make([][]string, 9)
+	for i := range data {
+		data[i] = []string{fmt.Sprintf("%d", i+1)}
+	}
+	in := Input{
+		Data:               data,
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               9,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}, BinCount: 3})
+	if err != nil {
+		t.Fatalf("Apply bin custom count: %v", err)
+	}
+
+	bins := map[string]int{}
+	for _, row := range res.Data {
+		bins[row[0]]++
+	}
+	if len(bins) != 3 {
+		t.Errorf("expected 3 bins, got %d: %v", len(bins), bins)
+	}
+}
+
+func TestApply_Bin_AllValuesAssigned(t *testing.T) {
+	// Every row should receive a bin label (not remain numeric or empty).
+	data := [][]string{{"1"}, {"5"}, {"10"}, {"3"}, {"7"}, {"2"}}
+	in := Input{
+		Data:               data,
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               len(data),
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}, BinCount: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i, row := range res.Data {
+		if !strings.HasPrefix(row[0], "Bin_") {
+			t.Errorf("row %d: expected Bin_* label, got %q", i, row[0])
+		}
+	}
+}
+
+func TestApply_Bin_CorrectBinBoundaries(t *testing.T) {
+	// Values: 0, 3, 6, 9 with binCount=3 → bin width=3.
+	// 0 → Bin_1, 3 → Bin_2 (or Bin_1 boundary), 6 → Bin_3 (or Bin_2), 9 → Bin_3
+	data := [][]string{{"0"}, {"3"}, {"6"}, {"9"}}
+	in := Input{
+		Data:               data,
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               4,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}, BinCount: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The last value (9) hits exactly binIndex==3 which should be clamped to Bin_3.
+	lastBin := res.Data[3][0]
+	if lastBin != "Bin_3" {
+		t.Errorf("expected last value to land in Bin_3 (clamped), got %q", lastBin)
+	}
+}
+
+func TestApply_Bin_NonNumericColumn(t *testing.T) {
+	in := Input{
+		Data:               [][]string{{"cat"}},
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "categorical"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               1,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns for categorical column")
+	}
+}
+
+func TestApply_Bin_NoNumericValues(t *testing.T) {
+	in := Input{
+		Data:               [][]string{{""}},
+		Headers:            []string{"X"},
+		ColumnTypes:        map[string]string{"X": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               1,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: Bin, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns when no numeric values")
+	}
+	if len(res.Messages) == 0 {
+		t.Error("expected message for empty column")
+	}
+}

--- a/pkg/transform/doc.go
+++ b/pkg/transform/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+// Package transform implements data transformations for tabular CSV data.
+//
+// All functions operate on [][]string data matrices with associated metadata
+// (headers, column types). This design keeps the package free of any dependency
+// on application-level types (such as FileData) so it can be shared across
+// application entry points without circular imports.
+//
+// Supported transformations:
+//   - Mathematical: log, sqrt, square (element-wise, numeric columns)
+//   - Scaling: z-score standardization, min-max scaling (numeric columns)
+//   - Discretization: equal-width binning (numeric → categorical)
+//   - Encoding: one-hot encoding (categorical → multiple numeric columns)
+//
+// The primary entry points are:
+//   - [Apply] — execute a transformation and return the modified data
+//   - [GetTransformableColumns] — list columns eligible for a given transformation
+package transform

--- a/pkg/transform/encoding.go
+++ b/pkg/transform/encoding.go
@@ -1,0 +1,97 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// applyOneHot performs one-hot encoding on the specified categorical columns.
+// For each column, K new binary columns are added (one per unique value), then
+// the original column is removed. Column order in headers and data is updated
+// accordingly.
+//
+// Columns with more than 20 unique non-missing values are skipped to avoid
+// combinatorial explosion.
+func applyOneHot(data [][]string, columnTypes map[string]string, catCols map[string][]string, headers *[]string, opts Options, result *Result) error {
+	for _, colName := range opts.Columns {
+		colIndex := findColumn(*headers, colName)
+		if colIndex == -1 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
+			continue
+		}
+
+		if columnTypes[colName] != "categorical" {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not categorical, skipping", colName))
+			continue
+		}
+
+		// Gather unique non-empty values.
+		uniqueSet := make(map[string]bool)
+		for i := range data {
+			if colIndex >= len(data[i]) {
+				continue
+			}
+			v := strings.TrimSpace(data[i][colIndex])
+			if v != "" {
+				uniqueSet[v] = true
+			}
+		}
+
+		if len(uniqueSet) == 0 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no values", colName))
+			continue
+		}
+
+		if len(uniqueSet) > 20 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has too many unique values (%d), skipping one-hot encoding", colName, len(uniqueSet)))
+			continue
+		}
+
+		sortedValues := make([]string, 0, len(uniqueSet))
+		for v := range uniqueSet {
+			sortedValues = append(sortedValues, v)
+		}
+		sort.Strings(sortedValues)
+
+		// Append one new column per unique value.
+		newColumns := make([]string, 0, len(sortedValues))
+		for _, val := range sortedValues {
+			newColName := fmt.Sprintf("%s_%s", colName, val)
+			*headers = append(*headers, newColName)
+			columnTypes[newColName] = "numeric"
+			newColumns = append(newColumns, newColName)
+
+			for i := range data {
+				if colIndex < len(data[i]) && strings.TrimSpace(data[i][colIndex]) == val {
+					data[i] = append(data[i], "1")
+				} else {
+					data[i] = append(data[i], "0")
+				}
+			}
+		}
+
+		// Remove the original column from headers and each row.
+		*headers = append((*headers)[:colIndex], (*headers)[colIndex+1:]...)
+		delete(columnTypes, colName)
+		delete(catCols, colName)
+
+		for i := range data {
+			if colIndex < len(data[i]) {
+				data[i] = append(data[i][:colIndex], data[i][colIndex+1:]...)
+			}
+		}
+
+		result.TransformedColumns = append(result.TransformedColumns, colName)
+		result.NewColumns = append(result.NewColumns, newColumns...)
+		result.Messages = append(result.Messages, fmt.Sprintf("One-hot encoded column '%s' into %d new columns", colName, len(newColumns)))
+	}
+
+	return nil
+}

--- a/pkg/transform/encoding_test.go
+++ b/pkg/transform/encoding_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"testing"
+)
+
+// ─── One-hot encoding ─────────────────────────────────────────────────────────
+
+func TestApply_OneHot_Basic(t *testing.T) {
+	// 3 rows, 2 unique values ("a", "b") → 2 new columns, original removed.
+	in := Input{
+		Data:               [][]string{{"a"}, {"b"}, {"a"}},
+		Headers:            []string{"Cat"},
+		ColumnTypes:        map[string]string{"Cat": "categorical"},
+		CategoricalColumns: map[string][]string{"Cat": {"a", "b", "a"}},
+		Rows:               3,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"Cat"}})
+	if err != nil {
+		t.Fatalf("Apply one-hot: %v", err)
+	}
+
+	// Original column removed; 2 new columns added.
+	if res.Columns != 2 {
+		t.Errorf("expected 2 columns after one-hot, got %d", res.Columns)
+	}
+	if len(res.NewColumns) != 2 {
+		t.Errorf("expected 2 new columns, got %v", res.NewColumns)
+	}
+	if len(res.TransformedColumns) != 1 || res.TransformedColumns[0] != "Cat" {
+		t.Errorf("expected TransformedColumns=[Cat], got %v", res.TransformedColumns)
+	}
+
+	// Original column must be absent from ColumnTypes.
+	if _, exists := res.ColumnTypes["Cat"]; exists {
+		t.Error("original column 'Cat' should be removed from ColumnTypes")
+	}
+
+	// New columns must be numeric.
+	for _, col := range res.NewColumns {
+		if res.ColumnTypes[col] != "numeric" {
+			t.Errorf("new column %q should be numeric, got %q", col, res.ColumnTypes[col])
+		}
+	}
+}
+
+func TestApply_OneHot_CorrectEncoding(t *testing.T) {
+	// Values: row0="a", row1="b", row2="a"
+	// Expected: Cat_a=[1,0,1], Cat_b=[0,1,0]
+	in := Input{
+		Data:               [][]string{{"a"}, {"b"}, {"a"}},
+		Headers:            []string{"Cat"},
+		ColumnTypes:        map[string]string{"Cat": "categorical"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               3,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"Cat"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find column indices for Cat_a and Cat_b.
+	aIdx, bIdx := -1, -1
+	for i, h := range res.Headers {
+		switch h {
+		case "Cat_a":
+			aIdx = i
+		case "Cat_b":
+			bIdx = i
+		}
+	}
+	if aIdx == -1 || bIdx == -1 {
+		t.Fatalf("expected headers Cat_a and Cat_b, got %v", res.Headers)
+	}
+
+	expected := map[int]struct{ a, b string }{
+		0: {"1", "0"},
+		1: {"0", "1"},
+		2: {"1", "0"},
+	}
+	for row, exp := range expected {
+		if res.Data[row][aIdx] != exp.a {
+			t.Errorf("row %d Cat_a: expected %q, got %q", row, exp.a, res.Data[row][aIdx])
+		}
+		if res.Data[row][bIdx] != exp.b {
+			t.Errorf("row %d Cat_b: expected %q, got %q", row, exp.b, res.Data[row][bIdx])
+		}
+	}
+}
+
+func TestApply_OneHot_KColumnsForKUniqueValues(t *testing.T) {
+	// 4 unique values → 4 new binary columns.
+	in := Input{
+		Data:               [][]string{{"x"}, {"y"}, {"z"}, {"w"}, {"x"}},
+		Headers:            []string{"C"},
+		ColumnTypes:        map[string]string{"C": "categorical"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               5,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"C"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.NewColumns) != 4 {
+		t.Errorf("expected 4 new columns for 4 unique values, got %d", len(res.NewColumns))
+	}
+}
+
+func TestApply_OneHot_TooManyUniqueValues(t *testing.T) {
+	// 21 unique values → should be skipped (>20 limit).
+	data := make([][]string, 21)
+	for i := range data {
+		data[i] = []string{string(rune('A' + i))}
+	}
+	in := Input{
+		Data:               data,
+		Headers:            []string{"C"},
+		ColumnTypes:        map[string]string{"C": "categorical"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               21,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"C"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.NewColumns) != 0 {
+		t.Errorf("expected no new columns when >20 unique values, got %v", res.NewColumns)
+	}
+	if len(res.Messages) == 0 {
+		t.Error("expected a message explaining the skip")
+	}
+}
+
+func TestApply_OneHot_AllMissingColumn(t *testing.T) {
+	// All values empty → should produce a message and no new columns.
+	in := Input{
+		Data:               [][]string{{""}, {""}},
+		Headers:            []string{"C"},
+		ColumnTypes:        map[string]string{"C": "categorical"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               2,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"C"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.NewColumns) != 0 {
+		t.Errorf("expected no new columns for all-missing column, got %v", res.NewColumns)
+	}
+}
+
+func TestApply_OneHot_NonCategoricalColumn(t *testing.T) {
+	in := Input{
+		Data:               [][]string{{"1"}},
+		Headers:            []string{"N"},
+		ColumnTypes:        map[string]string{"N": "numeric"},
+		CategoricalColumns: map[string][]string{},
+		Rows:               1,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"N"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.NewColumns) != 0 {
+		t.Error("expected no new columns for numeric column")
+	}
+}
+
+func TestApply_OneHot_OriginalColumnRemoved(t *testing.T) {
+	in := Input{
+		Data:               [][]string{{"a"}, {"b"}},
+		Headers:            []string{"Cat"},
+		ColumnTypes:        map[string]string{"Cat": "categorical"},
+		CategoricalColumns: map[string][]string{"Cat": {"a", "b"}},
+		Rows:               2,
+		Columns:            1,
+	}
+
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"Cat"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, h := range res.Headers {
+		if h == "Cat" {
+			t.Error("original column 'Cat' should have been removed from Headers")
+		}
+	}
+	if _, exists := res.CategoricalColumns["Cat"]; exists {
+		t.Error("original column 'Cat' should have been removed from CategoricalColumns")
+	}
+}

--- a/pkg/transform/encoding_test.go
+++ b/pkg/transform/encoding_test.go
@@ -188,6 +188,33 @@ func TestApply_OneHot_NonCategoricalColumn(t *testing.T) {
 	}
 }
 
+func TestApply_OneHot_DoesNotMutateCategoricalColumns(t *testing.T) {
+	// Result.CategoricalColumns must be a deep copy: mutating it must not
+	// affect the original Input.CategoricalColumns slice.
+	origSlice := []string{"a", "b"}
+	in := Input{
+		Data:               [][]string{{"a"}, {"b"}},
+		Headers:            []string{"Cat"},
+		ColumnTypes:        map[string]string{"Cat": "categorical"},
+		CategoricalColumns: map[string][]string{"Cat": origSlice},
+		Rows:               2,
+		Columns:            1,
+	}
+
+	// Apply does NOT one-hot "Cat" here — we just want to verify the deep copy
+	// of CategoricalColumns during Apply's setup, independent of one-hot.
+	res, err := Apply(in, Options{Type: OneHot, Columns: []string{"Cat"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = res
+
+	// The original slice must be unchanged.
+	if origSlice[0] != "a" || origSlice[1] != "b" {
+		t.Error("Apply mutated the original CategoricalColumns slice")
+	}
+}
+
 func TestApply_OneHot_OriginalColumnRemoved(t *testing.T) {
 	in := Input{
 		Data:               [][]string{{"a"}, {"b"}},

--- a/pkg/transform/math.go
+++ b/pkg/transform/math.go
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// applyMath applies element-wise mathematical transformations (log, sqrt, square)
+// to the specified columns in data. Messages about skipped values and counts are
+// appended to result.
+func applyMath(data [][]string, columnTypes map[string]string, headers []string, opts Options, result *Result) error {
+	for _, colName := range opts.Columns {
+		colIndex := findColumn(headers, colName)
+		if colIndex == -1 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
+			continue
+		}
+
+		if columnTypes[colName] != "numeric" {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
+			continue
+		}
+
+		transformedCount := 0
+		for i := range data {
+			if colIndex >= len(data[i]) {
+				continue
+			}
+
+			value := strings.TrimSpace(data[i][colIndex])
+			if value == "" {
+				continue
+			}
+
+			num, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				continue
+			}
+
+			var transformed float64
+			switch opts.Type {
+			case Log:
+				if num <= 0 {
+					result.Messages = append(result.Messages, fmt.Sprintf("Warning: Non-positive value in row %d, column '%s' - cannot apply log", i+1, colName))
+					continue
+				}
+				transformed = math.Log(num)
+			case Sqrt:
+				if num < 0 {
+					result.Messages = append(result.Messages, fmt.Sprintf("Warning: Negative value in row %d, column '%s' - cannot apply sqrt", i+1, colName))
+					continue
+				}
+				transformed = math.Sqrt(num)
+			case Square:
+				transformed = num * num
+			}
+
+			data[i][colIndex] = fmt.Sprintf("%.6g", transformed)
+			transformedCount++
+		}
+
+		result.TransformedColumns = append(result.TransformedColumns, colName)
+		result.Messages = append(result.Messages, fmt.Sprintf("Transformed %d values in column '%s'", transformedCount, colName))
+	}
+
+	return nil
+}

--- a/pkg/transform/math_test.go
+++ b/pkg/transform/math_test.go
@@ -1,0 +1,268 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const tol = 1e-9
+
+// tolFmt is the tolerance for values that have been formatted with %.6g and
+// parsed back — six significant figures limits precision to ~1e-5 for values
+// of order 1.
+const tolFmt = 1e-4
+
+func almostEqual(a, b, tolerance float64) bool {
+	return math.Abs(a-b) <= tolerance
+}
+
+func parseResult(t *testing.T, s string) float64 {
+	t.Helper()
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		t.Fatalf("parseResult: cannot parse %q: %v", s, err)
+	}
+	return v
+}
+
+func makeInput(data [][]string, headers []string, colTypes map[string]string) Input {
+	return Input{
+		Data:               data,
+		Headers:            headers,
+		ColumnTypes:        colTypes,
+		CategoricalColumns: map[string][]string{},
+		Rows:               len(data),
+		Columns:            len(headers),
+	}
+}
+
+// ─── Log transform ───────────────────────────────────────────────────────────
+
+func TestApply_Log_Basic(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1"}, {"math.E"}, {"10"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+	// Use plain numbers
+	in.Data = [][]string{{"1"}, {"2.718281828"}, {"10"}}
+
+	res, err := Apply(in, Options{Type: Log, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply log: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 1 || res.TransformedColumns[0] != "X" {
+		t.Errorf("expected TransformedColumns=[X], got %v", res.TransformedColumns)
+	}
+
+	// log(1) == 0
+	v0 := parseResult(t, res.Data[0][0])
+	if !almostEqual(v0, 0.0, tol) {
+		t.Errorf("log(1): expected 0, got %v", v0)
+	}
+
+	// log(e) ≈ 1
+	v1 := parseResult(t, res.Data[1][0])
+	if !almostEqual(v1, 1.0, 1e-6) {
+		t.Errorf("log(e): expected ~1, got %v", v1)
+	}
+
+	// log(10) ≈ 2.302585... (tolFmt accounts for %.6g rounding)
+	v2 := parseResult(t, res.Data[2][0])
+	if !almostEqual(v2, math.Log(10), tolFmt) {
+		t.Errorf("log(10): expected %v, got %v", math.Log(10), v2)
+	}
+}
+
+func TestApply_Log_NonPositive(t *testing.T) {
+	in := makeInput(
+		[][]string{{"0"}, {"-1"}, {"4"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Log, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Row 0 (value 0) and row 1 (value -1) should be skipped (messages added).
+	// Row 2 should be transformed.
+	v2 := parseResult(t, res.Data[2][0])
+	if !almostEqual(v2, math.Log(4), tolFmt) {
+		t.Errorf("log(4): expected %v, got %v", math.Log(4), v2)
+	}
+
+	warnings := 0
+	for _, m := range res.Messages {
+		if strings.Contains(m, "Warning") {
+			warnings++
+		}
+	}
+	if warnings < 2 {
+		t.Errorf("expected at least 2 warning messages for non-positive values, got %d", warnings)
+	}
+}
+
+// ─── Sqrt transform ──────────────────────────────────────────────────────────
+
+func TestApply_Sqrt_Basic(t *testing.T) {
+	in := makeInput(
+		[][]string{{"4"}, {"9"}, {"0"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Sqrt, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply sqrt: %v", err)
+	}
+
+	expected := []float64{2.0, 3.0, 0.0}
+	for i, exp := range expected {
+		got := parseResult(t, res.Data[i][0])
+		if !almostEqual(got, exp, tol) {
+			t.Errorf("sqrt row %d: expected %v, got %v", i, exp, got)
+		}
+	}
+}
+
+func TestApply_Sqrt_Negative(t *testing.T) {
+	in := makeInput(
+		[][]string{{"-1"}, {"4"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Sqrt, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Row 0 skipped, row 1 transformed.
+	v := parseResult(t, res.Data[1][0])
+	if !almostEqual(v, 2.0, tol) {
+		t.Errorf("sqrt(4): expected 2, got %v", v)
+	}
+
+	hasWarning := false
+	for _, m := range res.Messages {
+		if strings.Contains(m, "Warning") {
+			hasWarning = true
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning for negative value")
+	}
+}
+
+// ─── Square transform ────────────────────────────────────────────────────────
+
+func TestApply_Square_Basic(t *testing.T) {
+	in := makeInput(
+		[][]string{{"2"}, {"3"}, {"-4"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Square, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply square: %v", err)
+	}
+
+	expected := []float64{4.0, 9.0, 16.0}
+	for i, exp := range expected {
+		got := parseResult(t, res.Data[i][0])
+		if !almostEqual(got, exp, tol) {
+			t.Errorf("square row %d: expected %v, got %v", i, exp, got)
+		}
+	}
+}
+
+// ─── Column not found / non-numeric ──────────────────────────────────────────
+
+func TestApply_Math_ColumnNotFound(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Log, Columns: []string{"NoSuchColumn"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Errorf("expected no transformed columns, got %v", res.TransformedColumns)
+	}
+	if len(res.Messages) == 0 {
+		t.Error("expected a message for missing column")
+	}
+}
+
+func TestApply_Math_NonNumericColumn(t *testing.T) {
+	in := makeInput(
+		[][]string{{"cat"}},
+		[]string{"X"},
+		map[string]string{"X": "categorical"},
+	)
+
+	res, err := Apply(in, Options{Type: Sqrt, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.TransformedColumns) != 0 {
+		t.Errorf("expected no transformed columns for categorical, got %v", res.TransformedColumns)
+	}
+}
+
+// ─── Unsupported type ─────────────────────────────────────────────────────────
+
+func TestApply_UnsupportedType(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	_, err := Apply(in, Options{Type: "bogus", Columns: []string{"X"}})
+	if err == nil {
+		t.Error("expected error for unsupported transform type")
+	}
+}
+
+// ─── Empty data ───────────────────────────────────────────────────────────────
+
+func TestApply_EmptyData(t *testing.T) {
+	in := makeInput(nil, []string{"X"}, map[string]string{"X": "numeric"})
+	_, err := Apply(in, Options{Type: Log, Columns: []string{"X"}})
+	if err == nil {
+		t.Error("expected error for empty data")
+	}
+}
+
+// ─── Input immutability ───────────────────────────────────────────────────────
+
+func TestApply_DoesNotMutateInput(t *testing.T) {
+	original := [][]string{{"4"}, {"9"}}
+	in := makeInput(original, []string{"X"}, map[string]string{"X": "numeric"})
+
+	_, err := Apply(in, Options{Type: Sqrt, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if original[0][0] != "4" || original[1][0] != "9" {
+		t.Error("Apply must not mutate the original input data")
+	}
+}

--- a/pkg/transform/scaling.go
+++ b/pkg/transform/scaling.go
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// applyStandardize applies z-score standardization (mean=0, std=1) to the
+// specified numeric columns.
+func applyStandardize(data [][]string, columnTypes map[string]string, headers []string, opts Options, result *Result) error {
+	for _, colName := range opts.Columns {
+		colIndex := findColumn(headers, colName)
+		if colIndex == -1 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
+			continue
+		}
+
+		if columnTypes[colName] != "numeric" {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
+			continue
+		}
+
+		values, indices := collectNumeric(data, colIndex)
+
+		if len(values) < 2 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has insufficient numeric values for standardization", colName))
+			continue
+		}
+
+		mean := 0.0
+		for _, v := range values {
+			mean += v
+		}
+		mean /= float64(len(values))
+
+		variance := 0.0
+		for _, v := range values {
+			variance += (v - mean) * (v - mean)
+		}
+		variance /= float64(len(values))
+		stdDev := math.Sqrt(variance)
+
+		if stdDev < 1e-10 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has zero variance, cannot standardize", colName))
+			continue
+		}
+
+		for i, idx := range indices {
+			data[idx][colIndex] = fmt.Sprintf("%.6g", (values[i]-mean)/stdDev)
+		}
+
+		result.TransformedColumns = append(result.TransformedColumns, colName)
+		result.Messages = append(result.Messages, fmt.Sprintf("Standardized %d values in column '%s' (mean=%.3f, std=%.3f)", len(values), colName, mean, stdDev))
+	}
+
+	return nil
+}
+
+// applyMinMax applies min-max scaling to the specified numeric columns.
+// Values are scaled to [opts.MinValue, opts.MaxValue]; defaults to [0, 1].
+func applyMinMax(data [][]string, columnTypes map[string]string, headers []string, opts Options, result *Result) error {
+	targetMin := opts.MinValue
+	targetMax := opts.MaxValue
+	if targetMax <= targetMin {
+		targetMin = 0.0
+		targetMax = 1.0
+	}
+
+	for _, colName := range opts.Columns {
+		colIndex := findColumn(headers, colName)
+		if colIndex == -1 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' not found", colName))
+			continue
+		}
+
+		if columnTypes[colName] != "numeric" {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' is not numeric, skipping", colName))
+			continue
+		}
+
+		values, indices := collectNumeric(data, colIndex)
+
+		if len(values) == 0 {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has no numeric values", colName))
+			continue
+		}
+
+		minVal := math.Inf(1)
+		maxVal := math.Inf(-1)
+		for _, v := range values {
+			if v < minVal {
+				minVal = v
+			}
+			if v > maxVal {
+				maxVal = v
+			}
+		}
+
+		if maxVal <= minVal {
+			result.Messages = append(result.Messages, fmt.Sprintf("Column '%s' has constant values, cannot scale", colName))
+			continue
+		}
+
+		for i, idx := range indices {
+			scaled := (values[i]-minVal)/(maxVal-minVal)*(targetMax-targetMin) + targetMin
+			data[idx][colIndex] = fmt.Sprintf("%.6g", scaled)
+		}
+
+		result.TransformedColumns = append(result.TransformedColumns, colName)
+		result.Messages = append(result.Messages, fmt.Sprintf("Scaled %d values in column '%s' to range [%.2f, %.2f]", len(values), colName, targetMin, targetMax))
+	}
+
+	return nil
+}
+
+// collectNumeric extracts the non-missing numeric values from a column and
+// returns the values alongside their row indices in data.
+func collectNumeric(data [][]string, colIndex int) (values []float64, indices []int) {
+	for i := range data {
+		if colIndex >= len(data[i]) {
+			continue
+		}
+		v := strings.TrimSpace(data[i][colIndex])
+		if v == "" {
+			continue
+		}
+		num, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			continue
+		}
+		values = append(values, num)
+		indices = append(indices, i)
+	}
+	return values, indices
+}

--- a/pkg/transform/scaling_test.go
+++ b/pkg/transform/scaling_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"math"
+	"testing"
+)
+
+// ─── Standardize ─────────────────────────────────────────────────────────────
+
+func TestApply_Standardize_MeanAndStd(t *testing.T) {
+	// Values: 1, 2, 3, 4, 5 → mean=3, std=sqrt(2) ≈ 1.414
+	in := makeInput(
+		[][]string{{"1"}, {"2"}, {"3"}, {"4"}, {"5"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Standardize, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply standardize: %v", err)
+	}
+
+	// Compute mean and std of outputs — should be ≈0 and ≈1.
+	sum, sum2 := 0.0, 0.0
+	for _, row := range res.Data {
+		v := parseResult(t, row[0])
+		sum += v
+		sum2 += v * v
+	}
+	n := float64(len(res.Data))
+	mean := sum / n
+	stdDev := math.Sqrt(sum2/n - mean*mean)
+
+	// tolFmt accounts for %.6g rounding when the values were stored as strings.
+	if !almostEqual(mean, 0.0, 1e-4) {
+		t.Errorf("standardized mean: expected 0, got %v", mean)
+	}
+	if !almostEqual(stdDev, 1.0, 1e-4) {
+		t.Errorf("standardized std: expected 1, got %v", stdDev)
+	}
+}
+
+func TestApply_Standardize_ZeroVariance(t *testing.T) {
+	// All values identical → zero variance, cannot standardize.
+	in := makeInput(
+		[][]string{{"5"}, {"5"}, {"5"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Standardize, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns for zero-variance column")
+	}
+	if len(res.Messages) == 0 {
+		t.Error("expected message for zero variance")
+	}
+}
+
+func TestApply_Standardize_InsufficientValues(t *testing.T) {
+	in := makeInput(
+		[][]string{{"5"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: Standardize, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns for single-value column")
+	}
+}
+
+// ─── MinMax ──────────────────────────────────────────────────────────────────
+
+func TestApply_MinMax_DefaultRange(t *testing.T) {
+	// Values: 0, 5, 10 → scaled to [0, 1]: 0, 0.5, 1
+	in := makeInput(
+		[][]string{{"0"}, {"5"}, {"10"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: MinMax, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("Apply minmax: %v", err)
+	}
+
+	expected := []float64{0.0, 0.5, 1.0}
+	for i, exp := range expected {
+		got := parseResult(t, res.Data[i][0])
+		if !almostEqual(got, exp, tol) {
+			t.Errorf("minmax row %d: expected %v, got %v", i, exp, got)
+		}
+	}
+}
+
+func TestApply_MinMax_CustomRange(t *testing.T) {
+	// Values: 0, 5, 10 → scaled to [-1, 1]: -1, 0, 1
+	in := makeInput(
+		[][]string{{"0"}, {"5"}, {"10"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: MinMax, Columns: []string{"X"}, MinValue: -1.0, MaxValue: 1.0})
+	if err != nil {
+		t.Fatalf("Apply minmax custom range: %v", err)
+	}
+
+	expected := []float64{-1.0, 0.0, 1.0}
+	for i, exp := range expected {
+		got := parseResult(t, res.Data[i][0])
+		if !almostEqual(got, exp, tol) {
+			t.Errorf("minmax custom row %d: expected %v, got %v", i, exp, got)
+		}
+	}
+}
+
+func TestApply_MinMax_ConstantColumn(t *testing.T) {
+	// All values identical → cannot scale.
+	in := makeInput(
+		[][]string{{"7"}, {"7"}, {"7"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: MinMax, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.TransformedColumns) != 0 {
+		t.Error("expected no transformed columns for constant column")
+	}
+}
+
+func TestApply_MinMax_AllInRange(t *testing.T) {
+	// After scaling, all output values must be in [targetMin, targetMax].
+	in := makeInput(
+		[][]string{{"3"}, {"1"}, {"4"}, {"1"}, {"5"}, {"9"}, {"2"}, {"6"}},
+		[]string{"X"},
+		map[string]string{"X": "numeric"},
+	)
+
+	res, err := Apply(in, Options{Type: MinMax, Columns: []string{"X"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i, row := range res.Data {
+		v := parseResult(t, row[0])
+		if v < -tol || v > 1+tol {
+			t.Errorf("row %d: scaled value %v out of [0, 1]", i, v)
+		}
+	}
+}
+
+// ─── GetTransformableColumns ──────────────────────────────────────────────────
+
+func TestGetTransformableColumns_Numeric(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1", "a", "2"}},
+		[]string{"N1", "Cat", "N2"},
+		map[string]string{"N1": "numeric", "Cat": "categorical", "N2": "numeric"},
+	)
+
+	cols := GetTransformableColumns(in, Standardize)
+	if len(cols) != 2 {
+		t.Errorf("expected 2 numeric columns, got %v", cols)
+	}
+}
+
+func TestGetTransformableColumns_ExcludesTarget(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1", "2"}},
+		[]string{"X", "Y#target"},
+		map[string]string{"X": "numeric", "Y#target": "numeric"},
+	)
+
+	cols := GetTransformableColumns(in, Log)
+	if len(cols) != 1 || cols[0] != "X" {
+		t.Errorf("expected only [X], got %v", cols)
+	}
+}
+
+func TestGetTransformableColumns_OneHot(t *testing.T) {
+	in := makeInput(
+		[][]string{{"1", "a"}},
+		[]string{"N", "C"},
+		map[string]string{"N": "numeric", "C": "categorical"},
+	)
+
+	cols := GetTransformableColumns(in, OneHot)
+	if len(cols) != 1 || cols[0] != "C" {
+		t.Errorf("expected only [C] for OneHot, got %v", cols)
+	}
+}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -1,0 +1,119 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Apply executes the transformation described by opts against a deep copy of
+// the input data and returns the modified data as a Result. The original Input
+// is never modified.
+//
+// Unsupported transformation types return an error.
+func Apply(in Input, opts Options) (*Result, error) {
+	if len(in.Data) == 0 {
+		return nil, fmt.Errorf("no data to transform")
+	}
+
+	// Deep-copy input data so the original is never mutated.
+	headers := make([]string, len(in.Headers))
+	copy(headers, in.Headers)
+
+	data := make([][]string, len(in.Data))
+	for i := range in.Data {
+		data[i] = make([]string, len(in.Data[i]))
+		copy(data[i], in.Data[i])
+	}
+
+	columnTypes := make(map[string]string, len(in.ColumnTypes))
+	for k, v := range in.ColumnTypes {
+		columnTypes[k] = v
+	}
+
+	catCols := make(map[string][]string, len(in.CategoricalColumns))
+	for k, v := range in.CategoricalColumns {
+		catCols[k] = v
+	}
+
+	result := &Result{
+		TransformedColumns: []string{},
+		NewColumns:         []string{},
+		Messages:           []string{},
+	}
+
+	switch opts.Type {
+	case Log, Sqrt, Square:
+		if err := applyMath(data, columnTypes, headers, opts, result); err != nil {
+			return nil, err
+		}
+	case Standardize:
+		if err := applyStandardize(data, columnTypes, headers, opts, result); err != nil {
+			return nil, err
+		}
+	case MinMax:
+		if err := applyMinMax(data, columnTypes, headers, opts, result); err != nil {
+			return nil, err
+		}
+	case Bin:
+		if err := applyBin(data, columnTypes, catCols, headers, opts, result); err != nil {
+			return nil, err
+		}
+	case OneHot:
+		if err := applyOneHot(data, columnTypes, catCols, &headers, opts, result); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported transformation type: %s", opts.Type)
+	}
+
+	result.Headers = headers
+	result.Data = data
+	result.ColumnTypes = columnTypes
+	result.CategoricalColumns = catCols
+	result.Columns = len(headers)
+
+	return result, nil
+}
+
+// GetTransformableColumns returns the column names from in that are eligible
+// for the given transformation type.
+//
+// Mathematical and scaling transforms (Log, Sqrt, Square, Standardize, MinMax,
+// Bin) require numeric columns. Columns with the "#target" suffix are excluded.
+// OneHot requires categorical columns.
+func GetTransformableColumns(in Input, transformType Type) []string {
+	columns := []string{}
+
+	for _, header := range in.Headers {
+		colType := in.ColumnTypes[header]
+
+		switch transformType {
+		case Log, Sqrt, Square, Standardize, MinMax, Bin:
+			if colType == "numeric" && !strings.HasSuffix(header, "#target") {
+				columns = append(columns, header)
+			}
+		case OneHot:
+			if colType == "categorical" {
+				columns = append(columns, header)
+			}
+		}
+	}
+
+	return columns
+}
+
+// findColumn returns the index of colName in headers, or -1 if not found.
+func findColumn(headers []string, colName string) int {
+	for i, h := range headers {
+		if h == colName {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -38,7 +38,9 @@ func Apply(in Input, opts Options) (*Result, error) {
 
 	catCols := make(map[string][]string, len(in.CategoricalColumns))
 	for k, v := range in.CategoricalColumns {
-		catCols[k] = v
+		values := make([]string, len(v))
+		copy(values, v)
+		catCols[k] = values
 	}
 
 	result := &Result{

--- a/pkg/transform/types.go
+++ b/pkg/transform/types.go
@@ -1,0 +1,82 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package transform
+
+// Type identifies a supported transformation.
+type Type string
+
+const (
+	// Log applies the natural logarithm to each value. Values must be positive.
+	Log Type = "log"
+	// Sqrt applies the square root to each value. Values must be non-negative.
+	Sqrt Type = "sqrt"
+	// Square squares each value.
+	Square Type = "square"
+	// Standardize applies z-score standardization (mean=0, std=1).
+	Standardize Type = "standardize"
+	// MinMax applies min-max scaling to a configurable target range (default [0, 1]).
+	MinMax Type = "minmax"
+	// Bin discretizes a numeric column into equal-width bins.
+	Bin Type = "bin"
+	// OneHot encodes a categorical column into one binary column per unique value.
+	OneHot Type = "onehot"
+)
+
+// Options configures a transformation.
+type Options struct {
+	// Type is the transformation to apply.
+	Type Type
+	// Columns lists the column names to transform.
+	Columns []string
+	// BinCount is the number of bins for Bin transformations (default: 5).
+	BinCount int
+	// MinValue is the lower bound of the target range for MinMax scaling (default: 0).
+	MinValue float64
+	// MaxValue is the upper bound of the target range for MinMax scaling (default: 1).
+	MaxValue float64
+}
+
+// Input carries the tabular data and metadata that transform functions operate on.
+// It mirrors the relevant fields of the application FileData type so that
+// callers can pass raw slices without introducing a package dependency.
+type Input struct {
+	// Data is the row-major data matrix (each row is a slice of string values).
+	Data [][]string
+	// Headers is the ordered list of column names.
+	Headers []string
+	// ColumnTypes maps each column name to its detected type ("numeric" or "categorical").
+	ColumnTypes map[string]string
+	// CategoricalColumns maps each categorical column name to its value slice.
+	// Used by binning (to register newly discretized columns) and one-hot encoding
+	// (to remove the source column after expansion).
+	CategoricalColumns map[string][]string
+	// Rows is the number of data rows.
+	Rows int
+	// Columns is the number of columns (= len(Headers)).
+	Columns int
+}
+
+// Result carries the output of [Apply].
+// The original Input is never modified; all changes are reflected here.
+type Result struct {
+	// TransformedColumns lists the column names that were successfully transformed.
+	TransformedColumns []string
+	// NewColumns lists column names added during the transformation (e.g. one-hot columns).
+	NewColumns []string
+	// Messages contains informational and warning messages produced during the transformation.
+	Messages []string
+	// Headers is the updated ordered list of column names after the transformation.
+	Headers []string
+	// Data is the updated row-major data matrix after the transformation.
+	Data [][]string
+	// ColumnTypes is the updated column-type map after the transformation.
+	ColumnTypes map[string]string
+	// CategoricalColumns is the updated categorical-column value map after the transformation.
+	CategoricalColumns map[string][]string
+	// Columns is the updated number of columns.
+	Columns int
+}

--- a/scripts/ci/test-core.sh
+++ b/scripts/ci/test-core.sh
@@ -29,7 +29,7 @@ mkdir -p cmd/gopca-desktop/frontend/dist
 echo '<!DOCTYPE html><html><body>Test</body></html>' > cmd/gopca-desktop/frontend/dist/index.html
 
 # First run core packages and GoPCA Desktop tests
-if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./cmd/gopca-desktop; then
+if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./cmd/gopca-desktop; then
     echo "✗ Core tests failed"
     exit 1
 fi
@@ -66,7 +66,7 @@ echo "✓ All core tests passed"
 # Show coverage summary
 echo ""
 echo "=== Coverage Summary ==="
-go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
+go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
 
 echo ""
 echo "=== Core tests completed successfully ===" 


### PR DESCRIPTION
## Summary

- Extracts all transformation logic (~510 lines) from `cmd/gocsv/app.go` into a new `pkg/transform/` package
- `applyTransformationInternal` and `GetTransformableColumns` in `app.go` become thin delegates; Wails-bound types (`TransformOptions`, `TransformationResult`, `TransformationType`) remain in `package main` to avoid TypeScript namespace breakage
- `pkg/transform` follows the same `[][]string` + metadata interface as `pkg/dataquality` — no dependency on `FileData`
- `scripts/ci/test-core.sh` updated to include `pkg/transform`

## New package structure

```
pkg/transform/
├── doc.go         Package documentation
├── types.go       Type, Options, Input, Result
├── transform.go   Apply(), GetTransformableColumns(), dispatch
├── math.go        log, sqrt, square
├── scaling.go     z-score standardize, min-max
├── binning.go     equal-width binning
├── encoding.go    one-hot encoding
├── math_test.go
├── scaling_test.go
├── binning_test.go
└── encoding_test.go
```

## Coverage

`pkg/transform`: **88.7%** (target >85%)

## app.go size

| Phase | Lines |
|-------|-------|
| Before #639 | 3,613 |
| After #639 | 2,401 |
| After #640 (this PR) | 1,927 |

## Test plan

- [x] `go test ./pkg/transform/ -cover` — all pass, 88.7%
- [x] `bash scripts/ci/test-core.sh` — all packages pass
- [x] `npm run build` in `cmd/gocsv/frontend` — TypeScript compiles clean (no namespace breakage, Wails-bound types stayed in `package main`)

Fixes #640