### PR TITLE
feat(gocsv): add internal HTTP fetch infrastructure (Fixes #699)

### DIFF
--- a/cmd/gocsv/app.go
+++ b/cmd/gocsv/app.go
@@ -162,6 +162,18 @@ func (a *App) LoadCSV(filePath string) (*FileData, error) {
 		filePath = selection
 	}
 
+	// If filePath is a remote URL, fetch it to a temp file first.
+	// The temp file is named with the detected extension so the switch below routes correctly.
+	if strings.HasPrefix(filePath, "https://") || strings.HasPrefix(filePath, "http://") {
+		a.logInfo(fmt.Sprintf("Fetching remote file: %s", filePath))
+		tmpPath, err := fetchRemoteFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch remote file: %w", err)
+		}
+		defer os.Remove(tmpPath)
+		filePath = tmpPath
+	}
+
 	// Check file extension
 	ext := filepath.Ext(filePath)
 	var fileData *FileData

--- a/cmd/gocsv/fetch.go
+++ b/cmd/gocsv/fetch.go
@@ -1,0 +1,111 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite.
+//
+// GoPCA Suite is source-available software with free binary redistribution.
+// Official compiled binary releases may be used and redistributed free of charge
+// under the GoPCA Suite Source-Available Freeware License.
+//
+// The source code is provided for viewing, review, education, security analysis,
+// research, interoperability analysis, and evaluation only.
+//
+// Modification, redistribution, publication, sublicensing, reuse, incorporation
+// into another project, or creation of derivative works based on the source code
+// is not permitted without prior written permission from the copyright holder.
+//
+// Usage Restriction: GoPCA Suite may not be used, directly or indirectly, for
+// military, warfare, weapons, intelligence, surveillance, targeting, or
+// law-enforcement surveillance applications.
+//
+// See LICENSE for the full license terms.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+)
+
+const (
+	fetchTimeout  = 60 * time.Second
+	fetchMaxBytes = 500 * 1024 * 1024 // 500 MB — matches security.MaxFileSize
+)
+
+// contentTypeToExt maps MIME types to file extensions for format detection.
+var contentTypeToExt = map[string]string{
+	"application/vnd.apache.parquet": ".parquet",
+	"text/csv":                       ".csv",
+	"text/tab-separated-values":      ".tsv",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+	"application/vnd.ms-excel": ".xls",
+}
+
+// fetchRemoteFile downloads the file at url to a secure temporary file and
+// returns its path. The caller MUST remove the temp file when done.
+//
+// Extension is determined by (in order): URL path suffix, Content-Type header.
+// Returns an error if the extension cannot be determined or the download fails.
+func fetchRemoteFile(url string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("server returned HTTP %d", resp.StatusCode)
+	}
+
+	// Detect extension from URL path first, Content-Type as fallback.
+	ext := strings.ToLower(path.Ext(req.URL.Path))
+	if ext == "" {
+		ct := resp.Header.Get("Content-Type")
+		if i := strings.Index(ct, ";"); i != -1 {
+			ct = strings.TrimSpace(ct[:i])
+		}
+		ext = contentTypeToExt[ct]
+	}
+	if ext == "" {
+		return "", fmt.Errorf("could not determine file type from URL or Content-Type header")
+	}
+
+	// Create a temp file with the detected extension so the caller can route it
+	// through the existing extension switch. os.CreateTemp uses O_EXCL and
+	// creates the file with mode 0600, so no explicit chmod is needed.
+	tmpFile, err := os.CreateTemp("", "gocsv-fetch-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	// Stream body to temp file with size limit.
+	written, err := io.Copy(tmpFile, io.LimitReader(resp.Body, fetchMaxBytes+1))
+	tmpFile.Close()
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	if written > fetchMaxBytes {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("remote file exceeds %d MB limit", fetchMaxBytes/(1024*1024))
+	}
+
+	return tmpPath, nil
+}

--- a/cmd/gocsv/fetch.go
+++ b/cmd/gocsv/fetch.go
@@ -73,14 +73,17 @@ func fetchRemoteFile(url string) (string, error) {
 		return "", fmt.Errorf("server returned HTTP %d", resp.StatusCode)
 	}
 
