### PR TITLE
ci: replace go mod tidy with go mod download (Fixes #638)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     
-    - name: Download dependencies
-      run: go mod tidy
+    - name: Download Go dependencies
+      run: go mod download
+
+    - name: Verify go.mod is tidy
+      run: |
+        go mod tidy
+        git diff --exit-code -- go.mod go.sum
     
     - name: Set up Python for validation
       uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Replaces the single `go mod tidy` dependency step in the `test` job with two explicit steps:

1. **`go mod download`** — downloads exactly what is in the committed `go.mod`/`go.sum`, cannot mutate any files
2. **Verify go.mod is tidy** — runs `go mod tidy` then `git diff --exit-code -- go.mod go.sum`; fails the build if there is any drift

## Why

`go mod tidy` silently mutates `go.mod` and `go.sum` if they are not already tidy, meaning CI could build against a different dependency graph than what was committed and reviewed. The pre-commit hook already enforces tidiness locally, so the new verification step will pass in practice — it just makes the guarantee explicit in CI too.

## What is unchanged

- Module cache step (keyed on `**/go.sum`) continues to work correctly
- `build-cli`, `build-desktop`, and `build-gocsv` jobs are unaffected — they have no Go dependency download step
- Only the root `go.mod` is checked — same scope as the previous call
- Works on all three matrix OS (ubuntu, macos, windows)