### PR TITLE
feat(csv): slim app.go — extract CSV parse helpers to pkg/csv (#641)

### DIFF
--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -1196,7 +1196,7 @@ func (a *App) previewCSV(filePath string, options ImportOptions, preview *FilePr
 	// Detect column types
 	preview.ColumnTypes = make([]string, preview.TotalCols)
 	for i := 0; i < preview.TotalCols; i++ {
-		preview.ColumnTypes[i] = a.detectColumnType(allData, i)
+		preview.ColumnTypes[i] = pkgcsv.DetectColumnType(allData, i)
 	}
 
 	// Detect delimiter if not specified
@@ -1284,7 +1284,7 @@ func (a *App) previewExcel(filePath string, options ImportOptions, preview *File
 	// Detect column types
 	preview.ColumnTypes = make([]string, preview.TotalCols)
 	for i := 0; i < preview.TotalCols; i++ {
-		preview.ColumnTypes[i] = a.detectColumnType(rows, i)
+		preview.ColumnTypes[i] = pkgcsv.DetectColumnType(rows, i)
 	}
 
 	return preview, nil
@@ -1410,7 +1410,7 @@ func (a *App) importCSVWithOptions(filePath string, options ImportOptions) (*Fil
 
 	// Detect column types and process data
 	for i, header := range fileData.Headers {
-		colType := a.detectColumnType(allData, i)
+		colType := pkgcsv.DetectColumnType(allData, i)
 		fileData.ColumnTypes[header] = colType
 
 		if strings.HasSuffix(header, "#target") {
@@ -1550,7 +1550,7 @@ func (a *App) importExcelWithOptions(filePath string, options ImportOptions) (*F
 
 	// Detect column types
 	for i, header := range fileData.Headers {
-		colType := a.detectColumnType(rows, i)
+		colType := pkgcsv.DetectColumnType(rows, i)
 		fileData.ColumnTypes[header] = colType
 
 		if strings.HasSuffix(header, "#target") {
@@ -1622,53 +1622,6 @@ func (a *App) SelectFileForImport() (string, error) {
 	}
 
 	return filePath, nil
-}
-
-// detectColumnType detects the type of a column based on its values
-func (a *App) detectColumnType(data [][]string, colIndex int) string {
-	if len(data) == 0 || colIndex < 0 {
-		return "unknown"
-	}
-
-	// Count different types
-	numericCount := 0
-	totalCount := 0
-	uniqueValues := make(map[string]bool)
-
-	for _, row := range data {
-		if colIndex >= len(row) {
-			continue
-		}
-
-		value := strings.TrimSpace(row[colIndex])
-		if value == "" {
-			continue
-		}
-
-		totalCount++
-		uniqueValues[value] = true
-
-		// Try to parse as float
-		if _, err := strconv.ParseFloat(value, 64); err == nil {
-			numericCount++
-		}
-	}
-
-	if totalCount == 0 {
-		return "empty"
-	}
-
-	// If more than 90% of non-empty values are numeric, consider it numeric
-	if float64(numericCount)/float64(totalCount) > 0.9 {
-		return "numeric"
-	}
-
-	// If unique values are less than 20% of total values or less than 20, consider it categorical
-	if float64(len(uniqueValues))/float64(totalCount) < 0.2 || len(uniqueValues) < 20 {
-		return "categorical"
-	}
-
-	return "text"
 }
 
 // TransformationType represents the type of transformation

--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -338,113 +338,24 @@ func (a *App) parseCSVContent(content string, ext string) (*FileData, error) {
 	// If we have categorical or target columns, we need to combine them with numeric data
 	// for the full data display
 	if len(categoricalData) > 0 || len(numericTargetData) > 0 {
-		// Get all original headers to preserve column order
-		allOriginalHeaders := a.getAllOriginalHeaders(content, successfulFormat)
-		fileData = a.combineAllColumns(csvData, categoricalData, numericTargetData, allOriginalHeaders)
+		// Get all original headers to preserve column order, then merge all column types.
+		allOriginalHeaders := pkgcsv.GetOriginalHeaders(content, successfulFormat)
+		combined := pkgcsv.CombineColumns(csvData, categoricalData, numericTargetData, allOriginalHeaders)
+		fileData = &FileData{
+			Headers:              combined.Headers,
+			RowNames:             combined.RowNames,
+			Data:                 combined.Data,
+			Rows:                 combined.Rows,
+			Columns:              combined.Columns,
+			CategoricalColumns:   combined.CategoricalColumns,
+			NumericTargetColumns: ConvertFloat64MapToJSON(combined.NumericTargetData),
+			ColumnTypes:          combined.ColumnTypes,
+		}
 	}
 
 	return fileData, nil
 }
 
-// getAllOriginalHeaders extracts all headers from CSV content in their original order
-func (a *App) getAllOriginalHeaders(content string, format types.CSVFormat) []string {
-	csvReader := csv.NewReader(strings.NewReader(content))
-	csvReader.Comma = format.FieldDelimiter
-	csvReader.LazyQuotes = true
-	csvReader.TrimLeadingSpace = true
-
-	// Read first line to get headers
-	records, err := csvReader.Read()
-	if err != nil || len(records) == 0 {
-		return []string{}
-	}
-
-	// If the format has headers and row names, skip the first column (row name header)
-	if format.HasHeaders && format.HasRowNames && len(records) > 0 {
-		return records[1:]
-	}
-
-	return records
-}
-
-// combineAllColumns combines numeric, categorical, and target columns for display
-func (a *App) combineAllColumns(csvData *types.CSVData, categoricalData map[string][]string, numericTargetData map[string][]float64, originalHeaders []string) *FileData {
-	// If no original headers provided, fall back to the old behavior
-	if len(originalHeaders) == 0 {
-		originalHeaders = make([]string, 0)
-		// Add numeric headers first
-		originalHeaders = append(originalHeaders, csvData.Headers...)
-		// Add categorical headers
-		for colName := range categoricalData {
-			originalHeaders = append(originalHeaders, colName)
-		}
-		// Add target headers
-		for colName := range numericTargetData {
-			originalHeaders = append(originalHeaders, colName)
-		}
-	}
-
-	// Create a map to quickly find numeric column indices
-	numericColIndex := make(map[string]int)
-	for idx, header := range csvData.Headers {
-		numericColIndex[header] = idx
-	}
-
-	// Initialize the result data structures
-	allHeaders := make([]string, 0, len(originalHeaders))
-	allData := make([][]string, csvData.Rows)
-	columnTypes := make(map[string]string)
-
-	// Initialize rows
-	for i := range allData {
-		allData[i] = make([]string, 0, len(originalHeaders))
-	}
-
-	// Process columns in their original order
-	for _, header := range originalHeaders {
-		allHeaders = append(allHeaders, header)
-
-		// Check if it's a numeric column
-		if colIdx, isNumeric := numericColIndex[header]; isNumeric {
-			columnTypes[header] = "numeric"
-			for rowIdx := 0; rowIdx < csvData.Rows; rowIdx++ {
-				if csvData.MissingMask != nil && csvData.MissingMask[rowIdx][colIdx] {
-					allData[rowIdx] = append(allData[rowIdx], "")
-				} else {
-					allData[rowIdx] = append(allData[rowIdx], strconv.FormatFloat(csvData.Matrix[rowIdx][colIdx], 'g', -1, 64))
-				}
-			}
-		} else if values, isCategorical := categoricalData[header]; isCategorical {
-			// It's a categorical column
-			columnTypes[header] = "categorical"
-			for rowIdx, value := range values {
-				if rowIdx < len(allData) {
-					allData[rowIdx] = append(allData[rowIdx], value)
-				}
-			}
-		} else if values, isTarget := numericTargetData[header]; isTarget {
-			// It's a target column
-			columnTypes[header] = "target"
-			for rowIdx, value := range values {
-				if rowIdx < len(allData) {
-					allData[rowIdx] = append(allData[rowIdx], strconv.FormatFloat(value, 'g', -1, 64))
-				}
-			}
-		}
-		// If header not found in any category, it will be skipped
-	}
-
-	return &FileData{
-		Headers:              allHeaders,
-		RowNames:             csvData.RowNames,
-		Data:                 allData,
-		Rows:                 csvData.Rows,
-		Columns:              len(allHeaders),
-		CategoricalColumns:   categoricalData,
-		NumericTargetColumns: ConvertFloat64MapToJSON(numericTargetData),
-		ColumnTypes:          columnTypes,
-	}
-}
 
 // ValidateForGoPCA validates that the CSV data is compatible with GoPCA.
 func (a *App) ValidateForGoPCA(data *FileData) *ValidationResult {

--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -446,109 +446,18 @@ func (a *App) combineAllColumns(csvData *types.CSVData, categoricalData map[stri
 	}
 }
 
-// ValidateForGoPCA validates that the CSV data is compatible with GoPCA
+// ValidateForGoPCA validates that the CSV data is compatible with GoPCA.
 func (a *App) ValidateForGoPCA(data *FileData) *ValidationResult {
-	var warnings []string
-	var numericColumns int
-	var categoricalColumns int
-	var targetColumns int
-	var totalMissing int
-
-	// Check minimum data requirements
-	if data.Rows < 2 {
-		warnings = append(warnings, "ERROR: Data must have at least 2 rows (found "+fmt.Sprintf("%d", data.Rows)+")")
+	in := integration.ValidationInput{
+		Headers:     data.Headers,
+		Data:        data.Data,
+		ColumnTypes: data.ColumnTypes,
+		RowNames:    data.RowNames,
+		Rows:        data.Rows,
+		Columns:     data.Columns,
 	}
-
-	// Count column types using our pre-detected types
-	for _, colType := range data.ColumnTypes {
-		switch colType {
-		case "numeric":
-			numericColumns++
-		case "categorical":
-			categoricalColumns++
-		case "target":
-			targetColumns++
-		}
-	}
-
-	// Check for missing values in the data
-	for colIdx, header := range data.Headers {
-		missingInCol := 0
-
-		for i := 0; i < data.Rows; i++ {
-			if i >= len(data.Data) {
-				break
-			}
-			value := data.Data[i][colIdx]
-
-			// Check for missing values
-			trimmed := strings.TrimSpace(value)
-			if trimmed == "" || trimmed == "NA" || trimmed == "N/A" ||
-				trimmed == "nan" || trimmed == "NaN" || trimmed == "null" || trimmed == "NULL" {
-				missingInCol++
-				totalMissing++
-			}
-		}
-
-		// Report high missing value percentage
-		if data.Rows > 0 {
-			missingPercent := float64(missingInCol) / float64(data.Rows) * 100
-			if missingPercent > 50 {
-				warnings = append(warnings, fmt.Sprintf("WARNING: Column '%s' has %.1f%% missing values", header, missingPercent))
-			}
-		}
-	}
-
-	// Report column type summary
-	if categoricalColumns > 0 {
-		warnings = append(warnings, fmt.Sprintf("INFO: %d categorical column(s) detected - these will be excluded from PCA but available for visualization", categoricalColumns))
-	}
-
-	if targetColumns > 0 {
-		warnings = append(warnings, fmt.Sprintf("INFO: %d target column(s) detected - these will be excluded from PCA but available for visualization", targetColumns))
-	}
-
-	// Check if we have enough numeric columns for PCA
-	if numericColumns < 2 {
-		warnings = append(warnings, fmt.Sprintf("ERROR: Need at least 2 numeric columns for PCA (found %d)", numericColumns))
-	} else if numericColumns < 3 {
-		warnings = append(warnings, fmt.Sprintf("WARNING: Only %d numeric columns found - PCA results may be limited", numericColumns))
-	} else {
-		warnings = append(warnings, fmt.Sprintf("INFO: %d numeric columns will be used for PCA analysis", numericColumns))
-	}
-
-	// Report overall missing data
-	totalCells := data.Rows * data.Columns
-	if totalCells > 0 {
-		missingPercent := float64(totalMissing) / float64(totalCells) * 100
-		if missingPercent > 0 {
-			warnings = append(warnings, fmt.Sprintf("INFO: Dataset contains %.1f%% missing values (%d cells)", missingPercent, totalMissing))
-		}
-	}
-
-	// Check for reasonable data size
-	if data.Rows > 10000 {
-		warnings = append(warnings, fmt.Sprintf("INFO: Large dataset detected (%d rows) - processing may take time", data.Rows))
-	}
-
-	// Check if row names were detected
-	if len(data.RowNames) > 0 {
-		warnings = append(warnings, "INFO: Row names detected in first column")
-	}
-
-	// Determine if data is valid (no ERRORs)
-	isValid := true
-	for _, warning := range warnings {
-		if strings.HasPrefix(warning, "ERROR:") {
-			isValid = false
-			break
-		}
-	}
-
-	return &ValidationResult{
-		IsValid:  isValid,
-		Messages: warnings,
-	}
+	res := integration.ValidateForGoPCA(in)
+	return &ValidationResult{IsValid: res.IsValid, Messages: res.Messages}
 }
 
 // SaveCSV saves the data to a CSV file

--- a/pkg/csv/detect.go
+++ b/pkg/csv/detect.go
@@ -1,0 +1,63 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package csv
+
+import (
+	"strconv"
+	"strings"
+)
+
+// DetectColumnType inspects the values of a single column in a row-major data
+// matrix and returns one of the following type strings:
+//
+//   - "numeric"     — >90% of non-empty values parse as float64
+//   - "categorical" — unique-value ratio <20% of total, or fewer than 20 unique values
+//   - "text"        — everything else
+//   - "empty"       — no non-empty values found
+//   - "unknown"     — data is nil/empty or colIndex is negative
+//
+// The function never modifies data.
+func DetectColumnType(data [][]string, colIndex int) string {
+	if len(data) == 0 || colIndex < 0 {
+		return "unknown"
+	}
+
+	numericCount := 0
+	totalCount := 0
+	uniqueValues := make(map[string]bool)
+
+	for _, row := range data {
+		if colIndex >= len(row) {
+			continue
+		}
+		value := strings.TrimSpace(row[colIndex])
+		if value == "" {
+			continue
+		}
+		totalCount++
+		uniqueValues[value] = true
+		if _, err := strconv.ParseFloat(value, 64); err == nil {
+			numericCount++
+		}
+	}
+
+	if totalCount == 0 {
+		return "empty"
+	}
+
+	// More than 90% numeric → numeric column.
+	if float64(numericCount)/float64(totalCount) > 0.9 {
+		return "numeric"
+	}
+
+	// Low cardinality → categorical.
+	if float64(len(uniqueValues))/float64(totalCount) < 0.2 || len(uniqueValues) < 20 {
+		return "categorical"
+	}
+
+	return "text"
+}

--- a/pkg/csv/detect_test.go
+++ b/pkg/csv/detect_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package csv
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ─── DetectColumnType ─────────────────────────────────────────────────────────
+
+func TestDetectColumnType_Numeric(t *testing.T) {
+	data := [][]string{{"1.0"}, {"2.5"}, {"3"}, {"-4.1"}, {"0"}}
+	if got := DetectColumnType(data, 0); got != "numeric" {
+		t.Errorf("expected numeric, got %q", got)
+	}
+}
+
+func TestDetectColumnType_NumericWithOneMissing(t *testing.T) {
+	// 4 numeric + 1 empty → 4/4 non-empty = 100% numeric → "numeric"
+	data := [][]string{{"1"}, {"2"}, {"3"}, {"4"}, {""}}
+	if got := DetectColumnType(data, 0); got != "numeric" {
+		t.Errorf("expected numeric, got %q", got)
+	}
+}
+
+func TestDetectColumnType_NumericWith10PctNonNumeric(t *testing.T) {
+	// 9 numeric + 1 text → 90% numeric → exactly NOT >0.9 → categorical
+	rows := make([][]string, 10)
+	for i := 0; i < 9; i++ {
+		rows[i] = []string{fmt.Sprintf("%d", i+1)}
+	}
+	rows[9] = []string{"text"}
+	got := DetectColumnType(rows, 0)
+	// 9/10 = 0.9, which is NOT > 0.9, so falls through to categorical check.
+	// 10 unique values out of 10 → ratio=1.0 ≥ 0.2 and count=10 < 20 → categorical.
+	if got != "categorical" {
+		t.Errorf("expected categorical for 90%% numeric, got %q", got)
+	}
+}
+
+func TestDetectColumnType_Categorical_LowCardinality(t *testing.T) {
+	// 20 rows, 3 unique values → ratio = 3/20 = 0.15 < 0.2 → categorical
+	data := make([][]string, 20)
+	for i := range data {
+		data[i] = []string{[]string{"a", "b", "c"}[i%3]}
+	}
+	if got := DetectColumnType(data, 0); got != "categorical" {
+		t.Errorf("expected categorical, got %q", got)
+	}
+}
+
+func TestDetectColumnType_Categorical_FewUniqueValues(t *testing.T) {
+	// 100 rows, 15 unique values → count < 20 → categorical
+	data := make([][]string, 100)
+	for i := range data {
+		data[i] = []string{fmt.Sprintf("val%d", i%15)}
+	}
+	if got := DetectColumnType(data, 0); got != "categorical" {
+		t.Errorf("expected categorical for <20 unique values, got %q", got)
+	}
+}
+
+func TestDetectColumnType_Text(t *testing.T) {
+	// 100 rows, 50 unique non-numeric values → ratio=0.5 ≥ 0.2, count=50 ≥ 20 → text
+	data := make([][]string, 100)
+	for i := range data {
+		data[i] = []string{fmt.Sprintf("token_%d", i%50)}
+	}
+	if got := DetectColumnType(data, 0); got != "text" {
+		t.Errorf("expected text, got %q", got)
+	}
+}
+
+func TestDetectColumnType_AllEmpty(t *testing.T) {
+	data := [][]string{{""}, {""}, {""}}
+	if got := DetectColumnType(data, 0); got != "empty" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestDetectColumnType_EmptyData(t *testing.T) {
+	if got := DetectColumnType(nil, 0); got != "unknown" {
+		t.Errorf("expected unknown for nil data, got %q", got)
+	}
+	if got := DetectColumnType([][]string{}, 0); got != "unknown" {
+		t.Errorf("expected unknown for empty data, got %q", got)
+	}
+}
+
+func TestDetectColumnType_NegativeIndex(t *testing.T) {
+	data := [][]string{{"1"}, {"2"}}
+	if got := DetectColumnType(data, -1); got != "unknown" {
+		t.Errorf("expected unknown for negative index, got %q", got)
+	}
+}
+
+func TestDetectColumnType_IndexOutOfRange(t *testing.T) {
+	// colIndex beyond all rows — all skipped → empty
+	data := [][]string{{"1"}, {"2"}}
+	if got := DetectColumnType(data, 5); got != "empty" {
+		t.Errorf("expected empty for out-of-range index, got %q", got)
+	}
+}
+
+func TestDetectColumnType_MultiColumn_SelectsCorrectColumn(t *testing.T) {
+	// data has two columns: col0 is numeric, col1 is categorical
+	data := [][]string{
+		{"1.0", "red"},
+		{"2.0", "blue"},
+		{"3.0", "red"},
+		{"4.0", "green"},
+		{"5.0", "blue"},
+	}
+	if got := DetectColumnType(data, 0); got != "numeric" {
+		t.Errorf("col0: expected numeric, got %q", got)
+	}
+	if got := DetectColumnType(data, 1); got != "categorical" {
+		t.Errorf("col1: expected categorical, got %q", got)
+	}
+}
+
+func TestDetectColumnType_NegativeNumbers(t *testing.T) {
+	data := [][]string{{"-1"}, {"-2.5"}, {"-0.001"}}
+	if got := DetectColumnType(data, 0); got != "numeric" {
+		t.Errorf("expected numeric for negative numbers, got %q", got)
+	}
+}
+
+func TestDetectColumnType_ScientificNotation(t *testing.T) {
+	data := [][]string{{"1e5"}, {"2.3e-4"}, {"1.0E10"}}
+	if got := DetectColumnType(data, 0); got != "numeric" {
+		t.Errorf("expected numeric for scientific notation, got %q", got)
+	}
+}

--- a/pkg/csv/parse.go
+++ b/pkg/csv/parse.go
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package csv
+
+import (
+	"encoding/csv"
+	"strconv"
+	"strings"
+
+	"github.com/bitjungle/gopca/pkg/types"
+)
+
+// CombineResult holds the merged column data produced by CombineColumns.
+// The caller is responsible for converting NumericTargetData to any
+// application-specific JSON-safe type (e.g. []types.JSONFloat64).
+type CombineResult struct {
+	// Headers is the ordered list of column names after merging.
+	Headers []string
+	// RowNames holds per-row labels (may be nil).
+	RowNames []string
+	// Data is the row-major data matrix with all columns as strings.
+	Data [][]string
+	// Rows is the number of data rows.
+	Rows int
+	// Columns is the number of columns (= len(Headers)).
+	Columns int
+	// CategoricalColumns maps each categorical column name to its value slice.
+	CategoricalColumns map[string][]string
+	// NumericTargetData maps each target column name to its float64 value slice.
+	NumericTargetData map[string][]float64
+	// ColumnTypes maps each column name to "numeric", "categorical", or "target".
+	ColumnTypes map[string]string
+}
+
+// GetOriginalHeaders reads the first line of the CSV content string and returns
+// the column headers in their original order. When the format has both
+// HasHeaders and HasRowNames set, the leading row-name header column is skipped.
+// Returns an empty slice if the content is empty or cannot be read.
+func GetOriginalHeaders(content string, format types.CSVFormat) []string {
+	r := csv.NewReader(strings.NewReader(content))
+	r.Comma = format.FieldDelimiter
+	r.LazyQuotes = true
+	r.TrimLeadingSpace = true
+
+	records, err := r.Read()
+	if err != nil || len(records) == 0 {
+		return []string{}
+	}
+
+	if format.HasHeaders && format.HasRowNames {
+		return records[1:]
+	}
+	return records
+}
+
+// CombineColumns merges numeric, categorical, and target columns from a parsed
+// CSV dataset into a single unified CombineResult, preserving the column order
+// given by originalHeaders.
+//
+// When originalHeaders is empty the columns are ordered: numeric first,
+// then categorical, then target — map iteration order applies within each group.
+//
+// Columns listed in originalHeaders that do not appear in any of the three data
+// sources are silently skipped.
+func CombineColumns(
+	csvData *types.CSVData,
+	categoricalData map[string][]string,
+	numericTargetData map[string][]float64,
+	originalHeaders []string,
+) *CombineResult {
+	// If no original headers were provided, build a fallback order.
+	if len(originalHeaders) == 0 {
+		originalHeaders = make([]string, 0, len(csvData.Headers)+len(categoricalData)+len(numericTargetData))
+		originalHeaders = append(originalHeaders, csvData.Headers...)
+		for colName := range categoricalData {
+			originalHeaders = append(originalHeaders, colName)
+		}
+		for colName := range numericTargetData {
+			originalHeaders = append(originalHeaders, colName)
+		}
+	}
+
+	// Index numeric columns for O(1) lookup.
+	numericColIndex := make(map[string]int, len(csvData.Headers))
+	for idx, header := range csvData.Headers {
+		numericColIndex[header] = idx
+	}
+
+	allHeaders := make([]string, 0, len(originalHeaders))
+	allData := make([][]string, csvData.Rows)
+	columnTypes := make(map[string]string, len(originalHeaders))
+
+	for i := range allData {
+		allData[i] = make([]string, 0, len(originalHeaders))
+	}
+
+	for _, header := range originalHeaders {
+		if colIdx, isNumeric := numericColIndex[header]; isNumeric {
+			allHeaders = append(allHeaders, header)
+			columnTypes[header] = "numeric"
+			for rowIdx := 0; rowIdx < csvData.Rows; rowIdx++ {
+				if csvData.MissingMask != nil && csvData.MissingMask[rowIdx][colIdx] {
+					allData[rowIdx] = append(allData[rowIdx], "")
+				} else {
+					allData[rowIdx] = append(allData[rowIdx], strconv.FormatFloat(csvData.Matrix[rowIdx][colIdx], 'g', -1, 64))
+				}
+			}
+		} else if values, isCategorical := categoricalData[header]; isCategorical {
+			allHeaders = append(allHeaders, header)
+			columnTypes[header] = "categorical"
+			for rowIdx, value := range values {
+				if rowIdx < len(allData) {
+					allData[rowIdx] = append(allData[rowIdx], value)
+				}
+			}
+		} else if values, isTarget := numericTargetData[header]; isTarget {
+			allHeaders = append(allHeaders, header)
+			columnTypes[header] = "target"
+			for rowIdx, value := range values {
+				if rowIdx < len(allData) {
+					allData[rowIdx] = append(allData[rowIdx], strconv.FormatFloat(value, 'g', -1, 64))
+				}
+			}
+		}
+		// Headers not found in any source are silently skipped.
+	}
+
+	return &CombineResult{
+		Headers:            allHeaders,
+		RowNames:           csvData.RowNames,
+		Data:               allData,
+		Rows:               csvData.Rows,
+		Columns:            len(allHeaders),
+		CategoricalColumns: categoricalData,
+		NumericTargetData:  numericTargetData,
+		ColumnTypes:        columnTypes,
+	}
+}

--- a/pkg/csv/parse_test.go
+++ b/pkg/csv/parse_test.go
@@ -1,0 +1,291 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package csv
+
+import (
+	"testing"
+
+	"github.com/bitjungle/gopca/pkg/types"
+)
+
+// ─── GetOriginalHeaders ───────────────────────────────────────────────────────
+
+var commaFormat = types.CSVFormat{
+	FieldDelimiter: ',',
+	HasHeaders:     true,
+	HasRowNames:    false,
+}
+
+var commaFormatWithRowNames = types.CSVFormat{
+	FieldDelimiter: ',',
+	HasHeaders:     true,
+	HasRowNames:    true,
+}
+
+var tsvFormat = types.CSVFormat{
+	FieldDelimiter: '\t',
+	HasHeaders:     true,
+	HasRowNames:    false,
+}
+
+func TestGetOriginalHeaders_Standard(t *testing.T) {
+	content := "a,b,c\n1,2,3\n4,5,6\n"
+	got := GetOriginalHeaders(content, commaFormat)
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, h := range want {
+		if got[i] != h {
+			t.Errorf("[%d] got %q, want %q", i, got[i], h)
+		}
+	}
+}
+
+func TestGetOriginalHeaders_SkipsRowNameColumn(t *testing.T) {
+	content := "rowname,x,y\nR1,1,2\nR2,3,4\n"
+	got := GetOriginalHeaders(content, commaFormatWithRowNames)
+	want := []string{"x", "y"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, h := range want {
+		if got[i] != h {
+			t.Errorf("[%d] got %q, want %q", i, got[i], h)
+		}
+	}
+}
+
+func TestGetOriginalHeaders_TSV(t *testing.T) {
+	content := "col1\tcol2\tcol3\n1\t2\t3\n"
+	got := GetOriginalHeaders(content, tsvFormat)
+	want := []string{"col1", "col2", "col3"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, h := range want {
+		if got[i] != h {
+			t.Errorf("[%d] got %q, want %q", i, got[i], h)
+		}
+	}
+}
+
+func TestGetOriginalHeaders_Empty(t *testing.T) {
+	got := GetOriginalHeaders("", commaFormat)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice for empty content, got %v", got)
+	}
+}
+
+func TestGetOriginalHeaders_SingleRow(t *testing.T) {
+	content := "alpha,beta\n"
+	got := GetOriginalHeaders(content, commaFormat)
+	want := []string{"alpha", "beta"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, h := range want {
+		if got[i] != h {
+			t.Errorf("[%d] got %q, want %q", i, got[i], h)
+		}
+	}
+}
+
+// ─── CombineColumns ───────────────────────────────────────────────────────────
+
+// makeCSVData is a helper to build a minimal *types.CSVData for tests.
+func makeCSVData(headers []string, matrix [][]float64, rowNames []string, missingMask [][]bool) *types.CSVData {
+	rows := len(matrix)
+	cols := 0
+	if rows > 0 {
+		cols = len(matrix[0])
+	}
+	return &types.CSVData{
+		Matrix:      matrix,
+		Headers:     headers,
+		RowNames:    rowNames,
+		MissingMask: missingMask,
+		Rows:        rows,
+		Columns:     cols,
+	}
+}
+
+func TestCombineColumns_NumericOnly(t *testing.T) {
+	csvData := makeCSVData(
+		[]string{"x", "y"},
+		[][]float64{{1, 2}, {3, 4}},
+		nil, nil,
+	)
+	res := CombineColumns(csvData, nil, nil, []string{"x", "y"})
+
+	if res.Rows != 2 {
+		t.Errorf("Rows: got %d, want 2", res.Rows)
+	}
+	if res.Columns != 2 {
+		t.Errorf("Columns: got %d, want 2", res.Columns)
+	}
+	if res.ColumnTypes["x"] != "numeric" || res.ColumnTypes["y"] != "numeric" {
+		t.Errorf("ColumnTypes: got %v", res.ColumnTypes)
+	}
+	// First row values
+	if res.Data[0][0] != "1" || res.Data[0][1] != "2" {
+		t.Errorf("Data[0]: got %v, want [1 2]", res.Data[0])
+	}
+}
+
+func TestCombineColumns_ColumnOrderPreserved(t *testing.T) {
+	csvData := makeCSVData(
+		[]string{"n1", "n2"},
+		[][]float64{{10, 20}},
+		nil, nil,
+	)
+	catData := map[string][]string{"cat": {"A"}}
+	targetData := map[string][]float64{"tgt": {99.0}}
+
+	// Force a specific order: cat, n1, tgt, n2
+	headers := []string{"cat", "n1", "tgt", "n2"}
+	res := CombineColumns(csvData, catData, targetData, headers)
+
+	if len(res.Headers) != 4 {
+		t.Fatalf("Headers: got %v", res.Headers)
+	}
+	for i, want := range headers {
+		if res.Headers[i] != want {
+			t.Errorf("Headers[%d]: got %q, want %q", i, res.Headers[i], want)
+		}
+	}
+	// Verify column types
+	if res.ColumnTypes["cat"] != "categorical" {
+		t.Errorf("cat: expected categorical, got %q", res.ColumnTypes["cat"])
+	}
+	if res.ColumnTypes["n1"] != "numeric" {
+		t.Errorf("n1: expected numeric, got %q", res.ColumnTypes["n1"])
+	}
+	if res.ColumnTypes["tgt"] != "target" {
+		t.Errorf("tgt: expected target, got %q", res.ColumnTypes["tgt"])
+	}
+}
+
+func TestCombineColumns_MissingValuesAsEmptyStrings(t *testing.T) {
+	mask := [][]bool{{false, true}, {true, false}}
+	csvData := makeCSVData(
+		[]string{"a", "b"},
+		[][]float64{{1, 0}, {0, 5}},
+		nil,
+		mask,
+	)
+	res := CombineColumns(csvData, nil, nil, []string{"a", "b"})
+
+	// row 0 col 1 is missing
+	if res.Data[0][1] != "" {
+		t.Errorf("expected empty for missing, got %q", res.Data[0][1])
+	}
+	// row 1 col 0 is missing
+	if res.Data[1][0] != "" {
+		t.Errorf("expected empty for missing, got %q", res.Data[1][0])
+	}
+	// row 0 col 0 is present
+	if res.Data[0][0] != "1" {
+		t.Errorf("expected \"1\", got %q", res.Data[0][0])
+	}
+}
+
+func TestCombineColumns_RowNamesPreserved(t *testing.T) {
+	csvData := makeCSVData(
+		[]string{"v"},
+		[][]float64{{7}, {8}},
+		[]string{"row1", "row2"},
+		nil,
+	)
+	res := CombineColumns(csvData, nil, nil, []string{"v"})
+
+	if len(res.RowNames) != 2 || res.RowNames[0] != "row1" || res.RowNames[1] != "row2" {
+		t.Errorf("RowNames: got %v", res.RowNames)
+	}
+}
+
+func TestCombineColumns_FallbackOrderingWhenNoOriginalHeaders(t *testing.T) {
+	csvData := makeCSVData(
+		[]string{"n"},
+		[][]float64{{42}},
+		nil, nil,
+	)
+	catData := map[string][]string{"c": {"X"}}
+	targetData := map[string][]float64{"t": {3.14}}
+
+	// Pass nil originalHeaders → fallback ordering: numeric → categorical → target
+	res := CombineColumns(csvData, catData, targetData, nil)
+
+	if res.Columns != 3 {
+		t.Errorf("Columns: got %d, want 3", res.Columns)
+	}
+	// All three columns should appear
+	typesSeen := map[string]bool{}
+	for _, h := range res.Headers {
+		typesSeen[res.ColumnTypes[h]] = true
+	}
+	if !typesSeen["numeric"] || !typesSeen["categorical"] || !typesSeen["target"] {
+		t.Errorf("missing column types: %v", typesSeen)
+	}
+}
+
+func TestCombineColumns_UnknownHeadersSkipped(t *testing.T) {
+	csvData := makeCSVData(
+		[]string{"known"},
+		[][]float64{{1}},
+		nil, nil,
+	)
+	// "ghost" is not in any source
+	res := CombineColumns(csvData, nil, nil, []string{"ghost", "known"})
+
+	if res.Columns != 1 {
+		t.Errorf("Columns: got %d, want 1 (ghost should be skipped)", res.Columns)
+	}
+	if res.Headers[0] != "known" {
+		t.Errorf("Headers[0]: got %q, want \"known\"", res.Headers[0])
+	}
+}
+
+func TestCombineColumns_CategoricalValuesCorrect(t *testing.T) {
+	csvData := makeCSVData([]string{}, nil, nil, nil)
+	catData := map[string][]string{"label": {"foo", "bar", "baz"}}
+	csvData.Rows = 3
+
+	res := CombineColumns(csvData, catData, nil, []string{"label"})
+
+	if res.Data[0][0] != "foo" || res.Data[1][0] != "bar" || res.Data[2][0] != "baz" {
+		t.Errorf("categorical values: got %v", []string{res.Data[0][0], res.Data[1][0], res.Data[2][0]})
+	}
+}
+
+func TestCombineColumns_TargetValuesFormatted(t *testing.T) {
+	csvData := makeCSVData([]string{}, nil, nil, nil)
+	targetData := map[string][]float64{"score": {1.5, 2.5}}
+	csvData.Rows = 2
+
+	res := CombineColumns(csvData, nil, targetData, []string{"score"})
+
+	if res.Data[0][0] != "1.5" || res.Data[1][0] != "2.5" {
+		t.Errorf("target values: got %v", []string{res.Data[0][0], res.Data[1][0]})
+	}
+}
+
+func TestCombineColumns_NumericTargetDataInResult(t *testing.T) {
+	csvData := makeCSVData([]string{}, nil, nil, nil)
+	targetData := map[string][]float64{"y": {10.0, 20.0}}
+	csvData.Rows = 2
+
+	res := CombineColumns(csvData, nil, targetData, []string{"y"})
+
+	vals, ok := res.NumericTargetData["y"]
+	if !ok {
+		t.Fatal("NumericTargetData missing key 'y'")
+	}
+	if vals[0] != 10.0 || vals[1] != 20.0 {
+		t.Errorf("NumericTargetData[y]: got %v", vals)
+	}
+}

--- a/pkg/integration/validation.go
+++ b/pkg/integration/validation.go
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidationInput carries the dataset fields needed to validate compatibility
+// with GoPCA. It mirrors the relevant fields of the application FileData type
+// so that the function can be used without a dependency on the Wails layer.
+type ValidationInput struct {
+	// Headers is the ordered list of column names.
+	Headers []string
+	// Data is the row-major data matrix (each row is a slice of string values).
+	Data [][]string
+	// ColumnTypes maps each column name to its detected type: "numeric",
+	// "categorical", or "target".
+	ColumnTypes map[string]string
+	// RowNames holds the per-row label values when a row-name column was
+	// detected during import (may be nil).
+	RowNames []string
+	// Rows is the number of data rows.
+	Rows int
+	// Columns is the number of columns (= len(Headers)).
+	Columns int
+}
+
+// ValidationResult reports whether a dataset is compatible with GoPCA and
+// provides a list of messages categorised as ERROR, WARNING, or INFO.
+type ValidationResult struct {
+	// IsValid is true when no ERROR-level messages were generated.
+	IsValid bool
+	// Messages contains zero or more messages prefixed with "ERROR:",
+	// "WARNING:", or "INFO:".
+	Messages []string
+}
+
+// missingValueTokens is the set of string representations treated as missing
+// data during GoPCA compatibility validation.
+var missingValueTokens = map[string]bool{
+	"":     true,
+	"NA":   true,
+	"N/A":  true,
+	"nan":  true,
+	"NaN":  true,
+	"null": true,
+	"NULL": true,
+}
+
+// ValidateForGoPCA inspects in and returns a ValidationResult describing
+// whether the dataset can be used for PCA analysis in GoPCA Desktop.
+//
+// Checks performed:
+//   - Minimum row count (≥2)
+//   - Minimum numeric column count (≥2 required, ≥3 recommended)
+//   - Per-column missing value percentage (warns at >50%)
+//   - Overall missing value percentage
+//   - Dataset size (info at >10 000 rows)
+//   - Row name presence (info)
+//   - Categorical and target column counts (info)
+func ValidateForGoPCA(in ValidationInput) *ValidationResult {
+	var messages []string
+	var numericColumns, categoricalColumns, targetColumns, totalMissing int
+
+	// Minimum row count.
+	if in.Rows < 2 {
+		messages = append(messages, fmt.Sprintf("ERROR: Data must have at least 2 rows (found %d)", in.Rows))
+	}
+
+	// Count column types.
+	for _, colType := range in.ColumnTypes {
+		switch colType {
+		case "numeric":
+			numericColumns++
+		case "categorical":
+			categoricalColumns++
+		case "target":
+			targetColumns++
+		}
+	}
+
+	// Per-column missing value check.
+	for colIdx, header := range in.Headers {
+		missingInCol := 0
+		for i := 0; i < in.Rows; i++ {
+			if i >= len(in.Data) {
+				break
+			}
+			if colIdx >= len(in.Data[i]) {
+				continue
+			}
+			trimmed := strings.TrimSpace(in.Data[i][colIdx])
+			if missingValueTokens[trimmed] {
+				missingInCol++
+				totalMissing++
+			}
+		}
+		if in.Rows > 0 {
+			pct := float64(missingInCol) / float64(in.Rows) * 100
+			if pct > 50 {
+				messages = append(messages, fmt.Sprintf("WARNING: Column '%s' has %.1f%% missing values", header, pct))
+			}
+		}
+	}
+
+	// Categorical / target column summaries.
+	if categoricalColumns > 0 {
+		messages = append(messages, fmt.Sprintf(
+			"INFO: %d categorical column(s) detected - these will be excluded from PCA but available for visualization",
+			categoricalColumns))
+	}
+	if targetColumns > 0 {
+		messages = append(messages, fmt.Sprintf(
+			"INFO: %d target column(s) detected - these will be excluded from PCA but available for visualization",
+			targetColumns))
+	}
+
+	// Numeric column count.
+	switch {
+	case numericColumns < 2:
+		messages = append(messages, fmt.Sprintf("ERROR: Need at least 2 numeric columns for PCA (found %d)", numericColumns))
+	case numericColumns < 3:
+		messages = append(messages, fmt.Sprintf("WARNING: Only %d numeric columns found - PCA results may be limited", numericColumns))
+	default:
+		messages = append(messages, fmt.Sprintf("INFO: %d numeric columns will be used for PCA analysis", numericColumns))
+	}
+
+	// Overall missing percentage.
+	totalCells := in.Rows * in.Columns
+	if totalCells > 0 && totalMissing > 0 {
+		pct := float64(totalMissing) / float64(totalCells) * 100
+		messages = append(messages, fmt.Sprintf("INFO: Dataset contains %.1f%% missing values (%d cells)", pct, totalMissing))
+	}
+
+	// Large dataset advisory.
+	if in.Rows > 10000 {
+		messages = append(messages, fmt.Sprintf("INFO: Large dataset detected (%d rows) - processing may take time", in.Rows))
+	}
+
+	// Row names present.
+	if len(in.RowNames) > 0 {
+		messages = append(messages, "INFO: Row names detected in first column")
+	}
+
+	// Validity: any ERROR message makes the result invalid.
+	isValid := true
+	for _, m := range messages {
+		if strings.HasPrefix(m, "ERROR:") {
+			isValid = false
+			break
+		}
+	}
+
+	return &ValidationResult{IsValid: isValid, Messages: messages}
+}

--- a/pkg/integration/validation_test.go
+++ b/pkg/integration/validation_test.go
@@ -1,0 +1,344 @@
+// Copyright 2025-2026 bitjungle - Rune Mathisen. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+// The author respectfully requests that it not be used for
+// military, warfare, or surveillance applications.
+
+package integration
+
+import (
+	"strings"
+	"testing"
+)
+
+// helpers
+
+func makeInput(rows, cols int, headers []string, colTypes map[string]string, data [][]string) ValidationInput {
+	return ValidationInput{
+		Headers:     headers,
+		Data:        data,
+		ColumnTypes: colTypes,
+		Rows:        rows,
+		Columns:     cols,
+	}
+}
+
+func hasPrefix(messages []string, prefix string) bool {
+	for _, m := range messages {
+		if strings.HasPrefix(m, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func countPrefix(messages []string, prefix string) int {
+	n := 0
+	for _, m := range messages {
+		if strings.HasPrefix(m, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// ─── IsValid ──────────────────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_ValidDataset(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}},
+	)
+	res := ValidateForGoPCA(in)
+	if !res.IsValid {
+		t.Errorf("expected valid dataset, got messages: %v", res.Messages)
+	}
+	if hasPrefix(res.Messages, "ERROR:") {
+		t.Error("expected no ERROR messages for clean dataset")
+	}
+}
+
+// ─── Row count ────────────────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_TooFewRows(t *testing.T) {
+	in := makeInput(1, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{{"1", "2", "3"}},
+	)
+	res := ValidateForGoPCA(in)
+	if res.IsValid {
+		t.Error("expected invalid for <2 rows")
+	}
+	if !hasPrefix(res.Messages, "ERROR:") {
+		t.Error("expected ERROR message for too few rows")
+	}
+}
+
+func TestValidateForGoPCA_ZeroRows(t *testing.T) {
+	in := makeInput(0, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{},
+	)
+	res := ValidateForGoPCA(in)
+	if res.IsValid {
+		t.Error("expected invalid for 0 rows")
+	}
+}
+
+// ─── Numeric column count ─────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_ZeroNumericColumns(t *testing.T) {
+	in := makeInput(3, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "categorical", "B": "categorical"},
+		[][]string{{"x", "y"}, {"x", "y"}, {"x", "y"}},
+	)
+	res := ValidateForGoPCA(in)
+	if res.IsValid {
+		t.Error("expected invalid for 0 numeric columns")
+	}
+	if !hasPrefix(res.Messages, "ERROR:") {
+		t.Error("expected ERROR message for zero numeric columns")
+	}
+}
+
+func TestValidateForGoPCA_OneNumericColumn(t *testing.T) {
+	in := makeInput(3, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "numeric", "B": "categorical"},
+		[][]string{{"1", "x"}, {"2", "x"}, {"3", "x"}},
+	)
+	res := ValidateForGoPCA(in)
+	if res.IsValid {
+		t.Error("expected invalid for 1 numeric column")
+	}
+}
+
+func TestValidateForGoPCA_TwoNumericColumns_ValidButWarning(t *testing.T) {
+	in := makeInput(3, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "numeric", "B": "numeric"},
+		[][]string{{"1", "2"}, {"3", "4"}, {"5", "6"}},
+	)
+	res := ValidateForGoPCA(in)
+	if !res.IsValid {
+		t.Error("expected valid for exactly 2 numeric columns")
+	}
+	if !hasPrefix(res.Messages, "WARNING:") {
+		t.Error("expected WARNING for only 2 numeric columns")
+	}
+}
+
+func TestValidateForGoPCA_ThreeNumericColumns_Info(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}},
+	)
+	res := ValidateForGoPCA(in)
+	if !res.IsValid {
+		t.Errorf("expected valid, got: %v", res.Messages)
+	}
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "3 numeric columns") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected INFO message about 3 numeric columns")
+	}
+}
+
+// ─── Missing values ───────────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_HighMissingColumn(t *testing.T) {
+	// 2 out of 3 rows missing in column A → 66.7% → WARNING
+	in := makeInput(3, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "numeric", "B": "numeric"},
+		[][]string{{"1", "1"}, {"NA", "2"}, {"", "3"}},
+	)
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "WARNING:") && strings.Contains(m, "Column 'A'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected WARNING for high missing in column A, got: %v", res.Messages)
+	}
+}
+
+func TestValidateForGoPCA_MissingValueTokens(t *testing.T) {
+	// All recognised missing tokens should be counted.
+	tokens := []string{"NA", "N/A", "nan", "NaN", "null", "NULL", ""}
+	for _, tok := range tokens {
+		in := makeInput(3, 2,
+			[]string{"A", "B"},
+			map[string]string{"A": "numeric", "B": "numeric"},
+			// Only one cell in A — use the token; make rest valid.
+			[][]string{{tok, "1"}, {"0", "2"}, {"0", "3"}},
+		)
+		res := ValidateForGoPCA(in)
+		found := false
+		for _, m := range res.Messages {
+			if strings.Contains(m, "missing values") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("token %q: expected missing-value message", tok)
+		}
+	}
+}
+
+func TestValidateForGoPCA_OverallMissingInfo(t *testing.T) {
+	// One missing cell in a 2×2 dataset → INFO about overall missing%.
+	in := makeInput(2, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "numeric", "B": "numeric"},
+		[][]string{{"NA", "1"}, {"2", "3"}},
+	)
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "missing values") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected INFO about overall missing%%, got: %v", res.Messages)
+	}
+}
+
+func TestValidateForGoPCA_NoMissingNoOverallInfo(t *testing.T) {
+	// Zero missing cells → no overall missing INFO.
+	in := makeInput(2, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "numeric", "B": "numeric"},
+		[][]string{{"1", "2"}, {"3", "4"}},
+	)
+	res := ValidateForGoPCA(in)
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "missing values") {
+			t.Errorf("unexpected missing-value INFO for clean dataset: %q", m)
+		}
+	}
+}
+
+// ─── Column type summaries ────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_CategoricalColumnsInfo(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "Cat"},
+		map[string]string{"A": "numeric", "B": "numeric", "Cat": "categorical"},
+		[][]string{{"1", "2", "x"}, {"3", "4", "y"}, {"5", "6", "x"}},
+	)
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "categorical") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected INFO about categorical columns")
+	}
+}
+
+func TestValidateForGoPCA_TargetColumnsInfo(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "T"},
+		map[string]string{"A": "numeric", "B": "numeric", "T": "target"},
+		[][]string{{"1", "2", "0"}, {"3", "4", "1"}, {"5", "6", "0"}},
+	)
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "target") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected INFO about target columns")
+	}
+}
+
+// ─── Large dataset / row names ────────────────────────────────────────────────
+
+func TestValidateForGoPCA_LargeDatasetInfo(t *testing.T) {
+	in := ValidationInput{
+		Headers:     []string{"A", "B", "C"},
+		Data:        nil,
+		ColumnTypes: map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		Rows:        10001,
+		Columns:     3,
+	}
+	// Data is nil — row-count check fires first; then large-dataset INFO.
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "Large dataset") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Large dataset INFO for >10000 rows, got: %v", res.Messages)
+	}
+}
+
+func TestValidateForGoPCA_RowNamesInfo(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}},
+	)
+	in.RowNames = []string{"r1", "r2", "r3"}
+	res := ValidateForGoPCA(in)
+	found := false
+	for _, m := range res.Messages {
+		if strings.HasPrefix(m, "INFO:") && strings.Contains(m, "Row names") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected INFO about row names")
+	}
+}
+
+func TestValidateForGoPCA_NoRowNamesNoInfo(t *testing.T) {
+	in := makeInput(3, 3,
+		[]string{"A", "B", "C"},
+		map[string]string{"A": "numeric", "B": "numeric", "C": "numeric"},
+		[][]string{{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}},
+	)
+	res := ValidateForGoPCA(in)
+	for _, m := range res.Messages {
+		if strings.Contains(m, "Row names") {
+			t.Errorf("unexpected row-name message when RowNames is nil: %q", m)
+		}
+	}
+}
+
+// ─── Multiple errors ──────────────────────────────────────────────────────────
+
+func TestValidateForGoPCA_MultipleErrors(t *testing.T) {
+	// 1 row + 0 numeric columns → 2 ERRORs, isValid=false.
+	in := makeInput(1, 2,
+		[]string{"A", "B"},
+		map[string]string{"A": "categorical", "B": "categorical"},
+		[][]string{{"x", "y"}},
+	)
+	res := ValidateForGoPCA(in)
+	if res.IsValid {
+		t.Error("expected invalid")
+	}
+	if countPrefix(res.Messages, "ERROR:") < 2 {
+		t.Errorf("expected at least 2 ERROR messages, got: %v", res.Messages)
+	}
+}

