### PR TITLE
refactor: rename 'Sample' column header to 'Sample_ID' (#686)

### DIFF
--- a/cmd/gopca-desktop/frontend/src/components/DataTable.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/DataTable.tsx
@@ -153,7 +153,7 @@ return;
     if (hasRowNames) {
       cols.push({
         accessorKey: 'rowName',
-        header: 'Sample',
+        header: 'Sample_ID',
         cell: info => <div className="font-medium">{String(info.getValue())}</div>
       });
     }

--- a/cmd/gopca-desktop/frontend/src/components/SelectionTable.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/SelectionTable.tsx
@@ -281,7 +281,7 @@ export const SelectionTable: React.FC<SelectionTableProps> = ({
               <table className="text-xs">
                 <thead>
                   <tr>
-                    <th className="px-2 py-1 text-left text-gray-600 dark:text-gray-400">Sample</th>
+                    <th className="px-2 py-1 text-left text-gray-600 dark:text-gray-400">Sample_ID</th>
                     {headers.slice(0, 10).map((header, i) => (
                       <th key={i} className="px-2 py-1 text-right text-gray-600 dark:text-gray-400 truncate max-w-[100px]">
                         {header}

--- a/internal/cobra/output.go
+++ b/internal/cobra/output.go
@@ -50,7 +50,7 @@ func outputTableFormat(result *types.PCAResult, data *pkgcsv.Data, preprocessedD
 		fmt.Println("──────────────────────────────────────────────────────────────")
 
 		// Print headers
-		fmt.Printf("%-15s", "Sample")
+		fmt.Printf("%-15s", "Sample_ID")
 		for i := 0; i < len(result.ComponentLabels); i++ {
 			fmt.Printf("%12s", result.ComponentLabels[i])
 		}

--- a/internal/cobra/transform.go
+++ b/internal/cobra/transform.go
@@ -235,7 +235,7 @@ func outputTransformTable(result *types.PCAResult, data *pkgcsv.Data) error {
 	fmt.Println("──────────────────────────────────────────────────────────────")
 
 	// Print headers
-	fmt.Printf("%-15s", "Sample")
+	fmt.Printf("%-15s", "Sample_ID")
 	for i := 0; i < len(result.ComponentLabels); i++ {
 		fmt.Printf("%12s", result.ComponentLabels[i])
 	}

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -237,7 +237,7 @@ func GenerateTestMatrix(rows, cols int, seed float64) [][]string {
 
 	// Header row
 	data[0] = make([]string, cols+1)
-	data[0][0] = "Sample"
+	data[0][0] = "Sample_ID"
 	for j := 1; j <= cols; j++ {
 		data[0][j] = fmt.Sprintf("Feature%d", j)
 	}

--- a/pkg/types/csv_test.go
+++ b/pkg/types/csv_test.go
@@ -31,7 +31,7 @@ func TestCSVParser_Parse(t *testing.T) {
 				HasRowNames:      true,
 				NullValues:       []string{"", "NA", "NaN"},
 			},
-			input: `Sample,Feature1,Feature2,Feature3
+			input: `Sample_ID,Feature1,Feature2,Feature3
 Row1,1.5,2.3,4.1
 Row2,3.2,NA,5.6
 Row3,2.1,3.4,NaN`,
@@ -81,7 +81,7 @@ Row3,2.1,3.4,NaN`,
 				HasRowNames:      true,
 				NullValues:       []string{"", "NA", "m"},
 			},
-			input: `Sample;Var1;Var2;Var3
+			input: `Sample_ID;Var1;Var2;Var3
 S1;1,5;2,3;4,1
 S2;3,2;m;5,6
 S3;2,1;3,4;`,


### PR DESCRIPTION
## Summary

Renames the row-identifier column header from `Sample` to `Sample_ID` in the Data Preview table and CLI output, making its purpose unambiguous.

## Changes

- `DataTable.tsx`: Data Preview column header `'Sample'` → `'Sample_ID'`
- `SelectionTable.tsx`: Data Preview column header `'Sample'` → `'Sample_ID'`
- `output.go`: CLI scores table header `"Sample"` → `"Sample_ID"`
- `transform.go`: CLI transform table header `"Sample"` → `"Sample_ID"`
- `helpers.go`: Test data matrix header updated to match
- `csv_test.go`: Test CSV headers updated to match

All tests pass (`make ci-test`).

Fixes #686