### PR TITLE
feat(gocsv): OWID catalog browser (Fixes #700)

### DIFF
--- a/cmd/gocsv/frontend/src/App.tsx
+++ b/cmd/gocsv/frontend/src/App.tsx
@@ -23,7 +23,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import './App.css';
-import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, AboutDialog } from './components';
+import { CSVGrid, ValidationResults, MissingValueSummary, MissingValueDialog, DataQualityDashboard, UndoRedoControls, ImportWizard, DataTransformDialog, DocumentationViewer, AboutDialog, OwidCatalogDialog } from './components';
 import { ConfirmDialog, ErrorBoundary, ErrorAlert, ThemeProvider, ThemeToggle, HelpProvider, HelpDisplay, HelpWrapper, useHelp } from '@gopca/ui-components';
 import logo from './assets/images/GoCSV-logo-1024-transp.png';
 import helpContent from './help/help-content.json';
@@ -54,6 +54,7 @@ function AppContent() {
     const [showDocumentation, setShowDocumentation] = useState(false);
     const [showAboutDialog, setShowAboutDialog] = useState(false);
     const [showDownloadConfirm, setShowDownloadConfirm] = useState(false);
+    const [showOwidBrowser, setShowOwidBrowser] = useState(false);
     const [version, setVersion] = useState<string>('');
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -297,6 +298,15 @@ return;
         // Filename will be set by the event from backend
     };
 
