### PR TITLE
feat: Table of Contents for DocumentationViewer (Fixes #436)

### DIFF
--- a/packages/ui-components/src/components/DocumentationViewer.tsx
+++ b/packages/ui-components/src/components/DocumentationViewer.tsx
@@ -21,8 +21,10 @@
 //
 // See LICENSE for the full license terms.
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { MarkdownRenderer } from './MarkdownRenderer';
+import { TableOfContents } from './TableOfContents';
+import { TocEntry, extractHeadings } from '../utils/tocUtils';
 
 export interface DocumentationViewerProps {
   isOpen: boolean;
@@ -32,9 +34,11 @@ export interface DocumentationViewerProps {
 }
 
 /**
- * Shared documentation viewer component for displaying markdown files in a modal.
- * Handles loading, escape key, scroll prevention, and consistent styling.
- * Used by both GoPCA Desktop and GoCSV Desktop applications.
+ * Full-screen documentation viewer with a sticky sidebar table of contents.
+ * The TOC is auto-generated from H2 and H3 headings; the active section is
+ * highlighted via IntersectionObserver as the user scrolls.
+ *
+ * Used by both GoPCA Desktop and GoCSV Desktop.
  */
 export const DocumentationViewer: React.FC<DocumentationViewerProps> = ({
   isOpen,
@@ -44,62 +48,96 @@ export const DocumentationViewer: React.FC<DocumentationViewerProps> = ({
 }) => {
   const [markdownContent, setMarkdownContent] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
+  const [tocEntries, setTocEntries] = useState<TocEntry[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
+  // Load markdown when the viewer opens or the path changes.
   useEffect(() => {
     if (isOpen) {
-      // Reset state to show loading and clear stale content
       setIsLoading(true);
       setMarkdownContent('');
+      setTocEntries([]);
+      setActiveId(null);
 
-      // Load the markdown file
       fetch(markdownPath)
         .then(response => {
-          if (!response.ok) {
-            throw new Error(`Failed to load documentation: ${response.statusText}`);
-          }
+          if (!response.ok) throw new Error(`Failed to load: ${response.statusText}`);
           return response.text();
         })
         .then(text => {
           setMarkdownContent(text);
+          setTocEntries(extractHeadings(text));
           setIsLoading(false);
         })
         .catch(error => {
           console.error('Error loading documentation:', error);
-          setMarkdownContent(`# Error\n\nFailed to load documentation from ${markdownPath}.\n\nPlease try again later.`);
+          setMarkdownContent(`# Error\n\nFailed to load documentation from ${markdownPath}.`);
           setIsLoading(false);
         });
     }
   }, [isOpen, markdownPath]);
 
-  // Handle escape key to close
+  // Escape key closes the viewer; body scroll is suppressed while open.
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
+      if (e.key === 'Escape' && isOpen) onClose();
     };
-
     if (isOpen) {
       document.addEventListener('keydown', handleEscape);
-      // Prevent body scroll when modal is open
       document.body.style.overflow = 'hidden';
     }
-
     return () => {
       document.removeEventListener('keydown', handleEscape);
       document.body.style.overflow = 'unset';
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) {
-    return null;
-  }
+  // IntersectionObserver: highlight the TOC entry for the heading nearest
+  // the top of the scroll container.
+  useEffect(() => {
+    if (!scrollRef.current || tocEntries.length === 0 || isLoading) return;
+
+    const root = scrollRef.current;
+    const elements = tocEntries
+      .map(e => root.querySelector(`#${CSS.escape(e.id)}`) as HTMLElement | null)
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (elements.length === 0) return;
+
+    // Set the first heading as active initially.
+    setActiveId(elements[0].id);
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries.filter(e => e.isIntersecting);
+        if (visible.length > 0) setActiveId(visible[0].target.id);
+      },
+      {
+        root,
+        // Fire when a heading enters the upper quarter of the scroll area.
+        rootMargin: '-10% 0px -75% 0px',
+        threshold: 0,
+      }
+    );
+
+    elements.forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, [tocEntries, isLoading]);
+
+  const handleTocClick = (id: string) => {
+    const el = scrollRef.current?.querySelector(`#${CSS.escape(id)}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setActiveId(id);
+  };
+
+  if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-white dark:bg-gray-900">
-      {/* Header with exit button */}
-      <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+    <div className="fixed inset-0 z-50 bg-white dark:bg-gray-900 flex flex-col">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <div className="px-6 py-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
             {title}
           </h2>
@@ -118,16 +156,26 @@ export const DocumentationViewer: React.FC<DocumentationViewerProps> = ({
         </div>
       </div>
 
-      {/* Content area */}
-      <div className="overflow-y-auto" style={{ height: 'calc(100vh - 73px)' }}>
-        <div className="max-w-4xl mx-auto px-6 py-8 text-left">
-          {isLoading ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="text-gray-500 dark:text-gray-400">Loading documentation...</div>
-            </div>
-          ) : (
-            <MarkdownRenderer content={markdownContent} />
-          )}
+      {/* Body: TOC sidebar + scrollable content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sticky TOC sidebar */}
+        <TableOfContents
+          entries={tocEntries}
+          activeId={activeId}
+          onEntryClick={handleTocClick}
+        />
+
+        {/* Scrollable content column */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto">
+          <div className="max-w-4xl mx-auto px-6 py-8 text-left">
+            {isLoading ? (
+              <div className="flex items-center justify-center h-64">
+                <div className="text-gray-500 dark:text-gray-400">Loading documentation…</div>
+              </div>
+            ) : (
+              <MarkdownRenderer content={markdownContent} />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/ui-components/src/components/DocumentationViewer.tsx
+++ b/packages/ui-components/src/components/DocumentationViewer.tsx
@@ -111,7 +111,13 @@ export const DocumentationViewer: React.FC<DocumentationViewerProps> = ({
     const observer = new IntersectionObserver(
       entries => {
         const visible = entries.filter(e => e.isIntersecting);
-        if (visible.length > 0) setActiveId(visible[0].target.id);
+        if (visible.length > 0) {
+          // When multiple headings are simultaneously within the intersection
+          // band, pick the one closest to the top of the scroll container so
+          // the active TOC item is always stable and predictable.
+          visible.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+          setActiveId(visible[0].target.id);
+        }
       },
       {
         root,

--- a/packages/ui-components/src/components/MarkdownRenderer.tsx
+++ b/packages/ui-components/src/components/MarkdownRenderer.tsx
@@ -51,6 +51,11 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   className = '',
   onExternalLink,
 }) => {
+  // Mutable counter map captured by the heading component overrides below.
+  // Declared inside the render function so it resets to empty on every render,
+  // ensuring duplicate headings are numbered consistently from scratch each time.
+  const headingCounts = new Map<string, number>();
+
   return (
     <div className={`prose prose-lg dark:prose-invert max-w-none text-left
       prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-headings:text-left
@@ -169,15 +174,25 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               {children}
             </td>
           ),
-          // Heading overrides: generate stable IDs from text for TOC anchor links.
-          // The same slug function is used in extractHeadings so IDs always match.
+          // Heading overrides: generate stable, unique IDs for TOC anchor links.
+          // Duplicate heading texts are disambiguated with a numeric suffix that
+          // mirrors the logic in extractHeadings — "the-core-idea", then
+          // "the-core-idea-2" — so TOC links always land on the right element.
+          // id is placed after ...props spread so it cannot be overwritten by an
+          // id present in the AST node's props.
           h2: ({ children, ...props }) => {
-            const id = toSlug(extractTextContent(children));
-            return <h2 id={id} {...props}>{children}</h2>;
+            const base = toSlug(extractTextContent(children));
+            const count = headingCounts.get(base) ?? 0;
+            headingCounts.set(base, count + 1);
+            const id = count === 0 ? base : `${base}-${count + 1}`;
+            return <h2 {...props} id={id}>{children}</h2>;
           },
           h3: ({ children, ...props }) => {
-            const id = toSlug(extractTextContent(children));
-            return <h3 id={id} {...props}>{children}</h3>;
+            const base = toSlug(extractTextContent(children));
+            const count = headingCounts.get(base) ?? 0;
+            headingCounts.set(base, count + 1);
+            const id = count === 0 ? base : `${base}-${count + 1}`;
+            return <h3 {...props} id={id}>{children}</h3>;
           },
           // Custom image component to handle relative paths
           img: ({ src, alt, ...props }) => {

--- a/packages/ui-components/src/components/MarkdownRenderer.tsx
+++ b/packages/ui-components/src/components/MarkdownRenderer.tsx
@@ -27,6 +27,7 @@ import remarkMath from 'remark-math';
 import remarkGfm from 'remark-gfm';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
+import { toSlug, extractTextContent } from '../utils/tocUtils';
 
 export interface MarkdownRendererProps {
   content: string;
@@ -168,6 +169,16 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               {children}
             </td>
           ),
+          // Heading overrides: generate stable IDs from text for TOC anchor links.
+          // The same slug function is used in extractHeadings so IDs always match.
+          h2: ({ children, ...props }) => {
+            const id = toSlug(extractTextContent(children));
+            return <h2 id={id} {...props}>{children}</h2>;
+          },
+          h3: ({ children, ...props }) => {
+            const id = toSlug(extractTextContent(children));
+            return <h3 id={id} {...props}>{children}</h3>;
+          },
           // Custom image component to handle relative paths
           img: ({ src, alt, ...props }) => {
             // If the src is a relative path starting with 'images/', prepend the docs path

--- a/packages/ui-components/src/components/TableOfContents.tsx
+++ b/packages/ui-components/src/components/TableOfContents.tsx
@@ -1,0 +1,73 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite. See LICENSE for the full license terms.
+
+import React from 'react';
+import { TocEntry } from '../utils/tocUtils';
+
+export interface TableOfContentsProps {
+    entries: TocEntry[];
+    activeId: string | null;
+    onEntryClick: (id: string) => void;
+}
+
+/**
+ * Sticky sidebar table of contents for the DocumentationViewer.
+ * Renders H2 and H3 entries; H3s are indented. The active section
+ * (tracked by an IntersectionObserver in the parent) is highlighted
+ * with a blue left-border accent.
+ *
+ * Returns null when there are fewer than 2 entries.
+ */
+export const TableOfContents: React.FC<TableOfContentsProps> = ({
+    entries,
+    activeId,
+    onEntryClick,
+}) => {
+    if (entries.length < 2) return null;
+
+    return (
+        <aside
+            className="w-56 shrink-0 overflow-y-auto border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/40"
+            aria-label="Table of contents"
+        >
+            <div className="py-6 px-3">
+                <p className="mb-3 px-3 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 select-none">
+                    Contents
+                </p>
+                <nav>
+                    <ul className="space-y-0.5">
+                        {entries.map((entry) => {
+                            const isActive = entry.id === activeId;
+                            const isH3 = entry.level === 3;
+
+                            return (
+                                <li key={entry.id}>
+                                    <button
+                                        onClick={() => onEntryClick(entry.id)}
+                                        className={[
+                                            'w-full text-left leading-snug rounded-r transition-colors',
+                                            'border-l-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+                                            isH3
+                                                ? 'py-1 pr-2 text-xs'
+                                                : 'py-1.5 pr-2 text-sm',
+                                            isH3 ? 'pl-6' : 'pl-3',
+                                            isActive
+                                                ? 'border-blue-500 text-blue-600 dark:text-blue-400 font-medium'
+                                                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:border-gray-300 dark:hover:border-gray-500',
+                                        ].join(' ')}
+                                        aria-current={isActive ? 'location' : undefined}
+                                    >
+                                        {entry.text}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </nav>
+            </div>
+        </aside>
+    );
+};

--- a/packages/ui-components/src/components/TableOfContents.tsx
+++ b/packages/ui-components/src/components/TableOfContents.tsx
@@ -46,6 +46,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
                             return (
                                 <li key={entry.id}>
                                     <button
+                                        type="button"
                                         onClick={() => onEntryClick(entry.id)}
                                         className={[
                                             'w-full text-left leading-snug rounded-r transition-colors',

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -34,6 +34,8 @@ export { KeyboardHelp } from './components/KeyboardHelp';
 export { CustomSelect } from './components/CustomSelect';
 export { DocumentationViewer } from './components/DocumentationViewer';
 export { MarkdownRenderer } from './components/MarkdownRenderer';
+export { TableOfContents } from './components/TableOfContents';
+export { toSlug, extractTextContent, extractHeadings } from './utils/tocUtils';
 export { FontSizeControl } from './components/FontSizeControl';
 export { LoadingSpinner } from './components/LoadingSpinner';
 export { ErrorBoundary } from './components/ErrorBoundary';
@@ -61,6 +63,8 @@ export type { KeyboardHelpProps } from './components/KeyboardHelp';
 export type { SelectOption } from './components/CustomSelect';
 export type { DocumentationViewerProps } from './components/DocumentationViewer';
 export type { MarkdownRendererProps } from './components/MarkdownRenderer';
+export type { TableOfContentsProps } from './components/TableOfContents';
+export type { TocEntry } from './utils/tocUtils';
 
 // Contexts
 export { ThemeProvider, useTheme } from './contexts/ThemeContext';

--- a/packages/ui-components/src/utils/tocUtils.ts
+++ b/packages/ui-components/src/utils/tocUtils.ts
@@ -44,22 +44,29 @@ export function extractTextContent(children: React.ReactNode): string {
 
 /**
  * Parses a markdown string and returns H2 and H3 headings as TocEntry[].
- * Uses the same slug logic as the MarkdownRenderer heading overrides so that
- * IDs generated at parse time match the IDs rendered in the DOM.
+ *
+ * Duplicate heading texts are disambiguated with a numeric suffix so that
+ * every entry has a unique ID — matching the scheme used in MarkdownRenderer.
+ * Example: two "The Core Idea" headings → "the-core-idea", "the-core-idea-2".
  */
 export function extractHeadings(markdown: string): TocEntry[] {
     const entries: TocEntry[] = [];
+    const counts = new Map<string, number>();
+
     for (const line of markdown.split('\n')) {
         const trimmed = line.trim();
         const h2 = /^## (.+)$/.exec(trimmed);
         const h3 = /^### (.+)$/.exec(trimmed);
-        if (h2) {
-            const text = h2[1].trim();
-            entries.push({ level: 2, text, id: toSlug(text) });
-        } else if (h3) {
-            const text = h3[1].trim();
-            entries.push({ level: 3, text, id: toSlug(text) });
-        }
+        const match = h2 ?? h3;
+        if (!match) continue;
+
+        const level = h2 ? 2 : 3;
+        const text = match[1].trim();
+        const base = toSlug(text);
+        const count = counts.get(base) ?? 0;
+        counts.set(base, count + 1);
+        const id = count === 0 ? base : `${base}-${count + 1}`;
+        entries.push({ level: level as 2 | 3, text, id });
     }
     return entries;
 }

--- a/packages/ui-components/src/utils/tocUtils.ts
+++ b/packages/ui-components/src/utils/tocUtils.ts
@@ -1,0 +1,65 @@
+// GoPCA Suite
+//
+// Copyright © 2025-2026 Rune Mathisen <devel@bitjungle.com>
+//
+// This file is part of GoPCA Suite. See LICENSE for the full license terms.
+
+import React from 'react';
+
+/** A single entry in the table of contents. */
+export interface TocEntry {
+    level: 2 | 3;
+    text: string;
+    id: string;
+}
+
+/**
+ * Converts a heading string to a URL-safe slug used as an element ID.
+ * "What is PCA? A Step-by-Step Guide" → "what-is-pca-a-step-by-step-guide"
+ */
+export function toSlug(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .trim();
+}
+
+/**
+ * Recursively extracts plain text from React children.
+ * Handles bold/italic headings such as "## **Key** Concept".
+ */
+export function extractTextContent(children: React.ReactNode): string {
+    if (typeof children === 'string') return children;
+    if (typeof children === 'number') return String(children);
+    if (Array.isArray(children)) return children.map(extractTextContent).join('');
+    if (React.isValidElement(children)) {
+        return extractTextContent(
+            (children.props as { children?: React.ReactNode }).children
+        );
+    }
+    return '';
+}
+
+/**
+ * Parses a markdown string and returns H2 and H3 headings as TocEntry[].
+ * Uses the same slug logic as the MarkdownRenderer heading overrides so that
+ * IDs generated at parse time match the IDs rendered in the DOM.
+ */
+export function extractHeadings(markdown: string): TocEntry[] {
+    const entries: TocEntry[] = [];
+    for (const line of markdown.split('\n')) {
+        const trimmed = line.trim();
+        const h2 = /^## (.+)$/.exec(trimmed);
+        const h3 = /^### (.+)$/.exec(trimmed);
+        if (h2) {
+            const text = h2[1].trim();
+            entries.push({ level: 2, text, id: toSlug(text) });
+        } else if (h3) {
+            const text = h3[1].trim();
+            entries.push({ level: 3, text, id: toSlug(text) });
+        }
+    }
+    return entries;
+}


### PR DESCRIPTION
## Summary

Adds a sticky sidebar Table of Contents to the shared `DocumentationViewer` component. A single change in `packages/ui-components/` covers both GoPCA Desktop and GoCSV Desktop — no per-app changes needed.

## What it looks like

- **224 px sidebar** on the left, full document height, scrollable independently
- **H2 entries** at `text-sm`; **H3 entries** indented at `text-xs`
- **Active section** highlighted with a blue left-border accent that updates as the user scrolls
- **Click any entry** → smooth-scrolls to the heading
- **Hidden automatically** when fewer than 2 headings are found (no visual regression on short pages)
- Full **light/dark mode** support

## How it works

| File | Role |
|------|------|
| `tocUtils.ts` | `toSlug` (text → URL-safe ID), `extractHeadings` (regex parse H2/H3), `extractTextContent` (React children → plain text) |
| `TableOfContents.tsx` | Sidebar component; receives entries + activeId; emits click |
| `MarkdownRenderer.tsx` | h2/h3 overrides add `id={toSlug(text)}` — same function as `extractHeadings` so DOM IDs always match TOC links |
| `DocumentationViewer.tsx` | Two-column flex layout; `IntersectionObserver` with `root: scrollContainer` tracks which heading is in the upper quarter of the viewport and sets `activeId`; `handleTocClick` smooth-scrolls |

## Test plan

- [ ] `npm run build-ui` passes
- [ ] Both `cmd/gopca-desktop/frontend` and `cmd/gocsv/frontend` build without TypeScript errors
- [ ] `make pca-dev` → open Introduction to PCA → 14 H2 + H3s appear in sidebar, active item tracks scroll, clicking jumps to section
- [ ] `make csv-dev` → open Data Prep guide → 8 H2 sections in sidebar, works correctly
- [ ] Dark mode: sidebar, active highlight, and text all render correctly
- [ ] Escape key still closes the viewer