### PR TITLE
fix: reset Z-axis and loading component indices on new PCA run (Fixes #635)

### DIFF
--- a/cmd/gopca-desktop/frontend/src/hooks/useVisualization.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useVisualization.ts
@@ -202,6 +202,8 @@ export function useVisualization(
     const resetVisualizationSelections = useCallback(() => {
         setSelectedXComponent(0);
         setSelectedYComponent(1);
+        setSelectedZComponent(2);
+        setSelectedLoadingComponent(0);
     }, []);
 
     return {


### PR DESCRIPTION
## Summary

`resetVisualizationSelections` in `useVisualization.ts` only reset the X (→0) and Y (→1) component selectors, leaving `selectedZComponent` and `selectedLoadingComponent` with stale values.

**The bug:** Run PCA with 5 components, then re-run with 3 components. If `selectedZComponent` was 4, it is now out of range — 3D plots request a component that doesn't exist and loadings views show the wrong component.

**The fix:** Add the two missing resets to `selectedZComponent → 2` and `selectedLoadingComponent → 0`.