### PR TITLE
fix: hook cleanup — guard setTimeout and fix stale closure (Fixes #636, #637)

### DIFF
--- a/cmd/gopca-desktop/frontend/src/hooks/useAppInit.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useAppInit.ts
@@ -21,7 +21,7 @@
 //
 // See LICENSE for the full license terms.
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { GetVersion, GetGUIConfig, SaveFile, CheckGoCSVStatus, LoadCSVFile } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { setupPlotlyWailsIntegration } from '@gopca/ui-components';
@@ -46,6 +46,11 @@ export function useAppInit(
 ): AppInitResult {
     const [version, setVersion] = useState<string>('');
     const [guiConfig, setGuiConfig] = useState<config.GUIConfig | null>(null);
+
+    // Keep a ref to the latest callback so the one-time event listener always
+    // calls the current version even if the parent re-renders with a new function.
+    const onStartupFileRef = useRef(onStartupFile);
+    useEffect(() => { onStartupFileRef.current = onStartupFile; });
 
     useEffect(() => {
         // Make SaveFile available globally for Plotly export integration
@@ -72,17 +77,13 @@ export function useAppInit(
         const unsubscribe = EventsOn('load-file-on-startup', async (filePath: string) => {
             try {
                 const result = await LoadCSVFile(filePath);
-                onStartupFile(result);
+                onStartupFileRef.current(result);
             } catch (err) {
                 logger.error('Failed to load startup file:', err);
             }
         });
 
         return () => { unsubscribe(); };
-        // onStartupFile is intentionally excluded: it changes on every render
-        // because it closes over setState, but the handler only needs to be
-        // registered once at mount.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return { version, guiConfig };

--- a/cmd/gopca-desktop/frontend/src/hooks/useUIState.ts
+++ b/cmd/gopca-desktop/frontend/src/hooks/useUIState.ts
@@ -21,7 +21,7 @@
 //
 // See LICENSE for the full license terms.
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { logger } from '../utils/logger';
 
 export interface UIStateResult {
@@ -45,6 +45,14 @@ export function useUIState(): UIStateResult {
     const [showCopied, setShowCopied] = useState(false);
 
     const mainScrollRef = useRef<HTMLDivElement>(null);
+    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Clear any pending timeout when the component unmounts.
+    useEffect(() => {
+        return () => {
+            if (copyTimeoutRef.current !== null) clearTimeout(copyTimeoutRef.current);
+        };
+    }, []);
 
     const handleLogoClick = useCallback(() => {
         setShowAboutDialog(true);
@@ -54,7 +62,12 @@ export function useUIState(): UIStateResult {
         try {
             await navigator.clipboard.writeText(text);
             setShowCopied(true);
-            setTimeout(() => setShowCopied(false), 2000);
+            // Cancel any previous timeout so rapid clicks don't stack.
+            if (copyTimeoutRef.current !== null) clearTimeout(copyTimeoutRef.current);
+            copyTimeoutRef.current = setTimeout(() => {
+                setShowCopied(false);
+                copyTimeoutRef.current = null;
+            }, 2000);
         } catch (err) {
             logger.error('Failed to copy to clipboard:', err);
         }


### PR DESCRIPTION
## Summary

Two related React hook hygiene fixes in `cmd/gopca-desktop/frontend/src/hooks/`.

### useUIState.ts — #636: unguarded setTimeout

`copyToClipboard` called `setTimeout` without storing the ID. Two problems:
- Rapid successive copies stacked overlapping timeouts, each one capable of hiding the "Copied!" indicator early
- Unmounting within the 2-second window would call `setShowCopied(false)` on dead state

**Fix:** `copyTimeoutRef` holds the active timeout ID. Any previous timeout is cancelled before scheduling a new one. A cleanup `useEffect` clears it on unmount.

### useAppInit.ts — #637: stale closure

The `load-file-on-startup` event handler captured `onStartupFile` at mount. If the parent re-rendered with a new callback, the stale version kept being called indefinitely.

**Fix:** `onStartupFileRef` always holds the latest callback. A dependency-free sync effect updates it after every render. The handler calls `onStartupFileRef.current()`. The `eslint-disable-next-line` suppression is removed — no longer needed.