--- a/scripts/ci/test-core.sh
+++ b/scripts/ci/test-core.sh
@@ -29,7 +29,7 @@ mkdir -p cmd/gopca-desktop/frontend/dist
 echo '<!DOCTYPE html><html><body>Test</body></html>' > cmd/gopca-desktop/frontend/dist/index.html
 
 # First run core packages and GoPCA Desktop tests
-if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gopca-desktop; then
+if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/csv ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gopca-desktop; then
     echo "✗ Core tests failed"
     exit 1
 fi
@@ -66,7 +66,7 @@ echo "✓ All core tests passed"
 # Show coverage summary
 echo ""
 echo "=== Coverage Summary ==="
-go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
+go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/csv ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
 
 echo ""
 echo "=== Core tests completed successfully ===" 

--- a/scripts/ci/test-core.sh
+++ b/scripts/ci/test-core.sh
@@ -29,7 +29,7 @@ mkdir -p cmd/gopca-desktop/frontend/dist
 echo '<!DOCTYPE html><html><body>Test</body></html>' > cmd/gopca-desktop/frontend/dist/index.html
 
 # First run core packages and GoPCA Desktop tests
-if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./cmd/gopca-desktop; then
+if ! go test -v -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gopca-desktop; then
     echo "✗ Core tests failed"
     exit 1
 fi
