### PR TITLE
docs: tutorial follow-up edits after human review (#671)

### DIFF
--- a/cmd/gopca-desktop/frontend/public/docs/intro_to_pca.md
+++ b/cmd/gopca-desktop/frontend/public/docs/intro_to_pca.md
@@ -145,7 +145,7 @@ GoPCA Desktop ships with six carefully selected sample datasets. Together they c
 
 ### Dataset 4: Swiss Roll — When Standard PCA Is Not Enough
 
-**The data:** 1,000 synthetic data points in three dimensions, arranged on a two-dimensional surface that has been rolled up like a Swiss roll pastry. Each point has three coordinates (x, y, z) and a color value indicating its position along the roll.
+**The data:** 1,000 synthetic data points in three dimensions, arranged on a two-dimensional surface that has been rolled up like a Swiss roll pastry. Each point has three coordinates (x, y, z) and a special column `color #target` indicating position along the roll. Columns ending in `#target` are excluded from the PCA calculation and used only for colouring plots — a GoPCA convention for attaching external information to a dataset without influencing the analysis. See the [GoPCA Data Format Guide](data-format.md) for details.
 
 **Why it is special:** This dataset has no noise problem, no scale problem, and no outlier problem — and yet standard PCA completely fails to reveal its structure. The reason is geometric: the data lives on a curved surface, and PCA can only find flat (linear) projections. When you project a Swiss roll onto a flat plane, the two ends of the roll overlap. The underlying two-dimensional structure — which is completely real — is invisible to standard PCA. This is the clearest possible demonstration of PCA's fundamental limitation.
 

--- a/cmd/gopca-desktop/frontend/public/tutorials/corn/corn_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/corn/corn_exploration.md
@@ -31,7 +31,7 @@ This has two immediate consequences that make Corn unlike anything you have seen
 
 **Adjacent variables are not independent.** In Iris, sepal length and petal length are correlated but measure genuinely different things. In a NIR spectrum, the absorbance at 1500 nm and at 1502 nm are almost identical — they are sampling the same physical absorption feature separated by one instrument step. This extreme collinearity means PCA can compress 700 variables into 2–3 components and lose almost nothing, because most of the 700 variables are carrying nearly the same information.
 
-> Corn NIR is the natural next step: more variables than you can count, all correlated, and no predefined classes. PCA is not one option among several — it is the standard first tool for this kind of data.
+> Corn NIR is the natural next step: more variables than you can count, all highly correlated. PCA is not one option among several — it is the standard first tool for this kind of data.
 
 ---
 
@@ -82,10 +82,10 @@ Instead, **experiment, observe, and reflect**.
 
 ## Step 1: Run PCA with default settings — and diagnose the result
 
-Load the Corn dataset into GoPCA. Do not set a target column yet. Leave all settings at their defaults:
+Load the Corn dataset into GoPCA. Leave all settings at their defaults:
 
 * **Row Preprocessing** → None
-* **Column Preprocessing** → Mean Center
+* **Column Preprocessing** → Mean Center Only
 * **PCA Method** → SVD
 
 Click **Go PCA**.
@@ -115,7 +115,7 @@ NIR spectra are affected by **multiplicative scatter**: differences in particle 
 
 ## Step 2: Apply SNV and compare
 
-NIR spectra need **row-wise scatter correction** before column-wise preprocessing. The standard method is **SNV (Standard Normal Variate)**.
+NIR spectra need **row-wise scatter correction** before column-wise preprocessing. The standard method in GoPCA is **SNV (Standard Normal Variate)**.
 
 SNV operates on each spectrum individually:
 
@@ -161,16 +161,16 @@ Open the **Loadings Plot** (with SNV applied).
 
 ## Step 4: Connect PCA to chemistry
 
-Now set a target column to colour the samples by composition.
+Now lets try to colour the samples by composition.
 
-In GoPCA, set the **target column** to `Moisture#target`. Look at the **Scores Plot**.
+Look at the **Scores Plot**. Set the **Color by** to `Moisture#target`.
 
 #### Questions:
 
 * Do you see a gradient in the scores — samples ordered by moisture content?
 * Does the gradient run along PC1, PC2, or diagonally?
 
-👉 Try switching the target column to `Starch#target`, then `Protein#target`, then `Oil#target`:
+👉 Try switching the **Color by** to `Starch#target`, then `Protein#target`, then `Oil#target`:
 
 * Which compositional property is most strongly captured by PC1?
 * Are all four properties captured equally well, or do some require higher components?
@@ -181,7 +181,7 @@ In GoPCA, set the **target column** to `Moisture#target`. Look at the **Scores P
 
 ## Step 5: Look for outliers
 
-Return to the Scores Plot with no target column selected.
+Return to the Scores Plot with no **Color by** selected.
 
 #### Questions:
 

--- a/cmd/gopca-desktop/frontend/public/tutorials/corn/corn_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/corn/corn_exploration.md
@@ -11,6 +11,8 @@ This dataset consists of **80 corn samples**, each measured by an NIR instrument
 * `Protein#target` — protein content (%)
 * `Starch#target` — starch content (%)
 
+These four columns are excluded from the PCA automatically and are available for colouring the scores plot — you will use them in Step 4.
+
 The original purpose of such a dataset is **calibration**: build a model that predicts chemical composition from the spectrum alone, so future samples can be analysed in seconds rather than hours. This is a supervised problem — it uses the known laboratory values to train a model.
 
 Here, we will approach the same data with **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the laboratory values entirely. The question becomes: what structure does PCA find in the spectra on its own? And does that structure relate to chemistry?
@@ -249,7 +251,7 @@ Think about this:
 * How is PCA on spectral data different from PCA on independent measurements like Iris or Wine?
 * Why do the loadings appear as smooth curves rather than isolated vectors?
 * Why is SNV more appropriate here than column-wise standard scaling?
-* The original purpose of this dataset was to build a calibration model predicting composition from spectra. Could you use the PCA scores as input to such a model? What might be the advantage of using scores instead of raw spectra?
+* The original purpose of this dataset was to build a calibration model predicting composition from spectra. Could you use the PCA scores as input to such a model? What might be the advantage of using scores instead of raw spectra? Hint: search for **principal component regression** on the internet.
 
 ---
 

--- a/cmd/gopca-desktop/frontend/public/tutorials/iris/iris_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/iris/iris_exploration.md
@@ -184,7 +184,7 @@ in the same plot.
 
 ## Step 5: Use color and grouping
 
-In GoPCA, set the **target column** to the species column to color samples by species. Then enable **Confidence Ellipses**.
+In GoPCA, set the **Color By** menu to the species column to color samples by species. Then enable **Confidence Ellipses**.
 
 #### Questions:
 

--- a/cmd/gopca-desktop/frontend/public/tutorials/swiss_roll/swiss_roll_exploration.md
+++ b/cmd/gopca-desktop/frontend/public/tutorials/swiss_roll/swiss_roll_exploration.md
@@ -7,7 +7,7 @@ The Swiss Roll is a **synthetic benchmark** — a dataset constructed mathematic
 The dataset consists of **1,000 samples** in three dimensions:
 
 * `X`, `Y`, `Z` — the 3D coordinates of each point
-* `color #target` — a continuous numeric value encoding position along the roll (hidden from the analysis, used only for colouring plots)
+* `color #target` — position along the roll, used only for colouring plots (not included in the analysis)
 
 The data is generated from two underlying parameters:
 
@@ -20,7 +20,7 @@ The 3D coordinates follow from:
 * y = h
 * z = t · sin(t)
 
-The `color #target` column stores the raw value of *t* for each sample. In GoPCA, any column whose name ends with `#target` is excluded from the PCA analysis and hidden from the data table — it is available only as a colour variable in the scores plot. When you load the Swiss Roll dataset by clicking the button, this colour mapping is applied automatically.
+The `color #target` column stores the raw value of *t* and is used only for colouring the scores plot — it plays no part in the analysis. When you load the dataset, this colouring is applied automatically.
 
 The true structure is a **flat 2D sheet wound into a helix in 3D space**. This type of structure is called a **manifold** — a surface that is locally flat but globally curved. A piece of paper lying on a table is flat; roll it up and it becomes a manifold embedded in 3D. The Swiss Roll is exactly this: a flat 2D sheet with coordinates *t* and *h*, curled into a spiral shape.
 
@@ -83,9 +83,9 @@ Study both panels before running any analysis.
 
 ### Reflect:
 
-* In the 3D view: trace the colour gradient from dark purple inward to yellow at the outer edge. Can you follow it continuously along the surface of the roll?
-* In the top-down view: the inner edge (dark purple) and outer edge (yellow) are physically close in the X–Z plane — they are separated by only the width of one gap between spiral turns. How far apart are they if you instead trace along the surface of the sheet?
-* If you could cut the roll along one edge and flatten it completely, what shape would you get?
+* In the 3D view: trace the colour gradient from dark purple inward to yellow at the outer edge. Can you follow it continuously along the surface of the roll? *(Hint: run your finger along the surface — never lift it, never cut through the interior.)*
+* In the top-down view: the inner edge (dark purple) and outer edge (yellow) are physically close in the X–Z plane — they are separated by only the width of one gap between spiral turns. How far apart are they if you instead trace along the surface of the sheet? *(Hint: think of a roll of paper. The first centimetre of paper and the last centimetre are neighbours when the roll is wound — but how far apart are they when you unroll it?)*
+* If you could cut the roll along one edge and flatten it completely, what shape would you get? *(Hint: what is the shape of a single sheet of A4 paper before you roll it?)*
 
 👉 A perfectly flattened Swiss Roll would be a rectangle: one axis is *t* (position along the roll, from low to high), the other is *h* (height *Y*). The top-down spiral view makes the core problem immediately visible: the inner and outer edges sit physically adjacent in 3D space, yet they are at opposite ends of the unrolled sheet. Any method that measures straight-line distances through 3D space will see them as neighbours — and fail to unroll the manifold.
 
@@ -121,7 +121,7 @@ Do not run PCA yet. Familiarise yourself with what is shown in the data panel.
 * Only three numeric columns appear — `X`, `Y`, and `Z`. Why is `color #target` not visible in the table?
 * Study the 3D figure above: what will "low colour values" (inner edge of the roll) and "high colour values" (outer edge) look like in the scores plot if PCA correctly unrolls the manifold?
 
-👉 There are 1,000 samples and 3 numeric variables — a tiny dataset by modern standards. This makes the subsequent failure of linear PCA all the more striking. The `color #target` column is hidden because it is excluded from the analysis; it serves only as a visual guide to check whether the scores plot preserves the ordering along the roll.
+👉 There are 1,000 samples and 3 numeric variables — a tiny dataset by modern standards. This makes the subsequent failure of linear PCA all the more striking.
 
 ---
 
@@ -131,9 +131,10 @@ Set:
 
 * **PCA Method** → SVD
 
+Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
+
 Leave the colour variable as `color #target` (pre-selected automatically).
 
-Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
 
 #### Questions:
 
@@ -141,7 +142,7 @@ Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
 * Or are low and high colour values mixed together — samples from opposite ends of the roll landing on top of each other?
 * Does the scores plot resemble the flat rectangle you imagined — or is the colour pattern jumbled?
 
-👉 You will see that the colour is **mixed and not ordered**. The scores plot forms a horseshoe or arch shape — a classic artefact of applying a linear projection to curved data. You may notice a rough gradient running *around* the arch, but look more carefully: the inner edge (dark purple, low t) is bunched in the centre of the plot rather than at one end, and high colour values (cream/yellow) appear on one side of the arch directly adjacent to medium values (blue-purple) — groups that are at opposite ends of the unrolled sheet. The colour never forms the smooth end-to-end gradient you would see in a correctly unrolled rectangle. Samples that are close in straight-line 3D distance but far apart along the manifold surface end up side by side in the projection.
+👉 The scores plot forms a **tilted oval or elliptical ring** — a classic artefact of applying a linear projection to curved data. The colour appears to flow continuously around the ring: dark navy (low *t*) sits at the left, sweeping through purple and pink along the top arc, while a separate branch of peach and salmon sweeps around the bottom arc, with cream/yellow (high *t*) appearing at both the upper-right and lower-right tips (assuming that you use the "Rocket" color palette). At first glance this looks like an ordered gradient — but it is deceptive. The colour is running in a **closed loop around the ring**, not in a straight line from one end of a rectangle to the other. A correctly unrolled Swiss Roll would place all the dark navy samples at one side and all the cream/yellow samples at the opposite side, with a clean gradient between them. Here, the high-*t* samples (cream/yellow, outer edge) have been **split into two separate clusters** — one in the upper-right and one in the lower-right of the plot — while the low-*t* samples (dark navy, inner edge) are bunched together on the left. A correctly unrolled roll would place all the cream/yellow samples together at one end of a rectangle and all the navy samples at the other. Instead, the outer edge of the roll has been torn apart and wrapped around both sides of the ring. The roll has been **squashed and folded**, not unrolled.
 
 Now open the **Scree Plot**.
 
@@ -150,9 +151,11 @@ Now open the **Scree Plot**.
 * How much variance does PC1 explain?
 * Does a high explained variance mean the structure has been correctly recovered?
 
-👉 **This is the key diagnostic moment.** Linear PCA may explain 60–80% of the total variance while completely failing to reveal the true structure. Variance is a property of the coordinate system — not of the manifold geometry. High explained variance is not the same as a good unrolling.
+👉 **This is the key diagnostic moment.** You should see PC1 explaining around 41% of the variance and PC2 around 30% — a total of roughly 71% for the first two components together. Notice also that there is **no clear elbow**: the variance does not drop sharply after PC1. This is itself a warning sign — it means PCA has not found one dominant direction that captures most of the structure. The variance is spread out because the spiral has roughly equal extent in every direction through 3D space.
 
-Compare this to Corn: there, PC1 explained 99% of variance, but the loading curve (monotone, never crossing zero) revealed it was capturing baseline tilt, not chemistry. Here, a seemingly reasonable explained variance hides an equally fundamental failure — but it is harder to detect from the scree plot alone. The scores plot, coloured by category, is the diagnostic tool.
+But the deeper point is this: even 71% combined explained variance tells you nothing about whether the *manifold* has been correctly recovered. Variance is a property of the coordinate system — not of the geometry of the roll. The scores plot, coloured by *t*, is the only diagnostic that reveals the failure.
+
+Compare this to Corn: there, PC1 explained 99% of variance, and the loading curve (monotone, never crossing zero) immediately revealed it was capturing a physical baseline artefact. Here, the scree plot looks unremarkable — no single dramatic number, no obvious red flag. The failure is entirely invisible until you look at the scores plot with a meaningful colour variable.
 
 > The Swiss Roll teaches a habit that applies to every dataset: always inspect the scores plot with a meaningful grouping variable before concluding that PCA has succeeded.
 
@@ -170,7 +173,7 @@ Points that are far apart *along the surface of the manifold* (for example, at o
 
 ### The kernel trick
 
-Kernel PCA addresses this by replacing the linear covariance structure with a **kernel function** that measures similarity between data points. The key idea, introduced by Schölkopf, Smola & Müller (1998), is to perform PCA not in the original 3D space but in a transformed feature space **F** — implicitly, without ever computing the transformation explicitly.
+Kernel PCA addresses this by replacing the linear covariance structure with a **kernel function** that measures similarity between data points. The key idea, introduced by Schölkopf, Smola & Müller (1997, 1998), is to perform PCA not in the original 3D space but in a transformed feature space **F** — implicitly, without ever computing the transformation explicitly.
 
 The **RBF (Gaussian) kernel** used here is:
 
@@ -225,7 +228,7 @@ A **perfect unrolling** of the Swiss Roll requires methods that compute *geodesi
 
 > This limitation is not a failure of Kernel PCA — it is a boundary condition. For many real datasets with milder curvature, Kernel PCA works very well. The Swiss Roll is a deliberately extreme case designed to test these limits.
 
-**Preprocessing note**: when Kernel PCA is selected, GoPCA restricts column-wise preprocessing to **Variance Scale** or **None**. Mean centering and standard scaling are unavailable because Kernel PCA performs its own centering in kernel space. For this dataset the variables are in the same units, so **None** is appropriate.
+**Preprocessing note**: when Kernel PCA is selected, GoPCA restricts column-wise preprocessing to **Variance Scale** or **None**. Mean centering and standard scaling are unavailable because Kernel PCA handles centering through modified kernel matrix algebra — subtracting the feature-space mean implicitly without ever computing it explicitly (Schölkopf et al., 1998). For this dataset the variables are in the same units, so **None** is appropriate.
 
 **Available plots**: the **Loadings Plot**, **Biplot**, **3D Biplot**, **Circle of Correlations**, and **Diagnostic Plot** are all unavailable for Kernel PCA — for the reasons explained in Step 3. The **Scores Plot**, **Scree Plot**, and **Kernel Matrix Heatmap** remain available.
 

--- a/docs/intro_to_pca.md
+++ b/docs/intro_to_pca.md
@@ -145,7 +145,7 @@ GoPCA Desktop ships with six carefully selected sample datasets. Together they c
 
 ### Dataset 4: Swiss Roll — When Standard PCA Is Not Enough
 
-**The data:** 1,000 synthetic data points in three dimensions, arranged on a two-dimensional surface that has been rolled up like a Swiss roll pastry. Each point has three coordinates (x, y, z) and a color value indicating its position along the roll.
+**The data:** 1,000 synthetic data points in three dimensions, arranged on a two-dimensional surface that has been rolled up like a Swiss roll pastry. Each point has three coordinates (x, y, z) and a special column `color #target` indicating position along the roll. Columns ending in `#target` are excluded from the PCA calculation and used only for colouring plots — a GoPCA convention for attaching external information to a dataset without influencing the analysis. See the [GoPCA Data Format Guide](data-format.md) for details.
 
 **Why it is special:** This dataset has no noise problem, no scale problem, and no outlier problem — and yet standard PCA completely fails to reveal its structure. The reason is geometric: the data lives on a curved surface, and PCA can only find flat (linear) projections. When you project a Swiss roll onto a flat plane, the two ends of the roll overlap. The underlying two-dimensional structure — which is completely real — is invisible to standard PCA. This is the clearest possible demonstration of PCA's fundamental limitation.
 

--- a/testdata/corn/corn_exploration.md
+++ b/testdata/corn/corn_exploration.md
@@ -31,7 +31,7 @@ This has two immediate consequences that make Corn unlike anything you have seen
 
 **Adjacent variables are not independent.** In Iris, sepal length and petal length are correlated but measure genuinely different things. In a NIR spectrum, the absorbance at 1500 nm and at 1502 nm are almost identical — they are sampling the same physical absorption feature separated by one instrument step. This extreme collinearity means PCA can compress 700 variables into 2–3 components and lose almost nothing, because most of the 700 variables are carrying nearly the same information.
 
-> Corn NIR is the natural next step: more variables than you can count, all correlated, and no predefined classes. PCA is not one option among several — it is the standard first tool for this kind of data.
+> Corn NIR is the natural next step: more variables than you can count, all highly correlated. PCA is not one option among several — it is the standard first tool for this kind of data.
 
 ---
 
@@ -82,10 +82,10 @@ Instead, **experiment, observe, and reflect**.
 
 ## Step 1: Run PCA with default settings — and diagnose the result
 
-Load the Corn dataset into GoPCA. Do not set a target column yet. Leave all settings at their defaults:
+Load the Corn dataset into GoPCA. Leave all settings at their defaults:
 
 * **Row Preprocessing** → None
-* **Column Preprocessing** → Mean Center
+* **Column Preprocessing** → Mean Center Only
 * **PCA Method** → SVD
 
 Click **Go PCA**.
@@ -115,7 +115,7 @@ NIR spectra are affected by **multiplicative scatter**: differences in particle 
 
 ## Step 2: Apply SNV and compare
 
-NIR spectra need **row-wise scatter correction** before column-wise preprocessing. The standard method is **SNV (Standard Normal Variate)**.
+NIR spectra need **row-wise scatter correction** before column-wise preprocessing. The standard method in GoPCA is **SNV (Standard Normal Variate)**.
 
 SNV operates on each spectrum individually:
 
@@ -161,16 +161,16 @@ Open the **Loadings Plot** (with SNV applied).
 
 ## Step 4: Connect PCA to chemistry
 
-Now set a target column to colour the samples by composition.
+Now lets try to colour the samples by composition.
 
-In GoPCA, set the **target column** to `Moisture#target`. Look at the **Scores Plot**.
+Look at the **Scores Plot**. Set the **Color by** to `Moisture#target`.
 
 #### Questions:
 
 * Do you see a gradient in the scores — samples ordered by moisture content?
 * Does the gradient run along PC1, PC2, or diagonally?
 
-👉 Try switching the target column to `Starch#target`, then `Protein#target`, then `Oil#target`:
+👉 Try switching the **Color by** to `Starch#target`, then `Protein#target`, then `Oil#target`:
 
 * Which compositional property is most strongly captured by PC1?
 * Are all four properties captured equally well, or do some require higher components?
@@ -181,7 +181,7 @@ In GoPCA, set the **target column** to `Moisture#target`. Look at the **Scores P
 
 ## Step 5: Look for outliers
 
-Return to the Scores Plot with no target column selected.
+Return to the Scores Plot with no **Color by** selected.
 
 #### Questions:
 
@@ -249,7 +249,7 @@ Think about this:
 * How is PCA on spectral data different from PCA on independent measurements like Iris or Wine?
 * Why do the loadings appear as smooth curves rather than isolated vectors?
 * Why is SNV more appropriate here than column-wise standard scaling?
-* The original purpose of this dataset was to build a calibration model predicting composition from spectra. Could you use the PCA scores as input to such a model? What might be the advantage of using scores instead of raw spectra?
+* The original purpose of this dataset was to build a calibration model predicting composition from spectra. Could you use the PCA scores as input to such a model? What might be the advantage of using scores instead of raw spectra? Hint: search for **principal component regression** on the internet.
 
 ---
 

--- a/testdata/corn/corn_exploration.md
+++ b/testdata/corn/corn_exploration.md
@@ -11,6 +11,8 @@ This dataset consists of **80 corn samples**, each measured by an NIR instrument
 * `Protein#target` — protein content (%)
 * `Starch#target` — starch content (%)
 
+These four columns are excluded from the PCA automatically and are available for colouring the scores plot — you will use them in Step 4.
+
 The original purpose of such a dataset is **calibration**: build a model that predicts chemical composition from the spectrum alone, so future samples can be analysed in seconds rather than hours. This is a supervised problem — it uses the known laboratory values to train a model.
 
 Here, we will approach the same data with **Principal Component Analysis (PCA)** — an *unsupervised* method that ignores the laboratory values entirely. The question becomes: what structure does PCA find in the spectra on its own? And does that structure relate to chemistry?

--- a/testdata/iris/iris_exploration.md
+++ b/testdata/iris/iris_exploration.md
@@ -184,7 +184,7 @@ in the same plot.
 
 ## Step 5: Use color and grouping
 
-In GoPCA, set the **target column** to the species column to color samples by species. Then enable **Confidence Ellipses**.
+In GoPCA, set the **Color By** menu to the species column to color samples by species. Then enable **Confidence Ellipses**.
 
 #### Questions:
 

--- a/testdata/swiss_roll/swiss_roll_exploration.md
+++ b/testdata/swiss_roll/swiss_roll_exploration.md
@@ -7,7 +7,7 @@ The Swiss Roll is a **synthetic benchmark** — a dataset constructed mathematic
 The dataset consists of **1,000 samples** in three dimensions:
 
 * `X`, `Y`, `Z` — the 3D coordinates of each point
-* `color #target` — a continuous numeric value encoding position along the roll (hidden from the analysis, used only for colouring plots)
+* `color #target` — position along the roll, used only for colouring plots (not included in the analysis)
 
 The data is generated from two underlying parameters:
 
@@ -20,7 +20,7 @@ The 3D coordinates follow from:
 * y = h
 * z = t · sin(t)
 
-The `color #target` column stores the raw value of *t* for each sample. In GoPCA, any column whose name ends with `#target` is excluded from the PCA analysis and hidden from the data table — it is available only as a colour variable in the scores plot. When you load the Swiss Roll dataset by clicking the button, this colour mapping is applied automatically.
+The `color #target` column stores the raw value of *t* and is used only for colouring the scores plot — it plays no part in the analysis. When you load the dataset, this colouring is applied automatically.
 
 The true structure is a **flat 2D sheet wound into a helix in 3D space**. This type of structure is called a **manifold** — a surface that is locally flat but globally curved. A piece of paper lying on a table is flat; roll it up and it becomes a manifold embedded in 3D. The Swiss Roll is exactly this: a flat 2D sheet with coordinates *t* and *h*, curled into a spiral shape.
 
@@ -83,9 +83,9 @@ Study both panels before running any analysis.
 
 ### Reflect:
 
-* In the 3D view: trace the colour gradient from dark purple inward to yellow at the outer edge. Can you follow it continuously along the surface of the roll?
-* In the top-down view: the inner edge (dark purple) and outer edge (yellow) are physically close in the X–Z plane — they are separated by only the width of one gap between spiral turns. How far apart are they if you instead trace along the surface of the sheet?
-* If you could cut the roll along one edge and flatten it completely, what shape would you get?
+* In the 3D view: trace the colour gradient from dark purple inward to yellow at the outer edge. Can you follow it continuously along the surface of the roll? *(Hint: run your finger along the surface — never lift it, never cut through the interior.)*
+* In the top-down view: the inner edge (dark purple) and outer edge (yellow) are physically close in the X–Z plane — they are separated by only the width of one gap between spiral turns. How far apart are they if you instead trace along the surface of the sheet? *(Hint: think of a roll of paper. The first centimetre of paper and the last centimetre are neighbours when the roll is wound — but how far apart are they when you unroll it?)*
+* If you could cut the roll along one edge and flatten it completely, what shape would you get? *(Hint: what is the shape of a single sheet of A4 paper before you roll it?)*
 
 👉 A perfectly flattened Swiss Roll would be a rectangle: one axis is *t* (position along the roll, from low to high), the other is *h* (height *Y*). The top-down spiral view makes the core problem immediately visible: the inner and outer edges sit physically adjacent in 3D space, yet they are at opposite ends of the unrolled sheet. Any method that measures straight-line distances through 3D space will see them as neighbours — and fail to unroll the manifold.
 
@@ -121,7 +121,7 @@ Do not run PCA yet. Familiarise yourself with what is shown in the data panel.
 * Only three numeric columns appear — `X`, `Y`, and `Z`. Why is `color #target` not visible in the table?
 * Study the 3D figure above: what will "low colour values" (inner edge of the roll) and "high colour values" (outer edge) look like in the scores plot if PCA correctly unrolls the manifold?
 
-👉 There are 1,000 samples and 3 numeric variables — a tiny dataset by modern standards. This makes the subsequent failure of linear PCA all the more striking. The `color #target` column is hidden because it is excluded from the analysis; it serves only as a visual guide to check whether the scores plot preserves the ordering along the roll.
+👉 There are 1,000 samples and 3 numeric variables — a tiny dataset by modern standards. This makes the subsequent failure of linear PCA all the more striking.
 
 ---
 
@@ -131,9 +131,10 @@ Set:
 
 * **PCA Method** → SVD
 
+Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
+
 Leave the colour variable as `color #target` (pre-selected automatically).
 
-Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
 
 #### Questions:
 
@@ -141,7 +142,7 @@ Click **Go PCA** and open the **Scores Plot (PC1 vs PC2)**.
 * Or are low and high colour values mixed together — samples from opposite ends of the roll landing on top of each other?
 * Does the scores plot resemble the flat rectangle you imagined — or is the colour pattern jumbled?
 
-👉 You will see that the colour is **mixed and not ordered**. The scores plot forms a horseshoe or arch shape — a classic artefact of applying a linear projection to curved data. You may notice a rough gradient running *around* the arch, but look more carefully: the inner edge (dark purple, low t) is bunched in the centre of the plot rather than at one end, and high colour values (cream/yellow) appear on one side of the arch directly adjacent to medium values (blue-purple) — groups that are at opposite ends of the unrolled sheet. The colour never forms the smooth end-to-end gradient you would see in a correctly unrolled rectangle. Samples that are close in straight-line 3D distance but far apart along the manifold surface end up side by side in the projection.
+👉 The scores plot forms a **tilted oval or elliptical ring** — a classic artefact of applying a linear projection to curved data. The colour appears to flow continuously around the ring: dark navy (low *t*) sits at the left, sweeping through purple and pink along the top arc, while a separate branch of peach and salmon sweeps around the bottom arc, with cream/yellow (high *t*) appearing at both the upper-right and lower-right tips (assuming that you use the "Rocket" color palette). At first glance this looks like an ordered gradient — but it is deceptive. The colour is running in a **closed loop around the ring**, not in a straight line from one end of a rectangle to the other. A correctly unrolled Swiss Roll would place all the dark navy samples at one side and all the cream/yellow samples at the opposite side, with a clean gradient between them. Here, the high-*t* samples (cream/yellow, outer edge) have been **split into two separate clusters** — one in the upper-right and one in the lower-right of the plot — while the low-*t* samples (dark navy, inner edge) are bunched together on the left. A correctly unrolled roll would place all the cream/yellow samples together at one end of a rectangle and all the navy samples at the other. Instead, the outer edge of the roll has been torn apart and wrapped around both sides of the ring. The roll has been **squashed and folded**, not unrolled.
 
 Now open the **Scree Plot**.
 
@@ -150,9 +151,11 @@ Now open the **Scree Plot**.
 * How much variance does PC1 explain?
 * Does a high explained variance mean the structure has been correctly recovered?
 
-👉 **This is the key diagnostic moment.** Linear PCA may explain 60–80% of the total variance while completely failing to reveal the true structure. Variance is a property of the coordinate system — not of the manifold geometry. High explained variance is not the same as a good unrolling.
+👉 **This is the key diagnostic moment.** You should see PC1 explaining around 41% of the variance and PC2 around 30% — a total of roughly 71% for the first two components together. Notice also that there is **no clear elbow**: the variance does not drop sharply after PC1. This is itself a warning sign — it means PCA has not found one dominant direction that captures most of the structure. The variance is spread out because the spiral has roughly equal extent in every direction through 3D space.
 
-Compare this to Corn: there, PC1 explained 99% of variance, but the loading curve (monotone, never crossing zero) revealed it was capturing baseline tilt, not chemistry. Here, a seemingly reasonable explained variance hides an equally fundamental failure — but it is harder to detect from the scree plot alone. The scores plot, coloured by category, is the diagnostic tool.
+But the deeper point is this: even 71% combined explained variance tells you nothing about whether the *manifold* has been correctly recovered. Variance is a property of the coordinate system — not of the geometry of the roll. The scores plot, coloured by *t*, is the only diagnostic that reveals the failure.
+
+Compare this to Corn: there, PC1 explained 99% of variance, and the loading curve (monotone, never crossing zero) immediately revealed it was capturing a physical baseline artefact. Here, the scree plot looks unremarkable — no single dramatic number, no obvious red flag. The failure is entirely invisible until you look at the scores plot with a meaningful colour variable.
 
 > The Swiss Roll teaches a habit that applies to every dataset: always inspect the scores plot with a meaningful grouping variable before concluding that PCA has succeeded.
 
@@ -170,7 +173,7 @@ Points that are far apart *along the surface of the manifold* (for example, at o
 
 ### The kernel trick
 
-Kernel PCA addresses this by replacing the linear covariance structure with a **kernel function** that measures similarity between data points. The key idea, introduced by Schölkopf, Smola & Müller (1998), is to perform PCA not in the original 3D space but in a transformed feature space **F** — implicitly, without ever computing the transformation explicitly.
+Kernel PCA addresses this by replacing the linear covariance structure with a **kernel function** that measures similarity between data points. The key idea, introduced by Schölkopf, Smola & Müller (1997, 1998), is to perform PCA not in the original 3D space but in a transformed feature space **F** — implicitly, without ever computing the transformation explicitly.
 
 The **RBF (Gaussian) kernel** used here is:
 
@@ -225,7 +228,7 @@ A **perfect unrolling** of the Swiss Roll requires methods that compute *geodesi
 
 > This limitation is not a failure of Kernel PCA — it is a boundary condition. For many real datasets with milder curvature, Kernel PCA works very well. The Swiss Roll is a deliberately extreme case designed to test these limits.
 
-**Preprocessing note**: when Kernel PCA is selected, GoPCA restricts column-wise preprocessing to **Variance Scale** or **None**. Mean centering and standard scaling are unavailable because Kernel PCA performs its own centering in kernel space. For this dataset the variables are in the same units, so **None** is appropriate.
+**Preprocessing note**: when Kernel PCA is selected, GoPCA restricts column-wise preprocessing to **Variance Scale** or **None**. Mean centering and standard scaling are unavailable because Kernel PCA handles centering through modified kernel matrix algebra — subtracting the feature-space mean implicitly without ever computing it explicitly (Schölkopf et al., 1998). For this dataset the variables are in the same units, so **None** is appropriate.
 
 **Available plots**: the **Loadings Plot**, **Biplot**, **3D Biplot**, **Circle of Correlations**, and **Diagnostic Plot** are all unavailable for Kernel PCA — for the reasons explained in Step 3. The **Scores Plot**, **Scree Plot**, and **Kernel Matrix Heatmap** remain available.
 


### PR DESCRIPTION
## Summary

Follow-up edits to the five sample dataset tutorials after the initial human review pass (PR #674). Cherry-picked from `671-tutorial-human-review` onto develop to avoid squash-merge history conflicts.

- **Iris**: fix UI label — "target column" → "Color By" to match the actual GoPCA interface
- **Corn**: refine introductory paragraph, fix UI label accuracy ("Mean Center Only", "Color by"), add one-line note that `#target` columns are excluded from PCA and available for colouring (forward-references Step 4)
- **Swiss Roll**: strip redundant `#target` format explanation (kept brief, canonical reference is `data-format.md`), tighten wording, reorder instructions for clarity, improve Reflect section hints
- **intro_to_pca.md**: update dataset count to six (CSTR added), introduce `#target` convention briefly in the Swiss Roll section with link to `data-format.md`

## Test plan

- [ ] Load Iris dataset — confirm "Color By" label in Step 5 matches the UI
- [ ] Load Corn dataset — confirm UI label "Mean Center Only" and "Color by" match; confirm `#target` note is visible
- [ ] Load Swiss Roll — confirm tutorial flows clearly, Reflect hints read naturally
- [ ] Confirm `intro_to_pca.md` Swiss Roll section mentions `#target` and links to `data-format.md`

Fixes #671