### PR TITLE
docs: EEG Eye State tutorial improvements (#658 follow-up)

### DIFF
--- a/cmd/gopca-desktop/frontend/public/tutorials/eeg_eye_state/eeg_eye_state_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/eeg_eye_state/eeg_eye_state_exploration.md
@@ -19,6 +19,10 @@ The recording lasted **117 seconds** at a sampling rate of **128 Hz** — giving
 * `eye_state = open` — eyes open
 * `eye_state = closed` — eyes closed
 
+In the original UCI dataset, eye state is encoded numerically: **0 = eyes open, 1 = eyes closed**. GoPCA displays these as `open` and `closed` text labels.
+
+> **Note on data quality**: the raw UCI recording contains a small number of significant outliers concentrated in the middle of the recording. These can produce unusual clusters or isolated points in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting results.
+
 The original research motivation was classification: can the EEG signal alone predict whether the eyes are open or closed? Here, we approach the same data using **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the labels entirely. The question becomes: what structure does PCA find in the EEG channels on its own, and does that structure relate to eye state?
 
 👉 This dataset is fundamentally different from Iris, Wine, Corn, and Swiss Roll:

--- a/cmd/gopca-desktop/frontend/public/tutorials/eeg_eye_state/eeg_eye_state_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/eeg_eye_state/eeg_eye_state_exploration.md
@@ -21,7 +21,7 @@ The recording lasted **117 seconds** at a sampling rate of **128 Hz** — giving
 
 In the original UCI dataset, eye state is encoded numerically: **0 = eyes open, 1 = eyes closed**. GoPCA displays these as `open` and `closed` text labels.
 
-> **Note on data quality**: the raw UCI recording contains a small number of significant outliers concentrated in the middle of the recording. These can produce unusual clusters or isolated points in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting results.
+> **Note on data quality**: the dataset contains four isolated time points with extreme values — at approximately t = 7 s, 81 s, 90 s, and 103 s — where one or more channels reach values 70–150× the normal signal range (almost certainly brief electrode or cable artifacts). These will appear as isolated extreme points far from the main cluster in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting unexpected structure in the results.
 
 The original research motivation was classification: can the EEG signal alone predict whether the eyes are open or closed? Here, we approach the same data using **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the labels entirely. The question becomes: what structure does PCA find in the EEG channels on its own, and does that structure relate to eye state?
 

--- a/cmd/gopca-desktop/frontend/src/components/sections/DataLoadSection.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/sections/DataLoadSection.tsx
@@ -94,15 +94,6 @@ export function DataLoadSection() {
                             Or Try Sample Datasets
                         </label>
                         <div className="space-y-2">
-                            <HelpWrapper helpKey="sample-dataset-corn">
-                                <button
-                                    onClick={() => loadDatasetWithTutorial('corn.csv', undefined, 'corn')}
-                                    className="w-full px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
-                                    disabled={loading}
-                                >
-                                    Corn (NIR)
-                                </button>
-                            </HelpWrapper>
                             <HelpWrapper helpKey="sample-dataset-iris">
                                 <button
                                     onClick={() => loadDatasetWithTutorial('iris.csv', 'species', 'iris')}
@@ -119,6 +110,15 @@ export function DataLoadSection() {
                                     disabled={loading}
                                 >
                                     Wine
+                                </button>
+                            </HelpWrapper>
+                            <HelpWrapper helpKey="sample-dataset-corn">
+                                <button
+                                    onClick={() => loadDatasetWithTutorial('corn.csv', undefined, 'corn')}
+                                    className="w-full px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                                    disabled={loading}
+                                >
+                                    Corn (NIR)
                                 </button>
                             </HelpWrapper>
                             <HelpWrapper helpKey="sample-dataset-swiss-roll">

--- a/testdata/eye_state/eeg_eye_state_exploration.md
+++ b/testdata/eye_state/eeg_eye_state_exploration.md
@@ -19,6 +19,10 @@ The recording lasted **117 seconds** at a sampling rate of **128 Hz** — giving
 * `eye_state = open` — eyes open
 * `eye_state = closed` — eyes closed
 
+In the original UCI dataset, eye state is encoded numerically: **0 = eyes open, 1 = eyes closed**. GoPCA displays these as `open` and `closed` text labels.
+
+> **Note on data quality**: the raw UCI recording contains a small number of significant outliers concentrated in the middle of the recording. These can produce unusual clusters or isolated points in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting results.
+
 The original research motivation was classification: can the EEG signal alone predict whether the eyes are open or closed? Here, we approach the same data using **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the labels entirely. The question becomes: what structure does PCA find in the EEG channels on its own, and does that structure relate to eye state?
 
 👉 This dataset is fundamentally different from Iris, Wine, Corn, and Swiss Roll:

--- a/testdata/eye_state/eeg_eye_state_exploration.md
+++ b/testdata/eye_state/eeg_eye_state_exploration.md
@@ -21,7 +21,7 @@ The recording lasted **117 seconds** at a sampling rate of **128 Hz** — giving
 
 In the original UCI dataset, eye state is encoded numerically: **0 = eyes open, 1 = eyes closed**. GoPCA displays these as `open` and `closed` text labels.
 
-> **Note on data quality**: the raw UCI recording contains a small number of significant outliers concentrated in the middle of the recording. These can produce unusual clusters or isolated points in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting results.
+> **Note on data quality**: the dataset contains four isolated time points with extreme values — at approximately t = 7 s, 81 s, 90 s, and 103 s — where one or more channels reach values 70–150× the normal signal range (almost certainly brief electrode or cable artifacts). These will appear as isolated extreme points far from the main cluster in the scores plot. They are part of the real dataset and do not need to be removed for this exploration, but keep them in mind when interpreting unexpected structure in the results.
 
 The original research motivation was classification: can the EEG signal alone predict whether the eyes are open or closed? Here, we approach the same data using **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the labels entirely. The question becomes: what structure does PCA find in the EEG channels on its own, and does that structure relate to eye state?
 


### PR DESCRIPTION
## Summary

Follow-up improvements to the EEG Eye State dataset and tutorial after PR #668 was merged.

- Change recommended default **Number of Time Lags from 16 to 32** (250 ms, covers 2–3 alpha cycles at 128 Hz) — recommended by tutorial author
- Expand window length table with duration and interpretation notes for lags 8, 16, 32, 64, 128
- Add key teaching point: *"Increasing the lag gives PCA memory. But too much memory can make the model harder to interpret."*
- Add **EEG electrode position topomap** (`eeg_electrode_map.png`) in the Background section, generated from MNE standard_1020 montage
- Add verified **data quality note**: 4 isolated artifact time points at t ≈ 7 s, 81 s, 90 s, 103 s with values 70–150× normal range (verified directly from CSV)
- Clarify original UCI label encoding (0 = open, 1 = closed)
- **Reorder sample dataset buttons**: Iris → Wine → Corn (NIR) → Swiss Roll → EEG Eye State (Fixes #669)

## Test plan

- [ ] Click **EEG Eye State** button — dataset loads correctly
- [ ] Tutorial opens and electrode map renders
- [ ] Default Number of Time Lags shown as 32 in tutorial text
- [ ] Button order in UI matches: Iris, Wine, Corn (NIR), Swiss Roll, EEG Eye State

Fixes #669