### PR TITLE
fix: restore Download as PNG button on Variable Importance plot (#685)

### DIFF
--- a/packages/ui-components/src/charts/pca/PlotlyTemporalVariableImportance.tsx
+++ b/packages/ui-components/src/charts/pca/PlotlyTemporalVariableImportance.tsx
@@ -8,7 +8,6 @@
 
 import React, { useMemo } from 'react';
 import { Data, Layout } from 'plotly.js';
-import { getExportMenuItems } from '../utils/plotlyExport';
 import { PlotlyWithFullscreen } from '../utils/plotlyFullscreen';
 import { getWatermarkDataUrlSync } from '../assets/watermark';
 import { PlotlyVisualizationConfig } from '../core/PlotlyVisualization';
@@ -235,8 +234,6 @@ export class PlotlyTemporalVariableImportance {
       config: {
         displayModeBar: true,
         displaylogo: false,
-        modeBarButtonsToRemove: ['toImage'],
-        modeBarButtonsToAdd: getExportMenuItems(),
         responsive: true
       }
     };


### PR DESCRIPTION
## Summary

- Removed `'toImage'` from `modeBarButtonsToRemove` in `PlotlyTemporalVariableImportance.tsx` — this was incorrectly suppressing Plotly's built-in camera/download button
- Removed the no-op `modeBarButtonsToAdd: getExportMenuItems()` call (returns `[]`, contributing nothing)
- Removed the now-unused `getExportMenuItems` import

The Variable Importance plot's modebar now shows the PNG download button, matching all other visualizations in GoPCA Desktop.

Fixes #685

## Test plan

- [ ] Load any dataset, run Temporal PCA, switch to Variable Importance visualization — confirm the camera icon appears in the modebar
- [ ] Click the camera icon — confirm a PNG is downloaded
- [ ] Verify no regression on other plots (Scores, Loadings, Biplot, etc.)
- [ ] `make ci-test` passes