+    // Handle OWID dataset import
+    const handleOwidDataLoaded = (data: FileData) => {
+        setFileData(data);
+        setFileLoaded(true);
+        setShowOwidBrowser(false);
+        setValidationResult(null);
+        setMissingValueStats(null);
+    };
+
     // Handle transform completion
     const handleTransformComplete = (data: FileData) => {
         setFileData(data);
@@ -426,9 +436,17 @@ return;
                                         </button>
                                     </HelpWrapper>
                                 </div>
+                                <button
+                                    onClick={() => setShowOwidBrowser(true)}
+                                    disabled={isLoading}
+                                    className="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm"
+                                >
+                                    Browse OWID Datasets
+                                </button>
                                 <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
                                     <p><span className="font-medium">Choose File:</span> Quick file picker for standard CSV/TSV files with automatic format detection</p>
                                     <p><span className="font-medium">Import with Wizard:</span> Advanced options for Excel sheets, custom delimiters, header rows, and column selection</p>
+                                    <p><span className="font-medium">Browse OWID Datasets:</span> Import directly from Our World in Data — energy, health, economics, demographics and more</p>
                                 </div>
                             </div>
 
@@ -724,6 +742,13 @@ return;
                 isOpen={showImportWizard}
                 onClose={() => setShowImportWizard(false)}
                 onImportComplete={handleImportComplete}
+            />
+
+            {/* OWID Catalog Browser */}
+            <OwidCatalogDialog
+                isOpen={showOwidBrowser}
+                onClose={() => setShowOwidBrowser(false)}
+                onDataLoaded={handleOwidDataLoaded}
             />
 
             {/* Data Transform Dialog */}

--- a/cmd/gocsv/frontend/src/components/OwidCatalogDialog.tsx
+++ b/cmd/gocsv/frontend/src/components/OwidCatalogDialog.tsx
@@ -1,0 +1,252 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite.
+//
+// GoPCA Suite is source-available software with free binary redistribution.
+// Official compiled binary releases may be used and redistributed free of charge
+// under the GoPCA Suite Source-Available Freeware License.
+//
+// The source code is provided for viewing, review, education, security analysis,
+// research, interoperability analysis, and evaluation only.
+//
+// Modification, redistribution, publication, sublicensing, reuse, incorporation
+// into another project, or creation of derivative works based on the source code
+// is not permitted without prior written permission from the copyright holder.
+//
+// Usage Restriction: GoPCA Suite may not be used, directly or indirectly, for
+// military, warfare, weapons, intelligence, surveillance, targeting, or
+// law-enforcement surveillance applications.
+//
+// See LICENSE for the full license terms.
+
+import React, { useState, useEffect, useRef } from 'react';
+import { SearchOWIDDatasets, LoadOWIDDataset } from '../../wailsjs/go/main/App';
+import { main } from '../../wailsjs/go/models';
+
+type FileData = main.FileData;
+type OWIDDataset = main.OWIDDataset;
+
+interface OwidCatalogDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onDataLoaded: (data: FileData) => void;
+}
+
+export const OwidCatalogDialog: React.FC<OwidCatalogDialogProps> = ({
+    isOpen,
+    onClose,
+    onDataLoaded,
+}) => {
+    const [query, setQuery] = useState('');
+    const [datasets, setDatasets] = useState<OWIDDataset[]>([]);
+    const [selected, setSelected] = useState<OWIDDataset | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSearching, setIsSearching] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const searchRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Load full catalog on open; re-search when query changes (debounced).
+    useEffect(() => {
+        if (!isOpen) return;
+
+        if (searchRef.current) clearTimeout(searchRef.current);
+        searchRef.current = setTimeout(async () => {
+            setIsSearching(true);
+            try {
+                const results = await SearchOWIDDatasets(query);
+                setDatasets(results ?? []);
+                // Clear selection if it's no longer in results
+                if (selected && results && !results.find((d: OWIDDataset) => d.path === selected.path)) {
+                    setSelected(null);
+                }
+            } catch (e) {
+                setError(`Search failed: ${e}`);
+            } finally {
+                setIsSearching(false);
+            }
+        }, 200);
+
+        return () => {
+            if (searchRef.current) clearTimeout(searchRef.current);
+        };
+    }, [query, isOpen]);
+
+    const handleImport = async () => {
+        if (!selected) return;
+        setIsLoading(true);
+        setError(null);
+        try {
+            const data = await LoadOWIDDataset(selected.path);
+            onDataLoaded(data);
+            onClose();
+        } catch (e) {
+            setError(`Failed to load dataset: ${e}`);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (!isLoading) {
+            setQuery('');
+            setSelected(null);
+            setError(null);
+            onClose();
+        }
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+            <div className="flex items-center justify-center min-h-screen px-4">
+                {/* Backdrop */}
+                <div
+                    className="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80 transition-opacity"
+                    onClick={handleClose}
+                />
+
+                {/* Dialog panel */}
+                <div className="relative inline-block bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-3xl p-0 overflow-hidden">
+                    {/* Header */}
+                    <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                        <div>
+                            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                                Browse OWID Datasets
+                            </h2>
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                Our World in Data — curated datasets for analysis
+                            </p>
+                        </div>
+                        <button
+                            onClick={handleClose}
+                            disabled={isLoading}
+                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-50"
+                            aria-label="Close"
+                        >
+                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+
+                    {/* Search */}
+                    <div className="px-6 py-3 border-b border-gray-200 dark:border-gray-700">
+                        <div className="relative">
+                            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <input
+                                type="text"
+                                value={query}
+                                onChange={e => setQuery(e.target.value)}
+                                placeholder="Search by topic, dataset name…"
+                                className="w-full pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                autoFocus
+                            />
+                        </div>
+                    </div>
+
+                    {/* Dataset list */}
+                    <div className="overflow-y-auto" style={{ maxHeight: '340px' }}>
+                        {isSearching ? (
+                            <div className="flex items-center justify-center py-10 text-gray-400 text-sm">
+                                Searching…
+                            </div>
+                        ) : datasets.length === 0 ? (
+                            <div className="flex items-center justify-center py-10 text-gray-400 text-sm">
+                                No datasets match your search.
+                            </div>
+                        ) : (
+                            <table className="w-full text-sm">
+                                <thead className="sticky top-0 bg-gray-50 dark:bg-gray-700/80 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                                    <tr>
+                                        <th className="px-4 py-2 text-left font-medium">Dataset</th>
+                                        <th className="px-4 py-2 text-left font-medium">Namespace</th>
+                                        <th className="px-4 py-2 text-left font-medium">Version</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                                    {datasets.map(d => (
+                                        <tr
+                                            key={d.path}
+                                            onClick={() => setSelected(d)}
+                                            className={`cursor-pointer transition-colors ${
+                                                selected?.path === d.path
+                                                    ? 'bg-blue-50 dark:bg-blue-900/30'
+                                                    : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                                            }`}
+                                        >
+                                            <td className="px-4 py-3">
+                                                <div className="font-medium text-gray-900 dark:text-gray-100">{d.title}</div>
+                                                <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">{d.description}</div>
+                                            </td>
+                                            <td className="px-4 py-3 text-gray-600 dark:text-gray-300 whitespace-nowrap">{d.namespace}</td>
+                                            <td className="px-4 py-3 text-gray-600 dark:text-gray-300 whitespace-nowrap font-mono text-xs">{d.version}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        )}
+                    </div>
+
+                    {/* Selected dataset info */}
+                    {selected && (
+                        <div className="px-6 py-3 bg-blue-50 dark:bg-blue-900/20 border-t border-blue-100 dark:border-blue-800 text-sm">
+                            <span className="font-medium text-blue-800 dark:text-blue-200">Selected:</span>{' '}
+                            <span className="text-blue-700 dark:text-blue-300">{selected.title}</span>
+                            <span className="text-blue-500 dark:text-blue-400 ml-2 text-xs">({selected.path})</span>
+                        </div>
+                    )}
+
+                    {/* Error */}
+                    {error && (
+                        <div className="px-6 py-3 bg-red-50 dark:bg-red-900/20 border-t border-red-100 dark:border-red-800 text-sm text-red-700 dark:text-red-300">
+                            {error}
+                        </div>
+                    )}
+
+                    {/* Loading bar */}
+                    {isLoading && (
+                        <div className="px-6 py-2 border-t border-gray-100 dark:border-gray-700">
+                            <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                                <svg className="animate-spin w-4 h-4 text-blue-500" fill="none" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+                                </svg>
+                                Downloading dataset…
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Footer */}
+                    <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                            Data from{' '}
+                            <span className="font-medium">Our World in Data</span>
+                            {' '}· CC BY 4.0
+                        </span>
+                        <div className="flex gap-3">
+                            <button
+                                onClick={handleClose}
+                                disabled={isLoading}
+                                className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleImport}
+                                disabled={!selected || isLoading}
+                                className="px-4 py-2 text-sm text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            >
+                                {isLoading ? 'Importing…' : 'Import Dataset'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/cmd/gocsv/frontend/src/components/index.ts
+++ b/cmd/gocsv/frontend/src/components/index.ts
@@ -37,6 +37,7 @@ export { DataTransformDialog } from './DataTransformDialog';
 export { DocumentationViewer } from './DocumentationViewer';
 export { RenameDialog } from './RenameDialog';
 export { AboutDialog } from './AboutDialog';
+export { OwidCatalogDialog } from './OwidCatalogDialog';
 export {
     TargetColumnIcon,
     CategoryColumnIcon,

--- a/cmd/gocsv/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/gocsv/frontend/wailsjs/go/main/App.d.ts
@@ -49,6 +49,8 @@ export function ImportFile(arg1:string,arg2:main.ImportOptions):Promise<main.Fil
 
 export function LoadCSV(arg1:string):Promise<main.FileData>;
 
+export function LoadOWIDDataset(arg1:string):Promise<main.FileData>;
+
 export function OpenInGoPCA(arg1:main.FileData):Promise<void>;
 
 export function PreviewFile(arg1:string,arg2:main.ImportOptions):Promise<main.FilePreview>;
@@ -58,6 +60,8 @@ export function Redo(arg1:main.FileData):Promise<main.FileData>;
 export function SaveCSV(arg1:main.FileData):Promise<void>;
 
 export function SaveExcel(arg1:main.FileData):Promise<void>;
+
+export function SearchOWIDDatasets(arg1:string):Promise<Array<main.OWIDDataset>>;
 
 export function SelectFileForImport():Promise<string>;
 

--- a/cmd/gocsv/frontend/wailsjs/go/main/App.js
+++ b/cmd/gocsv/frontend/wailsjs/go/main/App.js
@@ -94,6 +94,10 @@ export function LoadCSV(arg1) {
   return window['go']['main']['App']['LoadCSV'](arg1);
 }
 
+export function LoadOWIDDataset(arg1) {
+  return window['go']['main']['App']['LoadOWIDDataset'](arg1);
+}
+
 export function OpenInGoPCA(arg1) {
   return window['go']['main']['App']['OpenInGoPCA'](arg1);
 }
@@ -112,6 +116,10 @@ export function SaveCSV(arg1) {
 
 export function SaveExcel(arg1) {
   return window['go']['main']['App']['SaveExcel'](arg1);
+}
+
+export function SearchOWIDDatasets(arg1) {
+  return window['go']['main']['App']['SearchOWIDDatasets'](arg1);
 }
 
 export function SelectFileForImport() {

--- a/cmd/gocsv/frontend/wailsjs/go/models.ts
+++ b/cmd/gocsv/frontend/wailsjs/go/models.ts
@@ -481,6 +481,30 @@ export namespace main {
 	        this.selectedColumns = source["selectedColumns"];
 	    }
 	}
+	export class OWIDDataset {
+	    namespace: string;
+	    dataset: string;
+	    version: string;
+	    table: string;
+	    title: string;
+	    description: string;
+	    path: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new OWIDDataset(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.namespace = source["namespace"];
+	        this.dataset = source["dataset"];
+	        this.version = source["version"];
+	        this.table = source["table"];
+	        this.title = source["title"];
+	        this.description = source["description"];
+	        this.path = source["path"];
+	    }
+	}
 	export class TransformOptions {
 	    type: string;
 	    columns: string[];

--- a/cmd/gocsv/owid.go
+++ b/cmd/gocsv/owid.go
@@ -1,0 +1,92 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite.
+//
+// GoPCA Suite is source-available software with free binary redistribution.
+// Official compiled binary releases may be used and redistributed free of charge
+// under the GoPCA Suite Source-Available Freeware License.
+//
+// The source code is provided for viewing, review, education, security analysis,
+// research, interoperability analysis, and evaluation only.
+//
+// Modification, redistribution, publication, sublicensing, reuse, incorporation
+// into another project, or creation of derivative works based on the source code
+// is not permitted without prior written permission from the copyright holder.
+//
+// Usage Restriction: GoPCA Suite may not be used, directly or indirectly, for
+// military, warfare, weapons, intelligence, surveillance, targeting, or
+// law-enforcement surveillance applications.
+//
+// See LICENSE for the full license terms.
+
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+//go:embed owid_catalog.json
+var owidCatalogJSON []byte
+
+const owidBaseURL = "https://catalog.ourworldindata.org/"
+
+// OWIDDataset represents one curated entry in the OWID catalog.
+type OWIDDataset struct {
+	Namespace   string `json:"namespace"`
+	Dataset     string `json:"dataset"`
+	Version     string `json:"version"`
+	Table       string `json:"table"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+}
+
+var owidCatalog []OWIDDataset
+
+func init() {
+	if err := json.Unmarshal(owidCatalogJSON, &owidCatalog); err != nil {
+		panic("owid_catalog.json is invalid: " + err.Error())
+	}
+}
+
+// SearchOWIDDatasets returns catalog entries whose title, namespace, dataset, or
+// table contains query (case-insensitive). Returns all entries if query is empty.
+func (a *App) SearchOWIDDatasets(query string) []OWIDDataset {
+	q := strings.ToLower(query)
+	if q == "" {
+		return owidCatalog
+	}
+	var results []OWIDDataset
+	for _, d := range owidCatalog {
+		if strings.Contains(strings.ToLower(d.Title), q) ||
+			strings.Contains(strings.ToLower(d.Namespace), q) ||
+			strings.Contains(strings.ToLower(d.Dataset), q) ||
+			strings.Contains(strings.ToLower(d.Table), q) ||
+			strings.Contains(strings.ToLower(d.Description), q) {
+			results = append(results, d)
+		}
+	}
+	return results
+}
+
+// LoadOWIDDataset fetches the Parquet file for the given catalog path and loads
+// it into a FileData struct ready for display in the grid.
+// path is the catalog path field, e.g. "garden/energy/2024-06-20/energy_mix/energy_mix".
+func (a *App) LoadOWIDDataset(path string) (*FileData, error) {
+	url := owidBaseURL + path + ".parquet"
+	a.logInfo(fmt.Sprintf("Loading OWID dataset from: %s", url))
+
+	tmpPath, err := fetchRemoteFile(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch OWID dataset: %w", err)
+	}
+	defer os.Remove(tmpPath)
+
+	return a.loadParquet(tmpPath)
+}

--- a/cmd/gocsv/owid_catalog.json
+++ b/cmd/gocsv/owid_catalog.json
@@ -1,0 +1,56 @@
+[
+  {
+    "namespace": "energy",
+    "dataset": "energy_mix",
+    "version": "2024-06-20",
+    "table": "energy_mix",
+    "title": "Energy Mix by Country",
+    "description": "Primary energy consumption by source (coal, gas, oil, nuclear, renewables) for 138 countries, 1965–2023. 104 numeric variables — excellent for PCA.",
+    "path": "garden/energy/2024-06-20/energy_mix/energy_mix"
+  },
+  {
+    "namespace": "energy",
+    "dataset": "electricity_mix",
+    "version": "2024-06-20",
+    "table": "electricity_mix",
+    "title": "Electricity Mix by Country",
+    "description": "Electricity generation by source (coal, gas, nuclear, solar, wind, hydro, bioenergy) per country. 55 numeric variables.",
+    "path": "garden/energy/2024-06-20/electricity_mix/electricity_mix"
+  },
+  {
+    "namespace": "owid",
+    "dataset": "covid",
+    "version": "latest",
+    "table": "covid",
+    "title": "COVID-19 Dataset",
+    "description": "Cases, deaths, vaccinations, hospitalizations, and policy indicators by country. 62 numeric variables across 429 000 rows.",
+    "path": "garden/owid/latest/covid/covid"
+  },
+  {
+    "namespace": "ggdc",
+    "dataset": "maddison_project_database",
+    "version": "2024-04-26",
+    "table": "maddison_project_database",
+    "title": "Maddison Project Database",
+    "description": "Historical GDP per capita and population for countries worldwide, spanning centuries of economic history.",
+    "path": "garden/ggdc/2024-04-26/maddison_project_database/maddison_project_database"
+  },
+  {
+    "namespace": "demography",
+    "dataset": "population",
+    "version": "2023-03-31",
+    "table": "population",
+    "title": "World Population",
+    "description": "Population estimates by country from multiple sources, covering long historical and recent time series.",
+    "path": "garden/demography/2023-03-31/population/population"
+  },
+  {
+    "namespace": "living_planet",
+    "dataset": "lpd",
+    "version": "2020-09-10",
+    "table": "living_planet_database",
+    "title": "Living Planet Index Database",
+    "description": "Population trends for thousands of vertebrate species worldwide, with geographic coordinates and taxonomic classification.",
+    "path": "garden/living_planet/2020-09-10/lpd/living_planet_database"
+  }
+]

--- a/scripts/generate_owid_catalog.py
+++ b/scripts/generate_owid_catalog.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Verify and optionally extend the curated OWID dataset catalog at
+cmd/gocsv/owid_catalog.json.
+
+Usage (from repo root, no venv needed — only stdlib used):
+
+    python scripts/generate_owid_catalog.py [--check]
+
+With --check: validates that every path in the catalog returns HTTP 200.
+Without arguments: prints the current catalog summary.
+
+To add new datasets, probe candidate URLs manually:
+
+    curl -I "https://catalog.ourworldindata.org/<path>.parquet"
+
+Then add a new entry to cmd/gocsv/owid_catalog.json with:
+  namespace, dataset, version, table, title, description, path
+
+OWID URL pattern (from https://docs.owid.io/projects/etl/api/catalog-api/):
+  https://catalog.ourworldindata.org/{channel}/{namespace}/{version}/{dataset}/{table}.parquet
+
+Example:
+  https://catalog.ourworldindata.org/garden/energy/2024-06-20/energy_mix/energy_mix.parquet
+"""
+
+import json
+import sys
+import urllib.request
+
+CATALOG_PATH = "cmd/gocsv/owid_catalog.json"
+BASE_URL = "https://catalog.ourworldindata.org/"
+
+with open(CATALOG_PATH) as f:
+    catalog = json.load(f)
+
+print(f"Catalog: {len(catalog)} datasets\n")
+for d in catalog:
+    print(f"  [{d['namespace']}/{d['dataset']}] {d['title']}")
+
+if "--check" in sys.argv:
+    print("\nVerifying URLs...")
+    ok = 0
+    fail = 0
+    for d in catalog:
+        url = BASE_URL + d["path"] + ".parquet"
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=30) as r:
+                size = r.headers.get("Content-Length", "?")
+                print(f"  200  {size:>12}B  {d['path']}")
+                ok += 1
+        except Exception as e:
+            print(f"  ERR  {'?':>12}   {d['path']} — {e}")
+            fail += 1
+    print(f"\n{ok} OK, {fail} failed")


### PR DESCRIPTION
## Summary

Adds a **Browse OWID Datasets** button to the Step 1 Load Data panel. Users click it, search/select a dataset, click Import — GoCSV downloads and loads it directly into the grid.

## How it works

**Backend** (`owid.go`):
- `owid_catalog.json` is embedded at compile time via `//go:embed` — no network call needed to show the catalog
- `SearchOWIDDatasets(query)` searches in memory across title, namespace, dataset, table, and description
- `LoadOWIDDataset(path)` constructs `https://catalog.ourworldindata.org/{path}.parquet`, fetches via `fetchRemoteFile` (issue #699 infrastructure), loads with the existing `loadParquet` pipeline

**Catalog** (`owid_catalog.json`):
6 curated, verified datasets with human-readable titles and descriptions:

| Dataset | Variables | Size |
|---------|-----------|------|
| Energy Mix by Country | 104 numeric | 2.2 MB |
| Electricity Mix by Country | 55 numeric | 1.3 MB |
| COVID-19 Dataset | 62 numeric | 12 MB |
| Maddison Project Database | 4 numeric | 356 KB |
| World Population | 3 numeric | 1 MB |
| Living Planet Index Database | 4 numeric | 5.6 MB |

`scripts/generate_owid_catalog.py` is a developer tool for verifying and extending the catalog.

**Frontend** (`OwidCatalogDialog.tsx`):
- Search box with 200 ms debounce → calls `SearchOWIDDatasets`
- Scrollable table with namespace, title, version columns and row selection
- Inline spinner during download, inline error display
- Import button disabled until a row is selected

## Notes

- The OWID `catalog.feather` index is outdated and does not contain modern datasets, so we use a manually curated list of verified URLs instead. This is more user-friendly (6 high-quality PCA-ready datasets vs. hundreds of mixed-quality entries) and more reliable.
- The catalog can be extended by adding entries to `owid_catalog.json` and running `python scripts/generate_owid_catalog.py --check` to verify URLs.

## Test plan

- [ ] `go test ./...` passes in `cmd/gocsv/`
- [ ] `npm run build` succeeds in `cmd/gocsv/frontend/`
- [ ] `make lint` clean
- [ ] Manual: `make csv-dev` → click Browse OWID Datasets → search "energy" → select Energy Mix → Import → grid loads 7314 rows × 106 cols with `country#target`
- [ ] Manual: search "covid" → select COVID-19 → Import → grid loads with many numeric columns
- [ ] Manual: close dialog without selecting → no crash