### PR TITLE
fix(ci): fix macOS notarization in release builds

### DIFF
--- a/scripts/ci/notarize-macos-ci.sh
+++ b/scripts/ci/notarize-macos-ci.sh
@@ -78,19 +78,14 @@ echo "Archive created: $(du -h "$ZIP_PATH" | cut -f1)"
 echo "Submitting to Apple for notarization..."
 echo "This may take several minutes..."
 
-# Create a notarization profile to avoid passing credentials directly
-# This is more secure as it doesn't expose credentials in process lists
-xcrun notarytool store-credentials "ci-notarization" \
+# Submit and wait for notarization
+# Pass credentials inline to avoid keychain profile persistence issues in CI
+# (the signing step modifies the keychain list, which can make stored profiles inaccessible)
+SUBMISSION_ID=""
+if SUBMISSION_OUTPUT=$(xcrun notarytool submit "$ZIP_PATH" \
     --apple-id "$APPLE_ID" \
     --password "$APPLE_APP_SPECIFIC_PASSWORD" \
     --team-id "$APPLE_TEAM_ID" \
-    --validate \
-    2>&1 | grep -v "password" || true
-
-# Submit and wait for notarization
-SUBMISSION_ID=""
-if SUBMISSION_OUTPUT=$(xcrun notarytool submit "$ZIP_PATH" \
-    --keychain-profile "ci-notarization" \
     --wait \
     --timeout 30m \
     --verbose 2>&1); then
@@ -141,8 +136,5 @@ else
     echo "WARNING: Notarization failed, but continuing build"
     exit 0
 fi
-
-# Clean up stored credentials
-xcrun notarytool delete-credentials "ci-notarization" 2>/dev/null || true
 
 echo "=== Notarization completed successfully ==="


### PR DESCRIPTION
## Problem

macOS binaries in the v1.3.0 release are **signed but not notarized**. Gatekeeper will block them on first launch.

## Root cause

`notarize-macos-ci.sh` used `xcrun notarytool store-credentials` to save a keychain profile, then referenced it via `--keychain-profile`. However, the signing script that runs before notarization modifies and then restores the keychain search list. This leaves the stored profile inaccessible when `notarytool submit` runs, causing the silent failure:

```
Couldn't find keychain item matching [...] "acct": "com.apple.gke.notary.tool.saved-creds.ci-notarization"
WARNING: Notarization failed, but continuing build
```

## Fix

Pass `--apple-id`, `--password`, and `--team-id` directly to `notarytool submit` instead of relying on a stored keychain profile. This bypasses the keychain persistence problem entirely. Credentials are already available as environment variables from GitHub secrets.

## Follow-up

After merging, cut a v1.3.1 patch release to ship properly notarized macOS binaries.