@@ -66,7 +66,7 @@ echo "✓ All core tests passed"
 # Show coverage summary
 echo ""
 echo "=== Coverage Summary ==="
-go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
+go test -cover ./internal/cli ./internal/core ./internal/utils ./pkg/types ./pkg/dataquality ./pkg/transform ./pkg/integration ./cmd/gocsv ./cmd/gopca-desktop 2>/dev/null | grep -E "coverage:|ok" || true
 
 echo ""
 echo "=== Core tests completed successfully ===" 


### PR DESCRIPTION
## Summary

- Extracts `getAllOriginalHeaders` → `pkg/csv.GetOriginalHeaders`
- Extracts `combineAllColumns` → `pkg/csv.CombineColumns`
- Adds `pkg/csv/parse.go` and `pkg/csv/parse_test.go` (14 tests)
- Adds `pkg/csv` to `scripts/ci/test-core.sh` coverage
- `app.go` drops from 1 789 → 1 700 lines (−89 this commit)

### Cumulative progress on #641 (slim Wails layer)
| Commit | Extraction | app.go lines |
|--------|-----------|-------------|
| 1 | `ValidateForGoPCA` → `pkg/integration` | 1 836 |
| 2 | `detectColumnType` → `pkg/csv.DetectColumnType` | 1 789 |
| **3** | `getAllOriginalHeaders`, `combineAllColumns` → `pkg/csv` | **1 700** |

Original baseline: 3 613 lines. Target: ≤ 1 400.

## Test plan

- [x] `go test ./pkg/csv/...` — all 14 new tests pass
- [x] `bash scripts/ci/test-core.sh` — all suites green
- [x] `cd cmd/gocsv/frontend && npm run build` — TypeScript compiles cleanly
- [x] Pre-commit hooks pass (fmt, vet, tests)

Fixes #641