### PR TITLE
fix: pre-bundle plotly.js-dist-min to prevent Wails dev-server crash

### DIFF
--- a/cmd/gopca-desktop/frontend/vite.config.ts
+++ b/cmd/gopca-desktop/frontend/vite.config.ts
@@ -12,6 +12,13 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    // Pre-bundle plotly so Vite doesn't re-optimize it mid-session when the
+    // first lazy-loaded plot component is mounted. Without this, Vite discovers
+    // plotly.js-dist-min at runtime, forces a reload, and the Wails dev-server
+    // proxy panics on the cancelled request.
+    include: ['plotly.js-dist-min'],
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

- Adds `plotly.js-dist-min` to `optimizeDeps.include` in the GoPCA Desktop `vite.config.ts`
- Vite was discovering this dependency at runtime (lazy-loaded plot components), triggering a mid-session re-optimisation and forced reload
- The Wails dev-server proxy panics on the cancelled request and exits, killing the entire dev session
- Pre-declaring it forces Vite to bundle it during the initial startup scan — no mid-session reload, dev mode stays up

## Test plan

- [ ] `make pca-dev` starts cleanly — no "optimized dependencies changed. reloading" mid-session
- [ ] Plot components (Scores, Loadings, Biplot, etc.) load correctly