### PR TITLE
security: fix all code-scanning alerts (ReDoS + workflow permissions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ on:
 env:
   GO_VERSION: '1.24'
 
+# Restrict all jobs to read-only repository access by default.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/check-docs-sync.yml
+++ b/.github/workflows/check-docs-sync.yml
@@ -10,6 +10,10 @@ on:
       - 'scripts/sync-docs.sh'
       - 'Makefile'
 
+# Restrict all jobs to read-only repository access by default.
+permissions:
+  contents: read
+
 jobs:
   check-sync:
     name: Verify documentation synchronization

--- a/packages/ui-components/src/utils/errorMessages.ts
+++ b/packages/ui-components/src/utils/errorMessages.ts
@@ -259,8 +259,13 @@ export function parseError(error: unknown): FormattedError {
   if (error instanceof Error) {
     // Check for specific error types
     if (error.message.includes('ENOENT')) {
-      const match = error.message.match(/ENOENT[^']*'([^']+)'/);
-      const filename = match ? match[1] : 'unknown';
+      // Extract the filename from messages like: ENOENT: no such file or directory, open '/path/file'
+      // Use string splitting rather than a regex to avoid polynomial backtracking on unexpected input.
+      const firstQuote = error.message.indexOf("'");
+      const secondQuote = firstQuote >= 0 ? error.message.indexOf("'", firstQuote + 1) : -1;
+      const filename = firstQuote >= 0 && secondQuote > firstQuote
+        ? error.message.slice(firstQuote + 1, secondQuote)
+        : 'unknown';
       return ErrorTemplates.FILE_NOT_FOUND(filename);
     }
 


### PR DESCRIPTION
## Summary

Fixes all five warnings from the GitHub code-scanning / CodeQL analysis.

### 1. js/polynomial-redos — `errorMessages.ts` (2 alerts, same regex)

The regex `/ENOENT[^']*'([^']+)'/` contains `[^']+` (one-or-more non-quote) adjacent to a literal quote. On a string with no closing quote (e.g. `ENOENT: aaaaaa...`), the engine backtracks polynomially. Replaced with `indexOf`-based string parsing that is O(n) and immune to this class of attack.

### 2. actions/missing-workflow-permissions — `build.yml` + `check-docs-sync.yml` (3 alerts)

Both workflows lacked an explicit `permissions` declaration, defaulting to the repository's default (often `read-and-write`). Added `permissions: contents: read` at the top level — both workflows only need to read the repository to checkout and build.