### PR TITLE
fix: suppress scale warning when Robust Scale preprocessing is selected (#684)

### DIFF
--- a/cmd/gopca-desktop/app.go
+++ b/cmd/gopca-desktop/app.go
@@ -1164,6 +1164,7 @@ type ModelMetricsRequest struct {
 	VariableLabels    []string    `json:"variableLabels"`
 	SelectedPC        int         `json:"selectedPC"`
 	StandardScale     bool        `json:"standardScale"`
+	RobustScale       bool        `json:"robustScale"`
 	OriginalData      [][]float64 `json:"originalData,omitempty"` // For scale detection
 }
 
@@ -1314,7 +1315,7 @@ func (a *App) CalculateModelMetrics(request ModelMetricsRequest) ModelMetricsRes
 				scaleRatio = maxVar / minVar
 
 				// Generate warning if scales are heterogeneous and not standardized
-				if scaleRatio > 100 && !request.StandardScale {
+				if scaleRatio > 100 && !request.StandardScale && !request.RobustScale {
 					if scaleRatio > 10000 {
 						scaleWarning = fmt.Sprintf("Variables have very different scales (%.0fx difference). Consider standardization unless this is intentional.", scaleRatio)
 					} else {

--- a/cmd/gopca-desktop/frontend/src/components/ModelOverview.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/ModelOverview.tsx
@@ -13,6 +13,7 @@ interface ModelOverviewProps {
   pcaResult: PCAResult;
   selectedPC?: number;
   standardScale?: boolean;
+  robustScale?: boolean;
   originalData?: number[][];
 }
 
@@ -26,7 +27,7 @@ interface ModelMetrics {
   scaleWarning?: string;
 }
 
-export const ModelOverview: React.FC<ModelOverviewProps> = ({ pcaResult, selectedPC = 0, standardScale = false, originalData }) => {
+export const ModelOverview: React.FC<ModelOverviewProps> = ({ pcaResult, selectedPC = 0, standardScale = false, robustScale = false, originalData }) => {
   const [metrics, setMetrics] = useState<ModelMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -59,6 +60,7 @@ export const ModelOverview: React.FC<ModelOverviewProps> = ({ pcaResult, selecte
           variableLabels: pcaResult.variable_labels || [],
           selectedPC: selectedPC,
           standardScale: standardScale,
+          robustScale: robustScale,
           originalData: originalData || []
         });
 
@@ -84,7 +86,7 @@ export const ModelOverview: React.FC<ModelOverviewProps> = ({ pcaResult, selecte
     };
 
     fetchMetrics();
-  }, [pcaResult, selectedPC, standardScale, originalData]);
+  }, [pcaResult, selectedPC, standardScale, robustScale, originalData]);
 
   // Render special Kernel PCA overview
   if (pcaResult?.method === 'kernel') {

--- a/cmd/gopca-desktop/frontend/src/components/sections/ResultsSection.tsx
+++ b/cmd/gopca-desktop/frontend/src/components/sections/ResultsSection.tsx
@@ -170,6 +170,7 @@ export function ResultsSection({ guiConfig }: ResultsSectionProps) {
                             pcaResult={pcaResponse.result}
                             selectedPC={selectedXComponent}
                             standardScale={config.standardScale}
+                            robustScale={config.robustScale}
                             originalData={fileData?.data}
                         />
                     </div>


### PR DESCRIPTION
## Summary

- Added `RobustScale bool` field to `ModelMetricsRequest` struct in `app.go`
- Fixed warning condition to also suppress when Robust Scale is active: `!request.StandardScale && !request.RobustScale`
- Added `robustScale` prop to `ModelOverview` component and wired it through from `ResultsSection`

## Root Cause

The `ModelMetricsRequest` struct was missing the `RobustScale` field, so the backend's scale heterogeneity check only exempted Standard Scale. The frontend never passed `robustScale` down through `ResultsSection → ModelOverview`, so even after adding the field, the value would always have been `false`.

## Test plan

- [ ] Load a dataset with variables on very different scales (e.g. CSTR dataset)
- [ ] Select **Robust Scale** as preprocessing method and run PCA
- [ ] Confirm the "Variables have very different scales" warning does NOT appear
- [ ] Select **No scaling** with the same dataset and confirm the warning DOES appear
- [ ] Select **Standard Scale** and confirm the warning also does not appear

Fixes #684