-	// Detect extension from URL path first, Content-Type as fallback.
-	ext := strings.ToLower(path.Ext(req.URL.Path))
+	// Detect extension from the final (post-redirect) URL path first, then
+	// Content-Type as fallback. resp.Request.URL is the URL that actually served
+	// the body, which differs from req.URL when the server issued a redirect.
+	ext := strings.ToLower(path.Ext(resp.Request.URL.Path))
 	if ext == "" {
 		ct := resp.Header.Get("Content-Type")
 		if i := strings.Index(ct, ";"); i != -1 {
 			ct = strings.TrimSpace(ct[:i])
 		}
-		ext = contentTypeToExt[ct]
+		// MIME types are case-insensitive (RFC 2045); normalise before lookup.
+		ext = contentTypeToExt[strings.ToLower(ct)]
 	}
 	if ext == "" {
 		return "", fmt.Errorf("could not determine file type from URL or Content-Type header")

--- a/cmd/gocsv/fetch_test.go
+++ b/cmd/gocsv/fetch_test.go
@@ -1,0 +1,109 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite.
+//
+// GoPCA Suite is source-available software with free binary redistribution.
+// Official compiled binary releases may be used and redistributed free of charge
+// under the GoPCA Suite Source-Available Freeware License.
+//
+// The source code is provided for viewing, review, education, security analysis,
+// research, interoperability analysis, and evaluation only.
+//
+// Modification, redistribution, publication, sublicensing, reuse, incorporation
+// into another project, or creation of derivative works based on the source code
+// is not permitted without prior written permission from the copyright holder.
+//
+// Usage Restriction: GoPCA Suite may not be used, directly or indirectly, for
+// military, warfare, weapons, intelligence, surveillance, targeting, or
+// law-enforcement surveillance applications.
+//
+// See LICENSE for the full license terms.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parquetTestServer returns a test server that serves testdata/energy_mix/.
+func parquetTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.FileServer(http.Dir("../../testdata/energy_mix")))
+}
+
+func TestFetchRemoteFile_Parquet(t *testing.T) {
+	ts := parquetTestServer(t)
+	defer ts.Close()
+
+	tmpPath, err := fetchRemoteFile(ts.URL + "/energy_mix.parquet")
+	require.NoError(t, err)
+	defer os.Remove(tmpPath)
+
+	assert.True(t, strings.HasSuffix(tmpPath, ".parquet"), "temp file should have .parquet extension")
+
+	info, err := os.Stat(tmpPath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0), "temp file should not be empty")
+}
+
+func TestFetchRemoteFile_ContentTypeFallback(t *testing.T) {
+	// Serve a CSV with explicit Content-Type and no recognisable URL extension
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("a,b,c\n1,2,3\n4,5,6\n"))
+	}))
+	defer ts.Close()
+
+	tmpPath, err := fetchRemoteFile(ts.URL + "/data")
+	require.NoError(t, err)
+	defer os.Remove(tmpPath)
+
+	assert.True(t, strings.HasSuffix(tmpPath, ".csv"), "should fall back to .csv from Content-Type")
+}
+
+func TestFetchRemoteFile_404(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	_, err := fetchRemoteFile(ts.URL + "/nonexistent.parquet")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestFetchRemoteFile_UnknownType(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte("binary data"))
+	}))
+	defer ts.Close()
+
+	// URL has no extension, Content-Type not in our map
+	_, err := fetchRemoteFile(ts.URL + "/file")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not determine file type")
+}
+
+func TestLoadCSVFromURL(t *testing.T) {
+	ts := parquetTestServer(t)
+	defer ts.Close()
+
+	app := NewApp()
+	fd, err := app.LoadCSV(ts.URL + "/energy_mix.parquet")
+	require.NoError(t, err)
+	require.NotNil(t, fd)
+
+	assert.Equal(t, 7314, fd.Rows)
+	assert.Equal(t, 106, fd.Columns)
+	assert.Equal(t, "country#target", fd.Headers[0])
+	assert.Equal(t, 7314, len(fd.RowNames))
+	assert.Equal(t, "1", fd.RowNames[0])
+}

--- a/cmd/gocsv/fetch_test.go
+++ b/cmd/gocsv/fetch_test.go
@@ -92,6 +92,40 @@ func TestFetchRemoteFile_UnknownType(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not determine file type")
 }
 
+func TestFetchRemoteFile_Redirect(t *testing.T) {
+	// Serve a CSV at /final.csv; /redirect redirects there.
+	// Extension detection must use the final URL, not the original.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/final.csv", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("a,b\n1,2\n"))
+	}))
+	defer ts.Close()
+
+	tmpPath, err := fetchRemoteFile(ts.URL + "/redirect")
+	require.NoError(t, err)
+	defer os.Remove(tmpPath)
+
+	assert.True(t, strings.HasSuffix(tmpPath, ".csv"), "should detect .csv from redirected URL")
+}
+
+func TestFetchRemoteFile_CaseInsensitiveMIME(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "Text/CSV; charset=utf-8")
+		_, _ = w.Write([]byte("x,y\n1,2\n"))
+	}))
+	defer ts.Close()
+
+	tmpPath, err := fetchRemoteFile(ts.URL + "/data")
+	require.NoError(t, err)
+	defer os.Remove(tmpPath)
+
+	assert.True(t, strings.HasSuffix(tmpPath, ".csv"), "mixed-case MIME type should map to .csv")
+}
+
 func TestLoadCSVFromURL(t *testing.T) {
 	ts := parquetTestServer(t)
 	defer ts.Close()


### PR DESCRIPTION
## Summary

Adds `fetchRemoteFile` — a package-private function that downloads a remote URL to a temporary file and hands the path to the existing `LoadCSV` extension switch. No UI is exposed; this is pure internal plumbing for future integrations (first consumer: OWID catalog browser, issue #700).

## How it works

1. `LoadCSV` detects `http://` / `https://` prefixes before the extension switch
2. Calls `fetchRemoteFile(url)` which:
   - Opens a 60-second context-cancelled HTTP GET
   - Detects file type from URL path extension, falling back to `Content-Type` header
   - Streams the body into a `os.CreateTemp` file named `gocsv-fetch-*<ext>` (preserving the extension so the switch routes correctly)
   - Caps download at 500 MB via `io.LimitReader`
3. `defer os.Remove(tmpPath)` in `LoadCSV` cleans up after parsing
4. The existing switch handles `.parquet`, `.csv`, `.xlsx`, etc. — nothing else changes

## Tests

All tests use `net/http/httptest` — no live network access required:

| Test | Verifies |
|------|----------|
| `TestFetchRemoteFile_Parquet` | Temp file created with `.parquet` suffix, non-empty |
| `TestFetchRemoteFile_ContentTypeFallback` | `text/csv` Content-Type → `.csv` extension |
| `TestFetchRemoteFile_404` | HTTP 404 → error |
| `TestFetchRemoteFile_UnknownType` | Unknown Content-Type + no extension → error |
| `TestLoadCSVFromURL` | End-to-end: URL → 7314 rows, 106 cols, `country#target` |

## Security note

- `os.CreateTemp` creates files with mode 0600 (no world-readable temp files)
- Download capped at 500 MB
- 60-second timeout prevents hanging on slow endpoints
- No `file://` or other scheme bypass (Go's `net/http` only follows http/https redirects)